### PR TITLE
Remove references to js/routes directory

### DIFF
--- a/teachers_digital_platform/jinja2/teachers_digital_platform/base.html
+++ b/teachers_digital_platform/jinja2/teachers_digital_platform/base.html
@@ -47,8 +47,6 @@
 {# Conditional comment used to block IE8 and under from receiving JS #}
 <!--[if gt IE 8]><!-->
     {# Include site-wide JavaScript. #}
-    <script src="{{ static('js/routes/common.js') }}"></script>
-
     <script src="{{ static('tdp/js/tdp.js') }}"></script>
 <!--<![endif]-->
 

--- a/teachers_digital_platform/jinja2/teachers_digital_platform/prototypes/crt-base.html
+++ b/teachers_digital_platform/jinja2/teachers_digital_platform/prototypes/crt-base.html
@@ -68,9 +68,7 @@
 {# Conditional comment used to block IE8 and under from receiving JS #}
 <!--[if gt IE 8]><!-->
     {# Include site-wide JavaScript. #}
-    <script src="{{ static('js/routes/common.js') }}"></script>
-
-    <script src="{{ static('tdp/js/routes/tdp.js') }}"></script>
+    <script src="{{ static('tdp/js/tdp.js') }}"></script>
 <!--<![endif]-->
 
     <script>


### PR DESCRIPTION
The cfgov-refresh build process was breaking due to references to a `js/routes` directory that we aren’t using.

## Removals

- All references to `js/routes/common.js`

## Changes

- Reference to `tdp/tdp.js` instead of `tdp/routes/tdp.js`

## Review

- @

[Preview this PR without the whitespace changes](?w=0)

## Checklist

* [ ] Changes are limited to a single goal (no scope creep)
* [ ] Code can be automatically merged (no conflicts)
* [ ] Code follows the standards laid out in the [front end playbook](https://github.com/cfpb/front-end)
* [ ] Passes all existing automated tests
* [ ] New functions include new tests
* [ ] New functions are documented (with a description, list of inputs, and expected output)
* [ ] Placeholder code is flagged
* [ ] Visually tested in supported browsers and devices
* [ ] Project documentation has been updated (including the "Unreleased" section of the CHANGELOG)
