### PR TITLE
Fix styles task not building when tdp.less is not updated

### DIFF
--- a/gulp/config.js
+++ b/gulp/config.js
@@ -66,7 +66,12 @@ module.exports = {
         loc.lib + 'cf-*/src'
       ] ),
       compress: true
-    }
+    },
+    otherBuildTriggerFiles: [
+      loc.src + '/css/**/*.less',
+      loc.lib,
+      './gulp/**/*.js'
+    ]
   },
   scripts: {
     entrypoint: loc.src + '/js/index.js',

--- a/gulp/tasks/styles.js
+++ b/gulp/tasks/styles.js
@@ -8,17 +8,13 @@ const configPkg = config.pkg;
 const configBanner = config.banner;
 const configStyles = config.styles;
 const gulp = require( 'gulp' );
-const gulpBless = require( 'gulp-bless' );
-const gulpChanged = require( 'gulp-changed' );
-const gulpCleanCss = require( 'gulp-clean-css' );
+const gulpDebug = require( 'gulp-debug' );
 const gulpHeader = require( 'gulp-header' );
 const gulpLess = require( 'gulp-less' );
-const debug = require( 'gulp-debug' );
+const gulpNewer = require( 'gulp-newer' );
 const gulpPostcss = require( 'gulp-postcss' );
-const gulpRename = require( 'gulp-rename' );
 const gulpSourcemaps = require( 'gulp-sourcemaps' );
 const handleErrors = require( '../utils/handle-errors' );
-const postcssUnmq = require( 'postcss-unmq' );
 
 /**
  * Process modern CSS.
@@ -26,19 +22,22 @@ const postcssUnmq = require( 'postcss-unmq' );
  */
 function stylesModern() {
   return gulp.src( configStyles.cwd + configStyles.src )
-    .pipe(debug({title: 'src:'}))
-    .pipe( gulpChanged( configStyles.dest, { extension: '.css' } ) )
+    .pipe( gulpNewer( {
+      dest:  configStyles.dest + '/tdp.css',
+      extra: configStyles.otherBuildTriggerFiles
+    } ) )
+    .pipe( gulpDebug( { title: 'src:' } ) )
     .pipe( gulpSourcemaps.init() )
     .pipe( gulpLess( configStyles.settings ) )
     .on( 'error', handleErrors.bind( this, { exitProcess: true } ) )
     .pipe( gulpPostcss( [
       autoprefixer( { browsers: BROWSER_LIST.LAST_2 } )
     ] ) )
-    .pipe(debug({title: 'prefixed:'}))
+    .pipe( gulpDebug( { title: 'prefixed:' } ) )
     .pipe( gulpHeader( configBanner, { pkg: configPkg } ) )
     .pipe( gulpSourcemaps.write( '.' ) )
     .pipe( gulp.dest( configStyles.dest ) )
-    .pipe(debug({title: 'dest:'}))
+    .pipe( gulpDebug( { title: 'dest:' } ) )
     .pipe( browserSync.reload( {
       stream: true
     } ) );

--- a/package-lock.json
+++ b/package-lock.json
@@ -2355,10 +2355,26 @@
         }
       }
     },
+    "ansi-cyan": {
+      "version": "0.1.1",
+      "resolved": "https://registry.npmjs.org/ansi-cyan/-/ansi-cyan-0.1.1.tgz",
+      "integrity": "sha1-U4rlKK+JgvKK4w2G8vF0VtJgmHM=",
+      "requires": {
+        "ansi-wrap": "0.1.0"
+      }
+    },
     "ansi-escapes": {
       "version": "1.4.0",
       "resolved": "https://registry.npmjs.org/ansi-escapes/-/ansi-escapes-1.4.0.tgz",
       "integrity": "sha1-06ioOzGapneTZisT52HHkRQiMG4="
+    },
+    "ansi-red": {
+      "version": "0.1.1",
+      "resolved": "https://registry.npmjs.org/ansi-red/-/ansi-red-0.1.1.tgz",
+      "integrity": "sha1-jGOPnRCAgAo1PJwoyKgcpHBdlGw=",
+      "requires": {
+        "ansi-wrap": "0.1.0"
+      }
     },
     "ansi-regex": {
       "version": "2.1.1",
@@ -2372,6 +2388,11 @@
       "requires": {
         "color-convert": "1.9.1"
       }
+    },
+    "ansi-wrap": {
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/ansi-wrap/-/ansi-wrap-0.1.0.tgz",
+      "integrity": "sha1-qCJQ3bABXponyoLoLqYDu/pF768="
     },
     "ansicolors": {
       "version": "0.3.2",
@@ -2438,6 +2459,11 @@
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/arr-flatten/-/arr-flatten-1.1.0.tgz",
       "integrity": "sha512-L3hKV5R/p5o81R7O02IGnwpDmkp6E982XhtbuwSe3O4qOtMMMtodicASA1Cny2U+aCXcNpml+m4dPsvsJ3jatg=="
+    },
+    "arr-union": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/arr-union/-/arr-union-2.1.0.tgz",
+      "integrity": "sha1-IPnqtexw9cfSFbEHexw5Fh0pLH0="
     },
     "array-differ": {
       "version": "1.0.0",
@@ -8989,6 +9015,16 @@
         }
       }
     },
+    "gulp-newer": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/gulp-newer/-/gulp-newer-1.4.0.tgz",
+      "integrity": "sha512-h79fGO55S/P9eAADbLAP9aTtVYpLSR1ONj08VPaSdVVNVYhTS8p1CO1TW7kEMu+hC+sytmCqcUr5LesvZEtDoQ==",
+      "requires": {
+        "glob": "7.1.2",
+        "kew": "0.7.0",
+        "plugin-error": "0.1.2"
+      }
+    },
     "gulp-notify": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/gulp-notify/-/gulp-notify-3.0.0.tgz",
@@ -10745,6 +10781,11 @@
         "jwa": "1.1.5",
         "safe-buffer": "5.1.1"
       }
+    },
+    "kew": {
+      "version": "0.7.0",
+      "resolved": "https://registry.npmjs.org/kew/-/kew-0.7.0.tgz",
+      "integrity": "sha1-edk9LTM2PW/dKXCzNdkUGtWR15s="
     },
     "kind-of": {
       "version": "3.2.2",
@@ -12668,6 +12709,47 @@
       "integrity": "sha1-9tXREJ4Z1j7fQo4L1X4Sd3YVM0s=",
       "requires": {
         "find-up": "2.1.0"
+      }
+    },
+    "plugin-error": {
+      "version": "0.1.2",
+      "resolved": "https://registry.npmjs.org/plugin-error/-/plugin-error-0.1.2.tgz",
+      "integrity": "sha1-O5uzM1zPAPQl4HQ34ZJ2ln2kes4=",
+      "requires": {
+        "ansi-cyan": "0.1.1",
+        "ansi-red": "0.1.1",
+        "arr-diff": "1.1.0",
+        "arr-union": "2.1.0",
+        "extend-shallow": "1.1.4"
+      },
+      "dependencies": {
+        "arr-diff": {
+          "version": "1.1.0",
+          "resolved": "https://registry.npmjs.org/arr-diff/-/arr-diff-1.1.0.tgz",
+          "integrity": "sha1-aHwydYFjWI/vfeezb6vklesaOZo=",
+          "requires": {
+            "arr-flatten": "1.1.0",
+            "array-slice": "0.2.3"
+          }
+        },
+        "array-slice": {
+          "version": "0.2.3",
+          "resolved": "https://registry.npmjs.org/array-slice/-/array-slice-0.2.3.tgz",
+          "integrity": "sha1-3Tz7gO15c6dRF82sabC5nshhhvU="
+        },
+        "extend-shallow": {
+          "version": "1.1.4",
+          "resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-1.1.4.tgz",
+          "integrity": "sha1-Gda/lN/AnXa6cR85uHLSH/TdkHE=",
+          "requires": {
+            "kind-of": "1.1.0"
+          }
+        },
+        "kind-of": {
+          "version": "1.1.0",
+          "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-1.1.0.tgz",
+          "integrity": "sha1-FAo9LUGjbS78+pN3tiwk+ElaXEQ="
+        }
       }
     },
     "plur": {

--- a/package.json
+++ b/package.json
@@ -62,6 +62,7 @@
     "gulp-mocha": "3.0.1",
     "gulp-modernizr": "1.0.0-alpha",
     "gulp-mq-remove": "0.0.2",
+    "gulp-newer": "1.4.0",
     "gulp-notify": "3.0.0",
     "gulp-postcss": "7.0.0",
     "gulp-rename": "1.2.2",


### PR DESCRIPTION
Replaces gulp-changed with gulp-less to allow us to check the timestamp of `tdp.css` against all source files that could affect the output of `tdp.css`.


## Additions

- gulp-newer for more robust determination of the necessity of building the Less files

## Removals

- A bunch of unused modules in `styles.js`

## Changes

- Linting fixes and standardization in `styles.js`

## Testing

1. Pull this branch and `npm install`
2. Run `gulp clean` to clean everything out, then `gulp styles` for a baseline build.
3. Note time shown for `Finished 'styles:modern' after ____`
4. Run `gulp styles` again
5. Note that the time shown for `Finished 'styles:modern' after ____` is much much smaller. Styles were not built as gulp-newer did not detect any changes since the last update of the output `tdp.css` file.
6. Make a change in one of the new Less files, like `a-hr.less`
7. Run `gulp styles` again
8. Note that the time shown for `Finished 'styles:modern' after ____` is about where it was in step 3, indicating that the styles built after detecting the change made in step 6. You can also verify this by looking at the resulting `tdp.css` file for the change you made.

## Notes

- @dcmouyard I branched off your `theme-crt-survey-page` branch because `master` didn't have any of the new Less files, so the PR is to that branch. It could probably be PRed just fine to master, though, if that's easier.

## Todos

- In another PR, update `gulp scripts` to use `gulp-newer` instead of `gulp-changed`

## Checklist

* [ ] Changes are limited to a single goal (no scope creep)
* [ ] Code can be automatically merged (no conflicts)
* [ ] Code follows the standards laid out in the [front end playbook](https://github.com/cfpb/front-end)
* [ ] Passes all existing automated tests
* [ ] New functions include new tests
* [ ] New functions are documented (with a description, list of inputs, and expected output)
* [ ] Placeholder code is flagged
* [ ] Visually tested in supported browsers and devices
* [ ] Project documentation has been updated (including the "Unreleased" section of the CHANGELOG)
