### PR TITLE
Tell ESLint not to look up the tree for more .eslintrc files

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -1,3 +1,8 @@
+# Do not look up into parent directories.
+# Prevents ESLint version conflicts when cloned into
+# cfgov-refresh's develop-apps folder.
+root: true
+
 # Enable ecmascript 6 features.
 ecmaFeatures:
   arrowFunctions: false

--- a/gulp/config.js
+++ b/gulp/config.js
@@ -41,6 +41,9 @@ module.exports = {
       'gulpfile.js',
       'gulp/**/*.js'
     ],
+    tests: [
+      loc.test + '/js/**/*.js'
+    ],
     css: [
       loc.src + '/css/**/*.less',
       loc.src + '/css/**/*.css'

--- a/gulp/tasks/lint.js
+++ b/gulp/tasks/lint.js
@@ -39,7 +39,7 @@ gulp.task( 'lint:build', () => _genericLintJS( config.lint.build ) );
 /**
  * Lints the test js files for errors.
  */
-gulp.task( 'lint:tests', () => _genericLintJS( config.test.tests ) );
+gulp.task( 'lint:tests', () => _genericLintJS( config.lint.tests ) );
 
 /**
  * Lints the source js files for errors.


### PR DESCRIPTION
gulp-eslint was throwing errors in this repo when cloned within `cfgov-refresh/develop-apps/` due to a version mismatch between the version of ESLint used here and the later version used in cfgov-refresh. This PR tells ESLint to not use its default behavior of looking up the tree for additional `.eslintrc` files.

It also fixes the `lint:tests` subtask so that it actually finds the files.

## Additions

- `root: true` rule in `.eslintrc`

## Changes

- `lint:tests` now uses `config.lint.tests` as its `src`, for consistency with the other tasks, and because its previous configuration was not finding the JS test files.

## Testing

1. Pull branch to teachers-digital-platform clone within `cfgov-refresh/develop-apps/`
2. Run `gulp` or `gulp lint`
3. Observe no errors.

## Checklist

* [ ] Changes are limited to a single goal (no scope creep)
* [ ] Code can be automatically merged (no conflicts)
* [ ] Code follows the standards laid out in the [front end playbook](https://github.com/cfpb/front-end)
* [ ] Passes all existing automated tests
* [ ] New functions include new tests
* [ ] New functions are documented (with a description, list of inputs, and expected output)
* [ ] Placeholder code is flagged
* [ ] Visually tested in supported browsers and devices
* [ ] Project documentation has been updated (including the "Unreleased" section of the CHANGELOG)
