### PR TITLE
Manually bring in .cf-icon-svg Less to remediate collectstatic breakage

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1374,7 +1374,7 @@
         },
         "onetime": {
           "version": "1.1.0",
-          "resolved": "http://registry.npmjs.org/onetime/-/onetime-1.1.0.tgz",
+          "resolved": "https://registry.npmjs.org/onetime/-/onetime-1.1.0.tgz",
           "integrity": "sha1-ofeDj4MUxRbwXs78vEzP4EtO14k="
         },
         "open": {

--- a/teachers_digital_platform/css/cf-enhancements/atoms/icon-svg.less
+++ b/teachers_digital_platform/css/cf-enhancements/atoms/icon-svg.less
@@ -1,5 +1,0 @@
-//
-// SVG icons
-//
-
-.cf-icon-svg {}

--- a/teachers_digital_platform/css/tdp.less
+++ b/teachers_digital_platform/css/tdp.less
@@ -6,7 +6,7 @@
 // available, but the whole output doesn't duplicate what we're already getting
 // from cfgov-refresh.
 @import (reference) 'cf-core.less';
-@import 'cf-icons.less';
+@import 'temp/cf-icons.less';
 @import (reference) 'cf-buttons.less';
 @import (reference) 'cf-forms.less';
 @import (reference) 'cf-grid.less';

--- a/teachers_digital_platform/css/temp/cf-icons.less
+++ b/teachers_digital_platform/css/temp/cf-icons.less
@@ -1,0 +1,42 @@
+/* ==========================================================================
+   TEMPORARY COPY OF CF-ICONS
+   Remove when https://github.com/cfpb/cfgov-refresh/pull/3887 is
+   merged and deployed.
+   ========================================================================== */
+
+//
+// Theme variables
+//
+
+//
+// Size variables
+//
+
+// Icon height matches the 19px rendered canvas of text set in Avenir Next
+// sized at 16px ( 19/16 = 1.1875 )
+@cf-icon-height: 1.1875em;
+
+
+//
+// The basics
+//
+
+.cf-icon-svg {
+    height: @cf-icon-height;
+    vertical-align: text-top;
+    fill: currentColor;
+
+    // IE 10 & 11 require a max-width otherwise the SVG takes up 100%
+    max-width: 1em;
+
+    .lt-ie10 & {
+        // IE 9 require a width otherwise the SVG takes up 100%
+        width: 1em;
+    }
+
+    .lt-ie9 & {
+        // IE 8 doesn't support currentColor, hide icons and let the paired
+        // text stand on its own
+        display: none;
+    }
+}


### PR DESCRIPTION
This should stop Django's collectstatic process from looking for the old cf-icons fonts.

## Additions

- Temporary manual copy of `.cf-icon-svg` styles

## Removals

- Unused enhancements file which was throwing an error when I ran Gulp

## Changes

- `package-lock.json` updated itself to change an http URL to https

## Testing

1. Pull branch
1. Run `gulp`
1. View http://localhost:8000/tdp/prototypes/crt-survey/ and see the icons still there

Then we'll have to merge this, create a new release, update the version in cfgov-refresh, and see if that fixes the build.


## Checklist

* [x] Changes are limited to a single goal (no scope creep)
* [x] Code can be automatically merged (no conflicts)
* [x] Code follows the standards laid out in the [front end playbook](https://github.com/cfpb/front-end)
* [x] Passes all existing automated tests
* [x] New functions include new tests
* [x] New functions are documented (with a description, list of inputs, and expected output)
* [x] Placeholder code is flagged
* [x] Visually tested in supported browsers and devices
* [x] Project documentation has been updated (including the "Unreleased" section of the CHANGELOG)
