### PR TITLE
Updates jsdoc to no longer depend on a vulnerable package

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10318,10 +10318,13 @@
       }
     },
     "js2xmlparser": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/js2xmlparser/-/js2xmlparser-1.0.0.tgz",
-      "integrity": "sha1-WhcPLo1kds5FQF4EgjJCUTeC/jA=",
-      "dev": true
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/js2xmlparser/-/js2xmlparser-3.0.0.tgz",
+      "integrity": "sha1-P7YOqgicVED5MZ9RdgzNB+JJlzM=",
+      "dev": true,
+      "requires": {
+        "xmlcreate": "1.0.2"
+      }
     },
     "jsbn": {
       "version": "0.1.1",
@@ -10330,18 +10333,18 @@
       "optional": true
     },
     "jsdoc": {
-      "version": "3.4.3",
-      "resolved": "https://registry.npmjs.org/jsdoc/-/jsdoc-3.4.3.tgz",
-      "integrity": "sha1-5XQNYUXGgfZnnmwXeDqI292XzNM=",
+      "version": "3.5.5",
+      "resolved": "https://registry.npmjs.org/jsdoc/-/jsdoc-3.5.5.tgz",
+      "integrity": "sha512-6PxB65TAU4WO0Wzyr/4/YhlGovXl0EVYfpKbpSroSj0qBxT4/xod/l40Opkm38dRHRdQgdeY836M0uVnJQG7kg==",
       "dev": true,
       "requires": {
-        "bluebird": "3.4.7",
+        "babylon": "7.0.0-beta.19",
+        "bluebird": "3.5.1",
         "catharsis": "0.8.9",
         "escape-string-regexp": "1.0.5",
-        "espree": "3.1.7",
-        "js2xmlparser": "1.0.0",
-        "klaw": "1.3.1",
-        "marked": "0.3.7",
+        "js2xmlparser": "3.0.0",
+        "klaw": "2.0.0",
+        "marked": "0.3.9",
         "mkdirp": "0.5.1",
         "requizzle": "0.2.1",
         "strip-json-comments": "2.0.1",
@@ -10349,26 +10352,19 @@
         "underscore": "1.8.3"
       },
       "dependencies": {
-        "acorn": {
-          "version": "3.3.0",
-          "resolved": "https://registry.npmjs.org/acorn/-/acorn-3.3.0.tgz",
-          "integrity": "sha1-ReN/s56No/JbruP/U2niu18iAXo=",
+        "babylon": {
+          "version": "7.0.0-beta.19",
+          "resolved": "https://registry.npmjs.org/babylon/-/babylon-7.0.0-beta.19.tgz",
+          "integrity": "sha512-Vg0C9s/REX6/WIXN37UKpv5ZhRi6A4pjHlpkE34+8/a6c2W1Q692n3hmc+SZG5lKRnaExLUbxtJ1SVT+KaCQ/A==",
           "dev": true
         },
-        "bluebird": {
-          "version": "3.4.7",
-          "resolved": "https://registry.npmjs.org/bluebird/-/bluebird-3.4.7.tgz",
-          "integrity": "sha1-9y12C+Cbf3bQjtj66Ysomo0F+rM=",
-          "dev": true
-        },
-        "espree": {
-          "version": "3.1.7",
-          "resolved": "https://registry.npmjs.org/espree/-/espree-3.1.7.tgz",
-          "integrity": "sha1-/V3ux2qXpRIKnNOnyxF3oJI7EdI=",
+        "klaw": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/klaw/-/klaw-2.0.0.tgz",
+          "integrity": "sha1-WcEo4Nxc5BAgEVEZTuucv4WGUPY=",
           "dev": true,
           "requires": {
-            "acorn": "3.3.0",
-            "acorn-jsx": "3.0.1"
+            "graceful-fs": "4.1.11"
           }
         },
         "underscore": {
@@ -11443,9 +11439,9 @@
       "integrity": "sha1-Sz3ToTPRUYuO8NvHCb8qG0gkvIw="
     },
     "marked": {
-      "version": "0.3.7",
-      "resolved": "https://registry.npmjs.org/marked/-/marked-0.3.7.tgz",
-      "integrity": "sha512-zBEP4qO1YQp5aXHt8S5wTiOv9i2X74V/LQL0zhUNvVaklt6Ywa6lChxIvS+ibYlCGgADwKwZFhjC3+XfpsvQvQ==",
+      "version": "0.3.9",
+      "resolved": "https://registry.npmjs.org/marked/-/marked-0.3.9.tgz",
+      "integrity": "sha512-nW5u0dxpXxHfkHzzrveY45gCbi+R4PaO4WRZYqZNl+vB0hVGeqlFn0aOg1c8AKL63TrNFn9Bm2UP4AdiZ9TPLw==",
       "dev": true
     },
     "mathml-tag-names": {
@@ -17323,6 +17319,12 @@
       "version": "9.0.4",
       "resolved": "https://registry.npmjs.org/xmlbuilder/-/xmlbuilder-9.0.4.tgz",
       "integrity": "sha1-UZy0ymhtAFqEINNJbz8MruzKWA8=",
+      "dev": true
+    },
+    "xmlcreate": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/xmlcreate/-/xmlcreate-1.0.2.tgz",
+      "integrity": "sha1-+mv3YqYKQT+z3Y9LA8WyaSONMI8=",
       "dev": true
     },
     "xmldom": {

--- a/package.json
+++ b/package.json
@@ -93,7 +93,7 @@
     "cucumber": "3.0.6",
     "jasmine-reporters": "2.2.1",
     "jasmine-spec-reporter": "4.2.1",
-    "jsdoc": "3.4.3",
+    "jsdoc": "3.5.5",
     "jsdom": "11.3.0",
     "jsdom-global": "3.0.2",
     "minimist": "1.2.0",


### PR DESCRIPTION
Low severity as this is just a devdep, but this'll get the big yellow notice off.