### PR TITLE
Fixed Modal dialogs interfering with each other

### DIFF
--- a/teachers_digital_platform/crtool/src/__tests__/__snapshots__/ContentElementaryCriterionPage.test.js.snap
+++ b/teachers_digital_platform/crtool/src/__tests__/__snapshots__/ContentElementaryCriterionPage.test.js.snap
@@ -1653,71 +1653,69 @@ Array [
         <form
           className="o-modal_content"
         >
-          <span>
-            <div
-              className="o-modal_body"
+          <div
+            className="o-modal_body"
+          >
+            <button
+              className="o-modal_close a-btn a-btn__link"
+              onClick={[Function]}
             >
-              <button
-                className="o-modal_close a-btn a-btn__link"
-                onClick={[Function]}
+              Close  
+              <span
+                className="a-icon a-icon__large"
               >
-                Close  
-                <span
-                  className="a-icon a-icon__large"
+                <svg
+                  className="cf-icon-svg"
+                  viewBox="0 0 1000 1200"
+                  xmlns="http://www.w3.org/2000/svg"
                 >
-                  <svg
-                    className="cf-icon-svg"
-                    viewBox="0 0 1000 1200"
-                    xmlns="http://www.w3.org/2000/svg"
-                  >
-                    <path
-                      d="M500 105.2c-276.1 0-500 223.9-500 500s223.9 500 500 500 500-223.9 500-500-223.9-500-500-500zm261.8 692.2c19.4 19.6 19.3 51.3-.3 70.7-19.5 19.3-50.9 19.3-70.4 0L499.6 676.6 308 868.1c-19.6 19.4-51.3 19.3-70.7-.3-19.3-19.5-19.3-50.9 0-70.4l191.6-191.5-191.6-191.6c-19.3-19.8-18.9-51.4.9-70.7 19.4-18.9 50.4-18.9 69.8 0l191.6 191.5 191.5-191.5c19.6-19.4 51.3-19.3 70.7.3 19.3 19.5 19.3 50.9 0 70.4L570.3 605.9l191.5 191.5z"
-                    />
-                  </svg>
-                </span>
-              </button>
-              <h1
-                id="modal-save-work_title"
-              >
-                Saving your work
-              </h1>
-              <div
-                id="modal-save-work_desc"
-              >
-                <p>
-                  This tool uses cookies to 
-                  <strong>
-                    temporarily
-                  </strong>
-                   save your work. To see answers you’ve already completed, you need to use the same computer and browser, and don’t clear your cookies.
-                </p>
-                <p>
-                  To save a permanent copy of your work, please print the summary or save it as a PDF for every dimension as you complete it. You can also print or save a summary of the entire review. Learn how to 
-                  <a
-                    href="https://www.consumerfinance.gov/consumer-tools/save-as-pdf-instructions/"
-                    rel="noopener noreferrer"
-                    target="_blank"
-                  >
-                    save the summary as a PDF
-                  </a>
-                  .
-                </p>
-                <p>
-                  You can only work on a single curriculum at a time
-                </p>
-              </div>
-            </div>
-            <div
-              className="o-modal_footer"
+                  <path
+                    d="M500 105.2c-276.1 0-500 223.9-500 500s223.9 500 500 500 500-223.9 500-500-223.9-500-500-500zm261.8 692.2c19.4 19.6 19.3 51.3-.3 70.7-19.5 19.3-50.9 19.3-70.4 0L499.6 676.6 308 868.1c-19.6 19.4-51.3 19.3-70.7-.3-19.3-19.5-19.3-50.9 0-70.4l191.6-191.5-191.6-191.6c-19.3-19.8-18.9-51.4.9-70.7 19.4-18.9 50.4-18.9 69.8 0l191.6 191.5 191.5-191.5c19.6-19.4 51.3-19.3 70.7.3 19.3 19.5 19.3 50.9 0 70.4L570.3 605.9l191.5 191.5z"
+                  />
+                </svg>
+              </span>
+            </button>
+            <h1
+              id="modal-save-work_title"
             >
-              <button
-                className="a-btn"
-                onClick={[Function]}
-              >
-                Close
-              </button>
+              Saving your work
+            </h1>
+            <div
+              id="modal-save-work_desc"
+            >
+              <p>
+                This tool uses cookies to 
+                <strong>
+                  temporarily
+                </strong>
+                 save your work. To see answers you’ve already completed, you need to use the same computer and browser, and don’t clear your cookies.
+              </p>
+              <p>
+                To save a permanent copy of your work, please print the summary or save it as a PDF for every dimension as you complete it. You can also print or save a summary of the entire review. Learn how to 
+                <a
+                  href="https://www.consumerfinance.gov/consumer-tools/save-as-pdf-instructions/"
+                  rel="noopener noreferrer"
+                  target="_blank"
+                >
+                  save the summary as a PDF
+                </a>
+                .
+              </p>
+              <p>
+                You can only work on a single curriculum at a time
+              </p>
             </div>
-          </span>
+          </div>
+          <div
+            className="o-modal_footer"
+          >
+            <button
+              className="a-btn"
+              onClick={[Function]}
+            >
+              Close
+            </button>
+          </div>
         </form>
       </div>
     </div>

--- a/teachers_digital_platform/crtool/src/__tests__/__snapshots__/EfficacyCriterionPage.test.js.snap
+++ b/teachers_digital_platform/crtool/src/__tests__/__snapshots__/EfficacyCriterionPage.test.js.snap
@@ -147,71 +147,69 @@ Array [
               <form
                 className="o-modal_content"
               >
-                <span>
-                  <div
-                    className="o-modal_body"
+                <div
+                  className="o-modal_body"
+                >
+                  <button
+                    className="o-modal_close a-btn a-btn__link"
+                    onClick={[Function]}
                   >
-                    <button
-                      className="o-modal_close a-btn a-btn__link"
-                      onClick={[Function]}
+                    Close  
+                    <span
+                      className="a-icon a-icon__large"
                     >
-                      Close  
-                      <span
-                        className="a-icon a-icon__large"
+                      <svg
+                        className="cf-icon-svg"
+                        viewBox="0 0 1000 1200"
+                        xmlns="http://www.w3.org/2000/svg"
                       >
-                        <svg
-                          className="cf-icon-svg"
-                          viewBox="0 0 1000 1200"
-                          xmlns="http://www.w3.org/2000/svg"
-                        >
-                          <path
-                            d="M500 105.2c-276.1 0-500 223.9-500 500s223.9 500 500 500 500-223.9 500-500-223.9-500-500-500zm261.8 692.2c19.4 19.6 19.3 51.3-.3 70.7-19.5 19.3-50.9 19.3-70.4 0L499.6 676.6 308 868.1c-19.6 19.4-51.3 19.3-70.7-.3-19.3-19.5-19.3-50.9 0-70.4l191.6-191.5-191.6-191.6c-19.3-19.8-18.9-51.4.9-70.7 19.4-18.9 50.4-18.9 69.8 0l191.6 191.5 191.5-191.5c19.6-19.4 51.3-19.3 70.7.3 19.3 19.5 19.3 50.9 0 70.4L570.3 605.9l191.5 191.5z"
-                          />
-                        </svg>
-                      </span>
-                    </button>
-                    <h1
-                      id="modal-save-work_title"
-                    >
-                      Saving your work
-                    </h1>
-                    <div
-                      id="modal-save-work_desc"
-                    >
-                      <p>
-                        This tool uses cookies to 
-                        <strong>
-                          temporarily
-                        </strong>
-                         save your work. To see answers you’ve already completed, you need to use the same computer and browser, and don’t clear your cookies.
-                      </p>
-                      <p>
-                        To save a permanent copy of your work, please print the summary or save it as a PDF for every dimension as you complete it. You can also print or save a summary of the entire review. Learn how to 
-                        <a
-                          href="https://www.consumerfinance.gov/consumer-tools/save-as-pdf-instructions/"
-                          rel="noopener noreferrer"
-                          target="_blank"
-                        >
-                          save the summary as a PDF
-                        </a>
-                        .
-                      </p>
-                      <p>
-                        You can only work on a single curriculum at a time
-                      </p>
-                    </div>
-                  </div>
-                  <div
-                    className="o-modal_footer"
+                        <path
+                          d="M500 105.2c-276.1 0-500 223.9-500 500s223.9 500 500 500 500-223.9 500-500-223.9-500-500-500zm261.8 692.2c19.4 19.6 19.3 51.3-.3 70.7-19.5 19.3-50.9 19.3-70.4 0L499.6 676.6 308 868.1c-19.6 19.4-51.3 19.3-70.7-.3-19.3-19.5-19.3-50.9 0-70.4l191.6-191.5-191.6-191.6c-19.3-19.8-18.9-51.4.9-70.7 19.4-18.9 50.4-18.9 69.8 0l191.6 191.5 191.5-191.5c19.6-19.4 51.3-19.3 70.7.3 19.3 19.5 19.3 50.9 0 70.4L570.3 605.9l191.5 191.5z"
+                        />
+                      </svg>
+                    </span>
+                  </button>
+                  <h1
+                    id="modal-save-work_title"
                   >
-                    <button
-                      className="a-btn"
-                      onClick={[Function]}
-                    >
-                      Close
-                    </button>
+                    Saving your work
+                  </h1>
+                  <div
+                    id="modal-save-work_desc"
+                  >
+                    <p>
+                      This tool uses cookies to 
+                      <strong>
+                        temporarily
+                      </strong>
+                       save your work. To see answers you’ve already completed, you need to use the same computer and browser, and don’t clear your cookies.
+                    </p>
+                    <p>
+                      To save a permanent copy of your work, please print the summary or save it as a PDF for every dimension as you complete it. You can also print or save a summary of the entire review. Learn how to 
+                      <a
+                        href="https://www.consumerfinance.gov/consumer-tools/save-as-pdf-instructions/"
+                        rel="noopener noreferrer"
+                        target="_blank"
+                      >
+                        save the summary as a PDF
+                      </a>
+                      .
+                    </p>
+                    <p>
+                      You can only work on a single curriculum at a time
+                    </p>
                   </div>
-                </span>
+                </div>
+                <div
+                  className="o-modal_footer"
+                >
+                  <button
+                    className="a-btn"
+                    onClick={[Function]}
+                  >
+                    Close
+                  </button>
+                </div>
               </form>
             </div>
           </div>
@@ -1976,71 +1974,69 @@ Array [
         <form
           className="o-modal_content"
         >
-          <span>
-            <div
-              className="o-modal_body"
+          <div
+            className="o-modal_body"
+          >
+            <button
+              className="o-modal_close a-btn a-btn__link"
+              onClick={[Function]}
             >
-              <button
-                className="o-modal_close a-btn a-btn__link"
-                onClick={[Function]}
+              Close  
+              <span
+                className="a-icon a-icon__large"
               >
-                Close  
-                <span
-                  className="a-icon a-icon__large"
+                <svg
+                  className="cf-icon-svg"
+                  viewBox="0 0 1000 1200"
+                  xmlns="http://www.w3.org/2000/svg"
                 >
-                  <svg
-                    className="cf-icon-svg"
-                    viewBox="0 0 1000 1200"
-                    xmlns="http://www.w3.org/2000/svg"
-                  >
-                    <path
-                      d="M500 105.2c-276.1 0-500 223.9-500 500s223.9 500 500 500 500-223.9 500-500-223.9-500-500-500zm261.8 692.2c19.4 19.6 19.3 51.3-.3 70.7-19.5 19.3-50.9 19.3-70.4 0L499.6 676.6 308 868.1c-19.6 19.4-51.3 19.3-70.7-.3-19.3-19.5-19.3-50.9 0-70.4l191.6-191.5-191.6-191.6c-19.3-19.8-18.9-51.4.9-70.7 19.4-18.9 50.4-18.9 69.8 0l191.6 191.5 191.5-191.5c19.6-19.4 51.3-19.3 70.7.3 19.3 19.5 19.3 50.9 0 70.4L570.3 605.9l191.5 191.5z"
-                    />
-                  </svg>
-                </span>
-              </button>
-              <h1
-                id="modal-save-work_title"
-              >
-                Saving your work
-              </h1>
-              <div
-                id="modal-save-work_desc"
-              >
-                <p>
-                  This tool uses cookies to 
-                  <strong>
-                    temporarily
-                  </strong>
-                   save your work. To see answers you’ve already completed, you need to use the same computer and browser, and don’t clear your cookies.
-                </p>
-                <p>
-                  To save a permanent copy of your work, please print the summary or save it as a PDF for every dimension as you complete it. You can also print or save a summary of the entire review. Learn how to 
-                  <a
-                    href="https://www.consumerfinance.gov/consumer-tools/save-as-pdf-instructions/"
-                    rel="noopener noreferrer"
-                    target="_blank"
-                  >
-                    save the summary as a PDF
-                  </a>
-                  .
-                </p>
-                <p>
-                  You can only work on a single curriculum at a time
-                </p>
-              </div>
-            </div>
-            <div
-              className="o-modal_footer"
+                  <path
+                    d="M500 105.2c-276.1 0-500 223.9-500 500s223.9 500 500 500 500-223.9 500-500-223.9-500-500-500zm261.8 692.2c19.4 19.6 19.3 51.3-.3 70.7-19.5 19.3-50.9 19.3-70.4 0L499.6 676.6 308 868.1c-19.6 19.4-51.3 19.3-70.7-.3-19.3-19.5-19.3-50.9 0-70.4l191.6-191.5-191.6-191.6c-19.3-19.8-18.9-51.4.9-70.7 19.4-18.9 50.4-18.9 69.8 0l191.6 191.5 191.5-191.5c19.6-19.4 51.3-19.3 70.7.3 19.3 19.5 19.3 50.9 0 70.4L570.3 605.9l191.5 191.5z"
+                  />
+                </svg>
+              </span>
+            </button>
+            <h1
+              id="modal-save-work_title"
             >
-              <button
-                className="a-btn"
-                onClick={[Function]}
-              >
-                Close
-              </button>
+              Saving your work
+            </h1>
+            <div
+              id="modal-save-work_desc"
+            >
+              <p>
+                This tool uses cookies to 
+                <strong>
+                  temporarily
+                </strong>
+                 save your work. To see answers you’ve already completed, you need to use the same computer and browser, and don’t clear your cookies.
+              </p>
+              <p>
+                To save a permanent copy of your work, please print the summary or save it as a PDF for every dimension as you complete it. You can also print or save a summary of the entire review. Learn how to 
+                <a
+                  href="https://www.consumerfinance.gov/consumer-tools/save-as-pdf-instructions/"
+                  rel="noopener noreferrer"
+                  target="_blank"
+                >
+                  save the summary as a PDF
+                </a>
+                .
+              </p>
+              <p>
+                You can only work on a single curriculum at a time
+              </p>
             </div>
-          </span>
+          </div>
+          <div
+            className="o-modal_footer"
+          >
+            <button
+              className="a-btn"
+              onClick={[Function]}
+            >
+              Close
+            </button>
+          </div>
         </form>
       </div>
     </div>

--- a/teachers_digital_platform/crtool/src/__tests__/__snapshots__/QualityCriterionPage.test.js.snap
+++ b/teachers_digital_platform/crtool/src/__tests__/__snapshots__/QualityCriterionPage.test.js.snap
@@ -2355,71 +2355,69 @@ Array [
         <form
           className="o-modal_content"
         >
-          <span>
-            <div
-              className="o-modal_body"
+          <div
+            className="o-modal_body"
+          >
+            <button
+              className="o-modal_close a-btn a-btn__link"
+              onClick={[Function]}
             >
-              <button
-                className="o-modal_close a-btn a-btn__link"
-                onClick={[Function]}
+              Close  
+              <span
+                className="a-icon a-icon__large"
               >
-                Close  
-                <span
-                  className="a-icon a-icon__large"
+                <svg
+                  className="cf-icon-svg"
+                  viewBox="0 0 1000 1200"
+                  xmlns="http://www.w3.org/2000/svg"
                 >
-                  <svg
-                    className="cf-icon-svg"
-                    viewBox="0 0 1000 1200"
-                    xmlns="http://www.w3.org/2000/svg"
-                  >
-                    <path
-                      d="M500 105.2c-276.1 0-500 223.9-500 500s223.9 500 500 500 500-223.9 500-500-223.9-500-500-500zm261.8 692.2c19.4 19.6 19.3 51.3-.3 70.7-19.5 19.3-50.9 19.3-70.4 0L499.6 676.6 308 868.1c-19.6 19.4-51.3 19.3-70.7-.3-19.3-19.5-19.3-50.9 0-70.4l191.6-191.5-191.6-191.6c-19.3-19.8-18.9-51.4.9-70.7 19.4-18.9 50.4-18.9 69.8 0l191.6 191.5 191.5-191.5c19.6-19.4 51.3-19.3 70.7.3 19.3 19.5 19.3 50.9 0 70.4L570.3 605.9l191.5 191.5z"
-                    />
-                  </svg>
-                </span>
-              </button>
-              <h1
-                id="modal-save-work_title"
-              >
-                Saving your work
-              </h1>
-              <div
-                id="modal-save-work_desc"
-              >
-                <p>
-                  This tool uses cookies to 
-                  <strong>
-                    temporarily
-                  </strong>
-                   save your work. To see answers you’ve already completed, you need to use the same computer and browser, and don’t clear your cookies.
-                </p>
-                <p>
-                  To save a permanent copy of your work, please print the summary or save it as a PDF for every dimension as you complete it. You can also print or save a summary of the entire review. Learn how to 
-                  <a
-                    href="https://www.consumerfinance.gov/consumer-tools/save-as-pdf-instructions/"
-                    rel="noopener noreferrer"
-                    target="_blank"
-                  >
-                    save the summary as a PDF
-                  </a>
-                  .
-                </p>
-                <p>
-                  You can only work on a single curriculum at a time
-                </p>
-              </div>
-            </div>
-            <div
-              className="o-modal_footer"
+                  <path
+                    d="M500 105.2c-276.1 0-500 223.9-500 500s223.9 500 500 500 500-223.9 500-500-223.9-500-500-500zm261.8 692.2c19.4 19.6 19.3 51.3-.3 70.7-19.5 19.3-50.9 19.3-70.4 0L499.6 676.6 308 868.1c-19.6 19.4-51.3 19.3-70.7-.3-19.3-19.5-19.3-50.9 0-70.4l191.6-191.5-191.6-191.6c-19.3-19.8-18.9-51.4.9-70.7 19.4-18.9 50.4-18.9 69.8 0l191.6 191.5 191.5-191.5c19.6-19.4 51.3-19.3 70.7.3 19.3 19.5 19.3 50.9 0 70.4L570.3 605.9l191.5 191.5z"
+                  />
+                </svg>
+              </span>
+            </button>
+            <h1
+              id="modal-save-work_title"
             >
-              <button
-                className="a-btn"
-                onClick={[Function]}
-              >
-                Close
-              </button>
+              Saving your work
+            </h1>
+            <div
+              id="modal-save-work_desc"
+            >
+              <p>
+                This tool uses cookies to 
+                <strong>
+                  temporarily
+                </strong>
+                 save your work. To see answers you’ve already completed, you need to use the same computer and browser, and don’t clear your cookies.
+              </p>
+              <p>
+                To save a permanent copy of your work, please print the summary or save it as a PDF for every dimension as you complete it. You can also print or save a summary of the entire review. Learn how to 
+                <a
+                  href="https://www.consumerfinance.gov/consumer-tools/save-as-pdf-instructions/"
+                  rel="noopener noreferrer"
+                  target="_blank"
+                >
+                  save the summary as a PDF
+                </a>
+                .
+              </p>
+              <p>
+                You can only work on a single curriculum at a time
+              </p>
             </div>
-          </span>
+          </div>
+          <div
+            className="o-modal_footer"
+          >
+            <button
+              className="a-btn"
+              onClick={[Function]}
+            >
+              Close
+            </button>
+          </div>
         </form>
       </div>
     </div>

--- a/teachers_digital_platform/crtool/src/__tests__/__snapshots__/UtilityCriterionPage.test.js.snap
+++ b/teachers_digital_platform/crtool/src/__tests__/__snapshots__/UtilityCriterionPage.test.js.snap
@@ -782,71 +782,69 @@ exports[`Utility Criterion Page uses state to populate values 1`] = `
         <form
           className="o-modal_content"
         >
-          <span>
-            <div
-              className="o-modal_body"
+          <div
+            className="o-modal_body"
+          >
+            <button
+              className="o-modal_close a-btn a-btn__link"
+              onClick={[Function]}
             >
-              <button
-                className="o-modal_close a-btn a-btn__link"
-                onClick={[Function]}
+              Close  
+              <span
+                className="a-icon a-icon__large"
               >
-                Close  
-                <span
-                  className="a-icon a-icon__large"
+                <svg
+                  className="cf-icon-svg"
+                  viewBox="0 0 1000 1200"
+                  xmlns="http://www.w3.org/2000/svg"
                 >
-                  <svg
-                    className="cf-icon-svg"
-                    viewBox="0 0 1000 1200"
-                    xmlns="http://www.w3.org/2000/svg"
-                  >
-                    <path
-                      d="M500 105.2c-276.1 0-500 223.9-500 500s223.9 500 500 500 500-223.9 500-500-223.9-500-500-500zm261.8 692.2c19.4 19.6 19.3 51.3-.3 70.7-19.5 19.3-50.9 19.3-70.4 0L499.6 676.6 308 868.1c-19.6 19.4-51.3 19.3-70.7-.3-19.3-19.5-19.3-50.9 0-70.4l191.6-191.5-191.6-191.6c-19.3-19.8-18.9-51.4.9-70.7 19.4-18.9 50.4-18.9 69.8 0l191.6 191.5 191.5-191.5c19.6-19.4 51.3-19.3 70.7.3 19.3 19.5 19.3 50.9 0 70.4L570.3 605.9l191.5 191.5z"
-                    />
-                  </svg>
-                </span>
-              </button>
-              <h1
-                id="modal-save-work_title"
-              >
-                Saving your work
-              </h1>
-              <div
-                id="modal-save-work_desc"
-              >
-                <p>
-                  This tool uses cookies to 
-                  <strong>
-                    temporarily
-                  </strong>
-                   save your work. To see answers you’ve already completed, you need to use the same computer and browser, and don’t clear your cookies.
-                </p>
-                <p>
-                  To save a permanent copy of your work, please print the summary or save it as a PDF for every dimension as you complete it. You can also print or save a summary of the entire review. Learn how to 
-                  <a
-                    href="https://www.consumerfinance.gov/consumer-tools/save-as-pdf-instructions/"
-                    rel="noopener noreferrer"
-                    target="_blank"
-                  >
-                    save the summary as a PDF
-                  </a>
-                  .
-                </p>
-                <p>
-                  You can only work on a single curriculum at a time
-                </p>
-              </div>
-            </div>
-            <div
-              className="o-modal_footer"
+                  <path
+                    d="M500 105.2c-276.1 0-500 223.9-500 500s223.9 500 500 500 500-223.9 500-500-223.9-500-500-500zm261.8 692.2c19.4 19.6 19.3 51.3-.3 70.7-19.5 19.3-50.9 19.3-70.4 0L499.6 676.6 308 868.1c-19.6 19.4-51.3 19.3-70.7-.3-19.3-19.5-19.3-50.9 0-70.4l191.6-191.5-191.6-191.6c-19.3-19.8-18.9-51.4.9-70.7 19.4-18.9 50.4-18.9 69.8 0l191.6 191.5 191.5-191.5c19.6-19.4 51.3-19.3 70.7.3 19.3 19.5 19.3 50.9 0 70.4L570.3 605.9l191.5 191.5z"
+                  />
+                </svg>
+              </span>
+            </button>
+            <h1
+              id="modal-save-work_title"
             >
-              <button
-                className="a-btn"
-                onClick={[Function]}
-              >
-                Close
-              </button>
+              Saving your work
+            </h1>
+            <div
+              id="modal-save-work_desc"
+            >
+              <p>
+                This tool uses cookies to 
+                <strong>
+                  temporarily
+                </strong>
+                 save your work. To see answers you’ve already completed, you need to use the same computer and browser, and don’t clear your cookies.
+              </p>
+              <p>
+                To save a permanent copy of your work, please print the summary or save it as a PDF for every dimension as you complete it. You can also print or save a summary of the entire review. Learn how to 
+                <a
+                  href="https://www.consumerfinance.gov/consumer-tools/save-as-pdf-instructions/"
+                  rel="noopener noreferrer"
+                  target="_blank"
+                >
+                  save the summary as a PDF
+                </a>
+                .
+              </p>
+              <p>
+                You can only work on a single curriculum at a time
+              </p>
             </div>
-          </span>
+          </div>
+          <div
+            className="o-modal_footer"
+          >
+            <button
+              className="a-btn"
+              onClick={[Function]}
+            >
+              Close
+            </button>
+          </div>
         </form>
       </div>
     </div>

--- a/teachers_digital_platform/crtool/src/__tests__/__snapshots__/app_test.js.snap
+++ b/teachers_digital_platform/crtool/src/__tests__/__snapshots__/app_test.js.snap
@@ -30,71 +30,69 @@ exports[`renders without crashing 1`] = `
         <form
           className="o-modal_content"
         >
-          <span>
-            <div
-              className="o-modal_body"
+          <div
+            className="o-modal_body"
+          >
+            <button
+              className="o-modal_close a-btn a-btn__link"
+              onClick={[Function]}
             >
-              <button
-                className="o-modal_close a-btn a-btn__link"
-                onClick={[Function]}
+              Close  
+              <span
+                className="a-icon a-icon__large"
               >
-                Close  
-                <span
-                  className="a-icon a-icon__large"
+                <svg
+                  className="cf-icon-svg"
+                  viewBox="0 0 1000 1200"
+                  xmlns="http://www.w3.org/2000/svg"
                 >
-                  <svg
-                    className="cf-icon-svg"
-                    viewBox="0 0 1000 1200"
-                    xmlns="http://www.w3.org/2000/svg"
-                  >
-                    <path
-                      d="M500 105.2c-276.1 0-500 223.9-500 500s223.9 500 500 500 500-223.9 500-500-223.9-500-500-500zm261.8 692.2c19.4 19.6 19.3 51.3-.3 70.7-19.5 19.3-50.9 19.3-70.4 0L499.6 676.6 308 868.1c-19.6 19.4-51.3 19.3-70.7-.3-19.3-19.5-19.3-50.9 0-70.4l191.6-191.5-191.6-191.6c-19.3-19.8-18.9-51.4.9-70.7 19.4-18.9 50.4-18.9 69.8 0l191.6 191.5 191.5-191.5c19.6-19.4 51.3-19.3 70.7.3 19.3 19.5 19.3 50.9 0 70.4L570.3 605.9l191.5 191.5z"
-                    />
-                  </svg>
-                </span>
-              </button>
-              <h1
-                id="modal-save-work_title"
-              >
-                Saving your work
-              </h1>
-              <div
-                id="modal-save-work_desc"
-              >
-                <p>
-                  This tool uses cookies to 
-                  <strong>
-                    temporarily
-                  </strong>
-                   save your work. To see answers you’ve already completed, you need to use the same computer and browser, and don’t clear your cookies.
-                </p>
-                <p>
-                  To save a permanent copy of your work, please print the summary or save it as a PDF for every dimension as you complete it. You can also print or save a summary of the entire review. Learn how to 
-                  <a
-                    href="https://www.consumerfinance.gov/consumer-tools/save-as-pdf-instructions/"
-                    rel="noopener noreferrer"
-                    target="_blank"
-                  >
-                    save the summary as a PDF
-                  </a>
-                  .
-                </p>
-                <p>
-                  You can only work on a single curriculum at a time
-                </p>
-              </div>
-            </div>
-            <div
-              className="o-modal_footer"
+                  <path
+                    d="M500 105.2c-276.1 0-500 223.9-500 500s223.9 500 500 500 500-223.9 500-500-223.9-500-500-500zm261.8 692.2c19.4 19.6 19.3 51.3-.3 70.7-19.5 19.3-50.9 19.3-70.4 0L499.6 676.6 308 868.1c-19.6 19.4-51.3 19.3-70.7-.3-19.3-19.5-19.3-50.9 0-70.4l191.6-191.5-191.6-191.6c-19.3-19.8-18.9-51.4.9-70.7 19.4-18.9 50.4-18.9 69.8 0l191.6 191.5 191.5-191.5c19.6-19.4 51.3-19.3 70.7.3 19.3 19.5 19.3 50.9 0 70.4L570.3 605.9l191.5 191.5z"
+                  />
+                </svg>
+              </span>
+            </button>
+            <h1
+              id="modal-save-work_title"
             >
-              <button
-                className="a-btn"
-                onClick={[Function]}
-              >
-                Close
-              </button>
+              Saving your work
+            </h1>
+            <div
+              id="modal-save-work_desc"
+            >
+              <p>
+                This tool uses cookies to 
+                <strong>
+                  temporarily
+                </strong>
+                 save your work. To see answers you’ve already completed, you need to use the same computer and browser, and don’t clear your cookies.
+              </p>
+              <p>
+                To save a permanent copy of your work, please print the summary or save it as a PDF for every dimension as you complete it. You can also print or save a summary of the entire review. Learn how to 
+                <a
+                  href="https://www.consumerfinance.gov/consumer-tools/save-as-pdf-instructions/"
+                  rel="noopener noreferrer"
+                  target="_blank"
+                >
+                  save the summary as a PDF
+                </a>
+                .
+              </p>
+              <p>
+                You can only work on a single curriculum at a time
+              </p>
             </div>
-          </span>
+          </div>
+          <div
+            className="o-modal_footer"
+          >
+            <button
+              className="a-btn"
+              onClick={[Function]}
+            >
+              Close
+            </button>
+          </div>
         </form>
       </div>
     </div>
@@ -385,64 +383,62 @@ exports[`renders without crashing 1`] = `
           <form
             className="o-modal_content"
           >
-            <span>
+            <div
+              className="o-modal_body"
+            >
+              <button
+                className="o-modal_close a-btn a-btn__link"
+                onClick={[Function]}
+              >
+                Close  
+                <span
+                  className="a-icon a-icon__large"
+                >
+                  <svg
+                    className="cf-icon-svg"
+                    viewBox="0 0 1000 1200"
+                    xmlns="http://www.w3.org/2000/svg"
+                  >
+                    <path
+                      d="M500 105.2c-276.1 0-500 223.9-500 500s223.9 500 500 500 500-223.9 500-500-223.9-500-500-500zm261.8 692.2c19.4 19.6 19.3 51.3-.3 70.7-19.5 19.3-50.9 19.3-70.4 0L499.6 676.6 308 868.1c-19.6 19.4-51.3 19.3-70.7-.3-19.3-19.5-19.3-50.9 0-70.4l191.6-191.5-191.6-191.6c-19.3-19.8-18.9-51.4.9-70.7 19.4-18.9 50.4-18.9 69.8 0l191.6 191.5 191.5-191.5c19.6-19.4 51.3-19.3 70.7.3 19.3 19.5 19.3 50.9 0 70.4L570.3 605.9l191.5 191.5z"
+                    />
+                  </svg>
+                </span>
+              </button>
+              <h1
+                id="modal-start-over_title"
+              >
+                Starting over
+              </h1>
               <div
-                className="o-modal_body"
+                id="modal-start-over_desc"
+              >
+                <p>
+                  Starting a new review will erase your answers for all dimensions. Are you sure you want to start a new review?
+                </p>
+              </div>
+            </div>
+            <div
+              className="o-modal_footer"
+            >
+              <div
+                className="m-btn-group"
               >
                 <button
-                  className="o-modal_close a-btn a-btn__link"
+                  className="a-btn"
+                  formAction="../../tdp/crt-start/"
                   onClick={[Function]}
                 >
-                  Close  
-                  <span
-                    className="a-icon a-icon__large"
-                  >
-                    <svg
-                      className="cf-icon-svg"
-                      viewBox="0 0 1000 1200"
-                      xmlns="http://www.w3.org/2000/svg"
-                    >
-                      <path
-                        d="M500 105.2c-276.1 0-500 223.9-500 500s223.9 500 500 500 500-223.9 500-500-223.9-500-500-500zm261.8 692.2c19.4 19.6 19.3 51.3-.3 70.7-19.5 19.3-50.9 19.3-70.4 0L499.6 676.6 308 868.1c-19.6 19.4-51.3 19.3-70.7-.3-19.3-19.5-19.3-50.9 0-70.4l191.6-191.5-191.6-191.6c-19.3-19.8-18.9-51.4.9-70.7 19.4-18.9 50.4-18.9 69.8 0l191.6 191.5 191.5-191.5c19.6-19.4 51.3-19.3 70.7.3 19.3 19.5 19.3 50.9 0 70.4L570.3 605.9l191.5 191.5z"
-                      />
-                    </svg>
-                  </span>
+                  Yes
                 </button>
-                <h1
-                  id="modal-start-over_title"
+                <button
+                  className="a-btn a-btn__link"
+                  onClick={[Function]}
                 >
-                  Starting over
-                </h1>
-                <div
-                  id="modal-start-over_desc"
-                >
-                  <p>
-                    Starting a new review will erase your answers for all dimensions. Are you sure you want to start a new review?
-                  </p>
-                </div>
+                  No, return to current review
+                </button>
               </div>
-              <div
-                className="o-modal_footer"
-              >
-                <div
-                  className="m-btn-group"
-                >
-                  <button
-                    className="a-btn"
-                    formAction="../../tdp/crt-start/"
-                    onClick={[Function]}
-                  >
-                    Yes
-                  </button>
-                  <button
-                    className="a-btn a-btn__link"
-                    onClick={[Function]}
-                  >
-                    No, return to current review
-                  </button>
-                </div>
-              </div>
-            </span>
+            </div>
           </form>
         </div>
       </div>

--- a/teachers_digital_platform/crtool/src/js/components/dialogs/SaveWorkModal.js
+++ b/teachers_digital_platform/crtool/src/js/components/dialogs/SaveWorkModal.js
@@ -1,82 +1,82 @@
 import React from "react";
 
 export default class SaveWorkModal extends React.Component {
-  constructor(props) {
-    super(props);
+    constructor(props) {
+        super(props);
 
-    this.setWrapperRef = this.setWrapperRef.bind(this);
-    this.handleSaveWorkClickOutside = this.handleSaveWorkClickOutside.bind(this);
-  }
-
-  /* Click Outside setup */
-  componentDidMount() {
-    document.addEventListener('mousedown', this.handleSaveWorkClickOutside);
-  }
-
-  /* Click Outside setup */
-  componentWillUnmount() {
-    document.removeEventListener('mousedown', this.handleSaveWorkClickOutside);
-  }
-
-  /* Click Outside setup */
-  setWrapperRef(node) {
-    this.wrapperRef = node;
-  }
-
-  /* Click Outside setup */
-  handleSaveWorkClickOutside(event) {
-    if (this.wrapperRef && !this.wrapperRef.contains(event.target)) {
-      let saveWorkModalDialog = document.getElementById('modal-save-work');
-      saveWorkModalDialog.classList.remove('o-modal__visible');
+        this.setWrapperRef = this.setWrapperRef.bind(this);
+        this.handleSaveWorkClickOutside = this.handleSaveWorkClickOutside.bind(this);
     }
-  }
 
-  /* Modal specific open dialog */
-  openSaveWorkModalDialog() {
-    let saveWorkModalDialog = document.getElementById('modal-save-work');
-    saveWorkModalDialog.classList.add('o-modal__visible');
-  }
+    /* Click Outside setup */
+    componentDidMount() {
+        document.addEventListener('mousedown', this.handleSaveWorkClickOutside);
+    }
 
-  /* Modal specific close dialog */
-  closeSaveWorkModalDialog() {
-    let saveWorkModalDialog = document.getElementById('modal-save-work');
-    saveWorkModalDialog.classList.remove('o-modal__visible');
-  }
+    /* Click Outside setup */
+    componentWillUnmount() {
+        document.removeEventListener('mousedown', this.handleSaveWorkClickOutside);
+    }
 
-  render() {
-    return (
-      <div className="l-survey-top">
-        <button className="a-btn a-btn__link" onClick={(e) => {this.openSaveWorkModalDialog()}}>Can I save my work?</button>
-        <div className="o-modal"
-            id="modal-save-work"
-            aria-hidden="true"
-            role="alertdialog"
-            aria-labelledby="modal-save-work_title"
-            aria-describedby="modal-save-work_desc">
-          <div className="o-modal_backdrop"></div>
-          <div className="o-modal_container">
-              <form className="o-modal_content">
-                <span ref={this.setWrapperRef}>
-                  <div className="o-modal_body">
-                    <button className="o-modal_close a-btn a-btn__link" onClick={(e) => {this.closeSaveWorkModalDialog(); e.preventDefault();}}>
-                        Close
-                        &nbsp;<span className="a-icon a-icon__large"><svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 1000 1200" className="cf-icon-svg"><path d="M500 105.2c-276.1 0-500 223.9-500 500s223.9 500 500 500 500-223.9 500-500-223.9-500-500-500zm261.8 692.2c19.4 19.6 19.3 51.3-.3 70.7-19.5 19.3-50.9 19.3-70.4 0L499.6 676.6 308 868.1c-19.6 19.4-51.3 19.3-70.7-.3-19.3-19.5-19.3-50.9 0-70.4l191.6-191.5-191.6-191.6c-19.3-19.8-18.9-51.4.9-70.7 19.4-18.9 50.4-18.9 69.8 0l191.6 191.5 191.5-191.5c19.6-19.4 51.3-19.3 70.7.3 19.3 19.5 19.3 50.9 0 70.4L570.3 605.9l191.5 191.5z"/></svg></span>
-                    </button>
-                    <h1 id="modal-save-work_title">Saving your work</h1>
-                    <div id="modal-save-work_desc">
-                        <p>This tool uses cookies to <strong>temporarily</strong> save your work. To see answers you’ve already completed, you need to use the same computer and browser, and don’t clear your cookies.</p>
-                        <p>To save a permanent copy of your work, please print the summary or save it as a PDF for every dimension as you complete it. You can also print or save a summary of the entire review. Learn how to <a href="https://www.consumerfinance.gov/consumer-tools/save-as-pdf-instructions/" target="_blank" rel="noopener noreferrer">save the summary as a PDF</a>.</p>
-                        <p>You can only work on a single curriculum at a time</p>
+    /* Click Outside setup */
+    setWrapperRef(node) {
+        this.wrapperRef = node;
+    }
+
+    /* Click Outside setup */
+    handleSaveWorkClickOutside(event) {
+        if (this.wrapperRef && !this.wrapperRef.contains(event.target)) {
+        let saveWorkModalDialog = document.getElementById('modal-save-work');
+        saveWorkModalDialog.classList.remove('o-modal__visible');
+        }
+    }
+
+    /* Modal specific open dialog */
+    openSaveWorkModalDialog() {
+        let saveWorkModalDialog = document.getElementById('modal-save-work');
+        saveWorkModalDialog.classList.add('o-modal__visible');
+    }
+
+    /* Modal specific close dialog */
+    closeSaveWorkModalDialog() {
+        let saveWorkModalDialog = document.getElementById('modal-save-work');
+        saveWorkModalDialog.classList.remove('o-modal__visible');
+    }
+
+    render() {
+        return (
+        <div className="l-survey-top">
+            <button className="a-btn a-btn__link" onClick={(e) => {this.openSaveWorkModalDialog()}}>Can I save my work?</button>
+            <div className="o-modal"
+                id="modal-save-work"
+                aria-hidden="true"
+                role="alertdialog"
+                aria-labelledby="modal-save-work_title"
+                aria-describedby="modal-save-work_desc">
+            <div className="o-modal_backdrop"></div>
+            <div className="o-modal_container">
+                <form className="o-modal_content">
+                    <span ref={this.setWrapperRef}>
+                    <div className="o-modal_body">
+                        <button className="o-modal_close a-btn a-btn__link" onClick={(e) => {this.closeSaveWorkModalDialog(); e.preventDefault();}}>
+                            Close
+                            &nbsp;<span className="a-icon a-icon__large"><svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 1000 1200" className="cf-icon-svg"><path d="M500 105.2c-276.1 0-500 223.9-500 500s223.9 500 500 500 500-223.9 500-500-223.9-500-500-500zm261.8 692.2c19.4 19.6 19.3 51.3-.3 70.7-19.5 19.3-50.9 19.3-70.4 0L499.6 676.6 308 868.1c-19.6 19.4-51.3 19.3-70.7-.3-19.3-19.5-19.3-50.9 0-70.4l191.6-191.5-191.6-191.6c-19.3-19.8-18.9-51.4.9-70.7 19.4-18.9 50.4-18.9 69.8 0l191.6 191.5 191.5-191.5c19.6-19.4 51.3-19.3 70.7.3 19.3 19.5 19.3 50.9 0 70.4L570.3 605.9l191.5 191.5z"/></svg></span>
+                        </button>
+                        <h1 id="modal-save-work_title">Saving your work</h1>
+                        <div id="modal-save-work_desc">
+                            <p>This tool uses cookies to <strong>temporarily</strong> save your work. To see answers you’ve already completed, you need to use the same computer and browser, and don’t clear your cookies.</p>
+                            <p>To save a permanent copy of your work, please print the summary or save it as a PDF for every dimension as you complete it. You can also print or save a summary of the entire review. Learn how to <a href="https://www.consumerfinance.gov/consumer-tools/save-as-pdf-instructions/" target="_blank" rel="noopener noreferrer">save the summary as a PDF</a>.</p>
+                            <p>You can only work on a single curriculum at a time</p>
+                        </div>
                     </div>
-                  </div>
-                  <div className="o-modal_footer">
-                      <button className="a-btn" onClick={(e) => {this.closeSaveWorkModalDialog(); e.preventDefault();}}>Close</button>
-                  </div>
-                </span>
-              </form>
-          </div>
+                    <div className="o-modal_footer">
+                        <button className="a-btn" onClick={(e) => {this.closeSaveWorkModalDialog(); e.preventDefault();}}>Close</button>
+                    </div>
+                    </span>
+                </form>
+            </div>
+            </div>
         </div>
-      </div>
-    );
-  }
+        );
+    }
 }

--- a/teachers_digital_platform/crtool/src/js/components/dialogs/SaveWorkModal.js
+++ b/teachers_digital_platform/crtool/src/js/components/dialogs/SaveWorkModal.js
@@ -55,8 +55,7 @@ export default class SaveWorkModal extends React.Component {
                     aria-describedby="modal-save-work_desc">
                     <div className="o-modal_backdrop"></div>
                     <div className="o-modal_container">
-                        <form className="o-modal_content">
-                            <span ref={this.setWrapperRef}>
+                        <form className="o-modal_content" ref={this.setWrapperRef}>
                             <div className="o-modal_body">
                                 <button className="o-modal_close a-btn a-btn__link" onClick={(e) => {this.closeSaveWorkModalDialog(); e.preventDefault();}}>
                                     Close
@@ -72,7 +71,6 @@ export default class SaveWorkModal extends React.Component {
                             <div className="o-modal_footer">
                                 <button className="a-btn" onClick={(e) => {this.closeSaveWorkModalDialog(); e.preventDefault();}}>Close</button>
                             </div>
-                            </span>
                         </form>
                     </div>
                 </div>

--- a/teachers_digital_platform/crtool/src/js/components/dialogs/SaveWorkModal.js
+++ b/teachers_digital_platform/crtool/src/js/components/dialogs/SaveWorkModal.js
@@ -1,80 +1,82 @@
 import React from "react";
 
 export default class SaveWorkModal extends React.Component {
-    constructor(props) {
-        super(props);
+  constructor(props) {
+    super(props);
 
-        this.setWrapperRef = this.setWrapperRef.bind(this);
-        this.handleClickOutside = this.handleClickOutside.bind(this);
+    this.setWrapperRef = this.setWrapperRef.bind(this);
+    this.handleSaveWorkClickOutside = this.handleSaveWorkClickOutside.bind(this);
+  }
+
+  /* Click Outside setup */
+  componentDidMount() {
+    document.addEventListener('mousedown', this.handleSaveWorkClickOutside);
+  }
+
+  /* Click Outside setup */
+  componentWillUnmount() {
+    document.removeEventListener('mousedown', this.handleSaveWorkClickOutside);
+  }
+
+  /* Click Outside setup */
+  setWrapperRef(node) {
+    this.wrapperRef = node;
+  }
+
+  /* Click Outside setup */
+  handleSaveWorkClickOutside(event) {
+    if (this.wrapperRef && !this.wrapperRef.contains(event.target)) {
+      let saveWorkModalDialog = document.getElementById('modal-save-work');
+      saveWorkModalDialog.classList.remove('o-modal__visible');
     }
+  }
 
-    componentDidMount() {
-        document.addEventListener('mousedown', this.handleClickOutside);
-    }
+  /* Modal specific open dialog */
+  openSaveWorkModalDialog() {
+    let saveWorkModalDialog = document.getElementById('modal-save-work');
+    saveWorkModalDialog.classList.add('o-modal__visible');
+  }
 
-    componentWillUnmount() {
-        document.removeEventListener('mousedown', this.handleClickOutside);
-    }
+  /* Modal specific close dialog */
+  closeSaveWorkModalDialog() {
+    let saveWorkModalDialog = document.getElementById('modal-save-work');
+    saveWorkModalDialog.classList.remove('o-modal__visible');
+  }
 
-    /** Set the wrapper ref */
-    setWrapperRef(node) {
-        this.wrapperRef = node;
-    }
-
-    /** Alert if clicked on outside of element */
-    handleClickOutside(event) {
-      if (this.wrapperRef && !this.wrapperRef.contains(event.target)) {
-        let saveWorkModalDialog = document.getElementById('modal-save-work');
-        if (saveWorkModalDialog.classList.contains('o-modal__visible')) {
-            saveWorkModalDialog.classList.remove('o-modal__visible');
-        }
-      }
-    }
-
-    openSaveWorkModalDialog() {
-        let saveWorkModalDialog = document.getElementById('modal-save-work');
-        saveWorkModalDialog.classList.add('o-modal__visible');
-    }
-
-    closeSaveWorkModalDialog() {
-        let saveWorkModalDialog = document.getElementById('modal-save-work');
-        saveWorkModalDialog.classList.remove('o-modal__visible');
-    }
-
-    render() {
-        return (
-            <div className="l-survey-top">
-                <button className="a-btn a-btn__link" onClick={(e) => {this.openSaveWorkModalDialog()}}>Can I save my work?</button>
-                <div className="o-modal"
-                    id="modal-save-work"
-                    aria-hidden="true"
-                    role="alertdialog"
-                    aria-labelledby="modal-save-work_title"
-                    aria-describedby="modal-save-work_desc">
-                    <div className="o-modal_backdrop"></div>
-                    <div className="o-modal_container">
-                        <form className="o-modal_content">
-                            <span ref={this.setWrapperRef}>
-                                <div className="o-modal_body">
-                                    <button className="o-modal_close a-btn a-btn__link" onClick={(e) => {this.closeSaveWorkModalDialog(); e.preventDefault();}}>
-                                        Close
-                                        &nbsp;<span className="a-icon a-icon__large"><svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 1000 1200" className="cf-icon-svg"><path d="M500 105.2c-276.1 0-500 223.9-500 500s223.9 500 500 500 500-223.9 500-500-223.9-500-500-500zm261.8 692.2c19.4 19.6 19.3 51.3-.3 70.7-19.5 19.3-50.9 19.3-70.4 0L499.6 676.6 308 868.1c-19.6 19.4-51.3 19.3-70.7-.3-19.3-19.5-19.3-50.9 0-70.4l191.6-191.5-191.6-191.6c-19.3-19.8-18.9-51.4.9-70.7 19.4-18.9 50.4-18.9 69.8 0l191.6 191.5 191.5-191.5c19.6-19.4 51.3-19.3 70.7.3 19.3 19.5 19.3 50.9 0 70.4L570.3 605.9l191.5 191.5z"/></svg></span>
-                                    </button>
-                                    <h1 id="modal-save-work_title">Saving your work</h1>
-                                    <div id="modal-save-work_desc">
-                                        <p>This tool uses cookies to <strong>temporarily</strong> save your work. To see answers you’ve already completed, you need to use the same computer and browser, and don’t clear your cookies.</p>
-                                        <p>To save a permanent copy of your work, please print the summary or save it as a PDF for every dimension as you complete it. You can also print or save a summary of the entire review. Learn how to <a href="https://www.consumerfinance.gov/consumer-tools/save-as-pdf-instructions/" target="_blank" rel="noopener noreferrer">save the summary as a PDF</a>.</p>
-                                        <p>You can only work on a single curriculum at a time</p>
-                                    </div>
-                                </div>
-                                <div className="o-modal_footer">
-                                    <button className="a-btn" onClick={(e) => {this.closeSaveWorkModalDialog(); e.preventDefault();}}>Close</button>
-                                </div>
-                            </span>
-                        </form>
+  render() {
+    return (
+      <div className="l-survey-top">
+        <button className="a-btn a-btn__link" onClick={(e) => {this.openSaveWorkModalDialog()}}>Can I save my work?</button>
+        <div className="o-modal"
+            id="modal-save-work"
+            aria-hidden="true"
+            role="alertdialog"
+            aria-labelledby="modal-save-work_title"
+            aria-describedby="modal-save-work_desc">
+          <div className="o-modal_backdrop"></div>
+          <div className="o-modal_container">
+              <form className="o-modal_content">
+                <span ref={this.setWrapperRef}>
+                  <div className="o-modal_body">
+                    <button className="o-modal_close a-btn a-btn__link" onClick={(e) => {this.closeSaveWorkModalDialog(); e.preventDefault();}}>
+                        Close
+                        &nbsp;<span className="a-icon a-icon__large"><svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 1000 1200" className="cf-icon-svg"><path d="M500 105.2c-276.1 0-500 223.9-500 500s223.9 500 500 500 500-223.9 500-500-223.9-500-500-500zm261.8 692.2c19.4 19.6 19.3 51.3-.3 70.7-19.5 19.3-50.9 19.3-70.4 0L499.6 676.6 308 868.1c-19.6 19.4-51.3 19.3-70.7-.3-19.3-19.5-19.3-50.9 0-70.4l191.6-191.5-191.6-191.6c-19.3-19.8-18.9-51.4.9-70.7 19.4-18.9 50.4-18.9 69.8 0l191.6 191.5 191.5-191.5c19.6-19.4 51.3-19.3 70.7.3 19.3 19.5 19.3 50.9 0 70.4L570.3 605.9l191.5 191.5z"/></svg></span>
+                    </button>
+                    <h1 id="modal-save-work_title">Saving your work</h1>
+                    <div id="modal-save-work_desc">
+                        <p>This tool uses cookies to <strong>temporarily</strong> save your work. To see answers you’ve already completed, you need to use the same computer and browser, and don’t clear your cookies.</p>
+                        <p>To save a permanent copy of your work, please print the summary or save it as a PDF for every dimension as you complete it. You can also print or save a summary of the entire review. Learn how to <a href="https://www.consumerfinance.gov/consumer-tools/save-as-pdf-instructions/" target="_blank" rel="noopener noreferrer">save the summary as a PDF</a>.</p>
+                        <p>You can only work on a single curriculum at a time</p>
                     </div>
-                </div>
-            </div>
-        );
-    }
+                  </div>
+                  <div className="o-modal_footer">
+                      <button className="a-btn" onClick={(e) => {this.closeSaveWorkModalDialog(); e.preventDefault();}}>Close</button>
+                  </div>
+                </span>
+              </form>
+          </div>
+        </div>
+      </div>
+    );
+  }
 }

--- a/teachers_digital_platform/crtool/src/js/components/dialogs/SaveWorkModal.js
+++ b/teachers_digital_platform/crtool/src/js/components/dialogs/SaveWorkModal.js
@@ -45,38 +45,38 @@ export default class SaveWorkModal extends React.Component {
 
     render() {
         return (
-        <div className="l-survey-top">
-            <button className="a-btn a-btn__link" onClick={(e) => {this.openSaveWorkModalDialog()}}>Can I save my work?</button>
-            <div className="o-modal"
-                id="modal-save-work"
-                aria-hidden="true"
-                role="alertdialog"
-                aria-labelledby="modal-save-work_title"
-                aria-describedby="modal-save-work_desc">
-            <div className="o-modal_backdrop"></div>
-            <div className="o-modal_container">
-                <form className="o-modal_content">
-                    <span ref={this.setWrapperRef}>
-                    <div className="o-modal_body">
-                        <button className="o-modal_close a-btn a-btn__link" onClick={(e) => {this.closeSaveWorkModalDialog(); e.preventDefault();}}>
-                            Close
-                            &nbsp;<span className="a-icon a-icon__large"><svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 1000 1200" className="cf-icon-svg"><path d="M500 105.2c-276.1 0-500 223.9-500 500s223.9 500 500 500 500-223.9 500-500-223.9-500-500-500zm261.8 692.2c19.4 19.6 19.3 51.3-.3 70.7-19.5 19.3-50.9 19.3-70.4 0L499.6 676.6 308 868.1c-19.6 19.4-51.3 19.3-70.7-.3-19.3-19.5-19.3-50.9 0-70.4l191.6-191.5-191.6-191.6c-19.3-19.8-18.9-51.4.9-70.7 19.4-18.9 50.4-18.9 69.8 0l191.6 191.5 191.5-191.5c19.6-19.4 51.3-19.3 70.7.3 19.3 19.5 19.3 50.9 0 70.4L570.3 605.9l191.5 191.5z"/></svg></span>
-                        </button>
-                        <h1 id="modal-save-work_title">Saving your work</h1>
-                        <div id="modal-save-work_desc">
-                            <p>This tool uses cookies to <strong>temporarily</strong> save your work. To see answers you’ve already completed, you need to use the same computer and browser, and don’t clear your cookies.</p>
-                            <p>To save a permanent copy of your work, please print the summary or save it as a PDF for every dimension as you complete it. You can also print or save a summary of the entire review. Learn how to <a href="https://www.consumerfinance.gov/consumer-tools/save-as-pdf-instructions/" target="_blank" rel="noopener noreferrer">save the summary as a PDF</a>.</p>
-                            <p>You can only work on a single curriculum at a time</p>
-                        </div>
+            <div className="l-survey-top">
+                <button className="a-btn a-btn__link" onClick={(e) => {this.openSaveWorkModalDialog()}}>Can I save my work?</button>
+                <div className="o-modal"
+                    id="modal-save-work"
+                    aria-hidden="true"
+                    role="alertdialog"
+                    aria-labelledby="modal-save-work_title"
+                    aria-describedby="modal-save-work_desc">
+                    <div className="o-modal_backdrop"></div>
+                    <div className="o-modal_container">
+                        <form className="o-modal_content">
+                            <span ref={this.setWrapperRef}>
+                            <div className="o-modal_body">
+                                <button className="o-modal_close a-btn a-btn__link" onClick={(e) => {this.closeSaveWorkModalDialog(); e.preventDefault();}}>
+                                    Close
+                                    &nbsp;<span className="a-icon a-icon__large"><svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 1000 1200" className="cf-icon-svg"><path d="M500 105.2c-276.1 0-500 223.9-500 500s223.9 500 500 500 500-223.9 500-500-223.9-500-500-500zm261.8 692.2c19.4 19.6 19.3 51.3-.3 70.7-19.5 19.3-50.9 19.3-70.4 0L499.6 676.6 308 868.1c-19.6 19.4-51.3 19.3-70.7-.3-19.3-19.5-19.3-50.9 0-70.4l191.6-191.5-191.6-191.6c-19.3-19.8-18.9-51.4.9-70.7 19.4-18.9 50.4-18.9 69.8 0l191.6 191.5 191.5-191.5c19.6-19.4 51.3-19.3 70.7.3 19.3 19.5 19.3 50.9 0 70.4L570.3 605.9l191.5 191.5z"/></svg></span>
+                                </button>
+                                <h1 id="modal-save-work_title">Saving your work</h1>
+                                <div id="modal-save-work_desc">
+                                    <p>This tool uses cookies to <strong>temporarily</strong> save your work. To see answers you’ve already completed, you need to use the same computer and browser, and don’t clear your cookies.</p>
+                                    <p>To save a permanent copy of your work, please print the summary or save it as a PDF for every dimension as you complete it. You can also print or save a summary of the entire review. Learn how to <a href="https://www.consumerfinance.gov/consumer-tools/save-as-pdf-instructions/" target="_blank" rel="noopener noreferrer">save the summary as a PDF</a>.</p>
+                                    <p>You can only work on a single curriculum at a time</p>
+                                </div>
+                            </div>
+                            <div className="o-modal_footer">
+                                <button className="a-btn" onClick={(e) => {this.closeSaveWorkModalDialog(); e.preventDefault();}}>Close</button>
+                            </div>
+                            </span>
+                        </form>
                     </div>
-                    <div className="o-modal_footer">
-                        <button className="a-btn" onClick={(e) => {this.closeSaveWorkModalDialog(); e.preventDefault();}}>Close</button>
-                    </div>
-                    </span>
-                </form>
+                </div>
             </div>
-            </div>
-        </div>
         );
     }
 }

--- a/teachers_digital_platform/crtool/src/js/components/dialogs/StartOverModal.js
+++ b/teachers_digital_platform/crtool/src/js/components/dialogs/StartOverModal.js
@@ -3,90 +3,90 @@ import React from "react";
 import C from "../../constants";
 
 export default class StartOverModal extends React.Component {
-  constructor(props) {
-    super(props);
+    constructor(props) {
+        super(props);
 
-    this.setWrapperRef = this.setWrapperRef.bind(this);
-    this.handleStartOverClickOutside = this.handleStartOverClickOutside.bind(this);
-  }
-
-  /* Click Outside setup */
-  componentDidMount() {
-    document.addEventListener('mousedown', this.handleStartOverClickOutside);
-  }
-
-  /* Click Outside setup */
-  componentWillUnmount() {
-    document.removeEventListener('mousedown', this.handleStartOverClickOutside);
-  }
-
-  /* Click Outside setup */
-  setWrapperRef(node) {
-    this.wrapperRef = node;
-  }
-
-  /* Click Outside setup */
-  handleStartOverClickOutside(event) {
-    if (this.wrapperRef && !this.wrapperRef.contains(event.target)) {
-      let startOverModalDialog = document.getElementById('modal-start-over');
-      startOverModalDialog.classList.remove('o-modal__visible');
+        this.setWrapperRef = this.setWrapperRef.bind(this);
+        this.handleStartOverClickOutside = this.handleStartOverClickOutside.bind(this);
     }
-  }
 
-  /* Modal specific clearLocalStorage */
-  clearLocalStorage() {
-    this.props.clearLocalStorage();
-  }
+    /* Click Outside setup */
+    componentDidMount() {
+        document.addEventListener('mousedown', this.handleStartOverClickOutside);
+    }
 
-  /* Modal specific open dialog */
-  openstartOverModalDialog() {
-    let startOverModalDialog = document.getElementById('modal-start-over');
-    startOverModalDialog.classList.add('o-modal__visible');
-  }
+    /* Click Outside setup */
+    componentWillUnmount() {
+        document.removeEventListener('mousedown', this.handleStartOverClickOutside);
+    }
 
-  /* Modal specific close dialog */
-  closestartOverModalDialog() {
-    let startOverModalDialog = document.getElementById('modal-start-over');
-    startOverModalDialog.classList.remove('o-modal__visible');
-  }
+    /* Click Outside setup */
+    setWrapperRef(node) {
+        this.wrapperRef = node;
+    }
 
-  render() {
-    return (
-      <React.Fragment>
-        <button className="a-btn a-btn__link" onClick={(e) => {this.openstartOverModalDialog();}}>
-            Start over with a new review
-        </button>
-        <div className="o-modal"
-            id="modal-start-over"
-            aria-hidden="true"
-            role="alertdialog"
-            aria-labelledby="modal-start-over_title"
-            aria-describedby="modal-start-over_desc">
-          <div className="o-modal_backdrop"></div>
-          <div className="o-modal_container">
-            <form className="o-modal_content">
-              <span ref={this.setWrapperRef}>
-                <div className="o-modal_body">
-                  <button className="o-modal_close a-btn a-btn__link" onClick={(e) => {this.closestartOverModalDialog(); e.preventDefault();}}>
-                    Close
-                    &nbsp;<span className="a-icon a-icon__large"><svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 1000 1200" className="cf-icon-svg"><path d="M500 105.2c-276.1 0-500 223.9-500 500s223.9 500 500 500 500-223.9 500-500-223.9-500-500-500zm261.8 692.2c19.4 19.6 19.3 51.3-.3 70.7-19.5 19.3-50.9 19.3-70.4 0L499.6 676.6 308 868.1c-19.6 19.4-51.3 19.3-70.7-.3-19.3-19.5-19.3-50.9 0-70.4l191.6-191.5-191.6-191.6c-19.3-19.8-18.9-51.4.9-70.7 19.4-18.9 50.4-18.9 69.8 0l191.6 191.5 191.5-191.5c19.6-19.4 51.3-19.3 70.7.3 19.3 19.5 19.3 50.9 0 70.4L570.3 605.9l191.5 191.5z"/></svg></span>
-                  </button>
-                  <h1 id="modal-start-over_title">Starting over</h1>
-                  <div id="modal-start-over_desc">
-                    <p>Starting a new review will erase your answers for all dimensions. Are you sure you want to start a new review?</p>
-                  </div>
-                </div>
-                <div className="o-modal_footer">
-                  <div className="m-btn-group">
-                    <button className="a-btn" onClick={(e) => {this.clearLocalStorage()}} formAction={C.START_PAGE_RELATIVE_URL} >Yes</button>
-                    <button className="a-btn a-btn__link" onClick={(e) => {this.closestartOverModalDialog(); e.preventDefault();}}>No, return to current review</button>
-                  </div>
-                </div>
-              </span>
-            </form>
-          </div>
-        </div>
-      </React.Fragment>
-    );
-  }
+    /* Click Outside setup */
+    handleStartOverClickOutside(event) {
+        if (this.wrapperRef && !this.wrapperRef.contains(event.target)) {
+        let startOverModalDialog = document.getElementById('modal-start-over');
+        startOverModalDialog.classList.remove('o-modal__visible');
+        }
+    }
+
+    /* Modal specific clearLocalStorage */
+    clearLocalStorage() {
+        this.props.clearLocalStorage();
+    }
+
+    /* Modal specific open dialog */
+    openstartOverModalDialog() {
+        let startOverModalDialog = document.getElementById('modal-start-over');
+        startOverModalDialog.classList.add('o-modal__visible');
+    }
+
+    /* Modal specific close dialog */
+    closestartOverModalDialog() {
+        let startOverModalDialog = document.getElementById('modal-start-over');
+        startOverModalDialog.classList.remove('o-modal__visible');
+    }
+
+    render() {
+        return (
+        <React.Fragment>
+            <button className="a-btn a-btn__link" onClick={(e) => {this.openstartOverModalDialog();}}>
+                Start over with a new review
+            </button>
+            <div className="o-modal"
+                id="modal-start-over"
+                aria-hidden="true"
+                role="alertdialog"
+                aria-labelledby="modal-start-over_title"
+                aria-describedby="modal-start-over_desc">
+            <div className="o-modal_backdrop"></div>
+            <div className="o-modal_container">
+                <form className="o-modal_content">
+                <span ref={this.setWrapperRef}>
+                    <div className="o-modal_body">
+                    <button className="o-modal_close a-btn a-btn__link" onClick={(e) => {this.closestartOverModalDialog(); e.preventDefault();}}>
+                        Close
+                        &nbsp;<span className="a-icon a-icon__large"><svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 1000 1200" className="cf-icon-svg"><path d="M500 105.2c-276.1 0-500 223.9-500 500s223.9 500 500 500 500-223.9 500-500-223.9-500-500-500zm261.8 692.2c19.4 19.6 19.3 51.3-.3 70.7-19.5 19.3-50.9 19.3-70.4 0L499.6 676.6 308 868.1c-19.6 19.4-51.3 19.3-70.7-.3-19.3-19.5-19.3-50.9 0-70.4l191.6-191.5-191.6-191.6c-19.3-19.8-18.9-51.4.9-70.7 19.4-18.9 50.4-18.9 69.8 0l191.6 191.5 191.5-191.5c19.6-19.4 51.3-19.3 70.7.3 19.3 19.5 19.3 50.9 0 70.4L570.3 605.9l191.5 191.5z"/></svg></span>
+                    </button>
+                    <h1 id="modal-start-over_title">Starting over</h1>
+                    <div id="modal-start-over_desc">
+                        <p>Starting a new review will erase your answers for all dimensions. Are you sure you want to start a new review?</p>
+                    </div>
+                    </div>
+                    <div className="o-modal_footer">
+                    <div className="m-btn-group">
+                        <button className="a-btn" onClick={(e) => {this.clearLocalStorage()}} formAction={C.START_PAGE_RELATIVE_URL} >Yes</button>
+                        <button className="a-btn a-btn__link" onClick={(e) => {this.closestartOverModalDialog(); e.preventDefault();}}>No, return to current review</button>
+                    </div>
+                    </div>
+                </span>
+                </form>
+            </div>
+            </div>
+        </React.Fragment>
+        );
+    }
 }

--- a/teachers_digital_platform/crtool/src/js/components/dialogs/StartOverModal.js
+++ b/teachers_digital_platform/crtool/src/js/components/dialogs/StartOverModal.js
@@ -3,87 +3,90 @@ import React from "react";
 import C from "../../constants";
 
 export default class StartOverModal extends React.Component {
-    constructor(props) {
-        super(props);
+  constructor(props) {
+    super(props);
 
-        this.setWrapperRef = this.setWrapperRef.bind(this);
-        this.handleClickOutside = this.handleClickOutside.bind(this);
-    }
-
-    componentDidMount() {
-        document.addEventListener('mousedown', this.handleClickOutside);
-    }
-
-    componentWillUnmount() {
-        document.removeEventListener('mousedown', this.handleClickOutside);
-    }
-
-    /** Set the wrapper ref */
-    setWrapperRef(node) {
-        this.wrapperRef = node;
-    }
-
-    /** Alert if clicked on outside of element */
-    handleClickOutside(event) {
-        if (this.wrapperRef && !this.wrapperRef.contains(event.target)) {
-            let startOverModalDialog = document.getElementById('modal-start-over');
-            if (startOverModalDialog.classList.contains('o-modal__visible')) {
-                startOverModalDialog.classList.remove('o-modal__visible');
-            }
-        }
-    }
-
-    clearLocalStorage() {
-        this.props.clearLocalStorage();
-    }
-
-  openstartOverModalDialog() {
-      let startOverModalDialog = document.getElementById('modal-start-over');
-      startOverModalDialog.classList.add('o-modal__visible');
+    this.setWrapperRef = this.setWrapperRef.bind(this);
+    this.handleStartOverClickOutside = this.handleStartOverClickOutside.bind(this);
   }
 
-  closestartOverModalDialog() {
+  /* Click Outside setup */
+  componentDidMount() {
+    document.addEventListener('mousedown', this.handleStartOverClickOutside);
+  }
+
+  /* Click Outside setup */
+  componentWillUnmount() {
+    document.removeEventListener('mousedown', this.handleStartOverClickOutside);
+  }
+
+  /* Click Outside setup */
+  setWrapperRef(node) {
+    this.wrapperRef = node;
+  }
+
+  /* Click Outside setup */
+  handleStartOverClickOutside(event) {
+    if (this.wrapperRef && !this.wrapperRef.contains(event.target)) {
       let startOverModalDialog = document.getElementById('modal-start-over');
       startOverModalDialog.classList.remove('o-modal__visible');
+    }
   }
 
-    render() {
-        return (
-            <React.Fragment>
-                <button className="a-btn a-btn__link" onClick={(e) => {this.openstartOverModalDialog();}}>
-                    Start over with a new review
-                </button>
-                <div className="o-modal"
-                    id="modal-start-over"
-                    aria-hidden="true"
-                    role="alertdialog"
-                    aria-labelledby="modal-start-over_title"
-                    aria-describedby="modal-start-over_desc">
-                    <div className="o-modal_backdrop"></div>
-                    <div className="o-modal_container">
-                        <form className="o-modal_content">
-                            <span ref={this.setWrapperRef}>
-                                <div className="o-modal_body">
-                                    <button className="o-modal_close a-btn a-btn__link" onClick={(e) => {this.closestartOverModalDialog(); e.preventDefault();}}>
-                                        Close
-                                        &nbsp;<span className="a-icon a-icon__large"><svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 1000 1200" className="cf-icon-svg"><path d="M500 105.2c-276.1 0-500 223.9-500 500s223.9 500 500 500 500-223.9 500-500-223.9-500-500-500zm261.8 692.2c19.4 19.6 19.3 51.3-.3 70.7-19.5 19.3-50.9 19.3-70.4 0L499.6 676.6 308 868.1c-19.6 19.4-51.3 19.3-70.7-.3-19.3-19.5-19.3-50.9 0-70.4l191.6-191.5-191.6-191.6c-19.3-19.8-18.9-51.4.9-70.7 19.4-18.9 50.4-18.9 69.8 0l191.6 191.5 191.5-191.5c19.6-19.4 51.3-19.3 70.7.3 19.3 19.5 19.3 50.9 0 70.4L570.3 605.9l191.5 191.5z"/></svg></span>
-                                    </button>
-                                    <h1 id="modal-start-over_title">Starting over</h1>
-                                    <div id="modal-start-over_desc">
-                                        <p>Starting a new review will erase your answers for all dimensions. Are you sure you want to start a new review?</p>
-                                    </div>
-                                </div>
-                                <div className="o-modal_footer">
-                                    <div className="m-btn-group">
-                                        <button className="a-btn" onClick={(e) => {this.clearLocalStorage()}} formAction={C.START_PAGE_RELATIVE_URL} >Yes</button>
-                                        <button className="a-btn a-btn__link" onClick={(e) => {this.closestartOverModalDialog(); e.preventDefault();}}>No, return to current review</button>
-                                    </div>
-                                </div>
-                            </span>
-                        </form>
-                    </div>
+  /* Modal specific clearLocalStorage */
+  clearLocalStorage() {
+    this.props.clearLocalStorage();
+  }
+
+  /* Modal specific open dialog */
+  openstartOverModalDialog() {
+    let startOverModalDialog = document.getElementById('modal-start-over');
+    startOverModalDialog.classList.add('o-modal__visible');
+  }
+
+  /* Modal specific close dialog */
+  closestartOverModalDialog() {
+    let startOverModalDialog = document.getElementById('modal-start-over');
+    startOverModalDialog.classList.remove('o-modal__visible');
+  }
+
+  render() {
+    return (
+      <React.Fragment>
+        <button className="a-btn a-btn__link" onClick={(e) => {this.openstartOverModalDialog();}}>
+            Start over with a new review
+        </button>
+        <div className="o-modal"
+            id="modal-start-over"
+            aria-hidden="true"
+            role="alertdialog"
+            aria-labelledby="modal-start-over_title"
+            aria-describedby="modal-start-over_desc">
+          <div className="o-modal_backdrop"></div>
+          <div className="o-modal_container">
+            <form className="o-modal_content">
+              <span ref={this.setWrapperRef}>
+                <div className="o-modal_body">
+                  <button className="o-modal_close a-btn a-btn__link" onClick={(e) => {this.closestartOverModalDialog(); e.preventDefault();}}>
+                    Close
+                    &nbsp;<span className="a-icon a-icon__large"><svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 1000 1200" className="cf-icon-svg"><path d="M500 105.2c-276.1 0-500 223.9-500 500s223.9 500 500 500 500-223.9 500-500-223.9-500-500-500zm261.8 692.2c19.4 19.6 19.3 51.3-.3 70.7-19.5 19.3-50.9 19.3-70.4 0L499.6 676.6 308 868.1c-19.6 19.4-51.3 19.3-70.7-.3-19.3-19.5-19.3-50.9 0-70.4l191.6-191.5-191.6-191.6c-19.3-19.8-18.9-51.4.9-70.7 19.4-18.9 50.4-18.9 69.8 0l191.6 191.5 191.5-191.5c19.6-19.4 51.3-19.3 70.7.3 19.3 19.5 19.3 50.9 0 70.4L570.3 605.9l191.5 191.5z"/></svg></span>
+                  </button>
+                  <h1 id="modal-start-over_title">Starting over</h1>
+                  <div id="modal-start-over_desc">
+                    <p>Starting a new review will erase your answers for all dimensions. Are you sure you want to start a new review?</p>
+                  </div>
                 </div>
-            </React.Fragment>
-        );
-    }
+                <div className="o-modal_footer">
+                  <div className="m-btn-group">
+                    <button className="a-btn" onClick={(e) => {this.clearLocalStorage()}} formAction={C.START_PAGE_RELATIVE_URL} >Yes</button>
+                    <button className="a-btn a-btn__link" onClick={(e) => {this.closestartOverModalDialog(); e.preventDefault();}}>No, return to current review</button>
+                  </div>
+                </div>
+              </span>
+            </form>
+          </div>
+        </div>
+      </React.Fragment>
+    );
+  }
 }

--- a/teachers_digital_platform/crtool/src/js/components/dialogs/StartOverModal.js
+++ b/teachers_digital_platform/crtool/src/js/components/dialogs/StartOverModal.js
@@ -28,8 +28,8 @@ export default class StartOverModal extends React.Component {
     /* Click Outside setup */
     handleStartOverClickOutside(event) {
         if (this.wrapperRef && !this.wrapperRef.contains(event.target)) {
-        let startOverModalDialog = document.getElementById('modal-start-over');
-        startOverModalDialog.classList.remove('o-modal__visible');
+            let startOverModalDialog = document.getElementById('modal-start-over');
+            startOverModalDialog.classList.remove('o-modal__visible');
         }
     }
 
@@ -62,29 +62,29 @@ export default class StartOverModal extends React.Component {
                 role="alertdialog"
                 aria-labelledby="modal-start-over_title"
                 aria-describedby="modal-start-over_desc">
-            <div className="o-modal_backdrop"></div>
-            <div className="o-modal_container">
-                <form className="o-modal_content">
-                <span ref={this.setWrapperRef}>
-                    <div className="o-modal_body">
-                    <button className="o-modal_close a-btn a-btn__link" onClick={(e) => {this.closestartOverModalDialog(); e.preventDefault();}}>
-                        Close
-                        &nbsp;<span className="a-icon a-icon__large"><svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 1000 1200" className="cf-icon-svg"><path d="M500 105.2c-276.1 0-500 223.9-500 500s223.9 500 500 500 500-223.9 500-500-223.9-500-500-500zm261.8 692.2c19.4 19.6 19.3 51.3-.3 70.7-19.5 19.3-50.9 19.3-70.4 0L499.6 676.6 308 868.1c-19.6 19.4-51.3 19.3-70.7-.3-19.3-19.5-19.3-50.9 0-70.4l191.6-191.5-191.6-191.6c-19.3-19.8-18.9-51.4.9-70.7 19.4-18.9 50.4-18.9 69.8 0l191.6 191.5 191.5-191.5c19.6-19.4 51.3-19.3 70.7.3 19.3 19.5 19.3 50.9 0 70.4L570.3 605.9l191.5 191.5z"/></svg></span>
-                    </button>
-                    <h1 id="modal-start-over_title">Starting over</h1>
-                    <div id="modal-start-over_desc">
-                        <p>Starting a new review will erase your answers for all dimensions. Are you sure you want to start a new review?</p>
-                    </div>
-                    </div>
-                    <div className="o-modal_footer">
-                    <div className="m-btn-group">
-                        <button className="a-btn" onClick={(e) => {this.clearLocalStorage()}} formAction={C.START_PAGE_RELATIVE_URL} >Yes</button>
-                        <button className="a-btn a-btn__link" onClick={(e) => {this.closestartOverModalDialog(); e.preventDefault();}}>No, return to current review</button>
-                    </div>
-                    </div>
-                </span>
-                </form>
-            </div>
+                <div className="o-modal_backdrop"></div>
+                <div className="o-modal_container">
+                    <form className="o-modal_content">
+                    <span ref={this.setWrapperRef}>
+                        <div className="o-modal_body">
+                        <button className="o-modal_close a-btn a-btn__link" onClick={(e) => {this.closestartOverModalDialog(); e.preventDefault();}}>
+                            Close
+                            &nbsp;<span className="a-icon a-icon__large"><svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 1000 1200" className="cf-icon-svg"><path d="M500 105.2c-276.1 0-500 223.9-500 500s223.9 500 500 500 500-223.9 500-500-223.9-500-500-500zm261.8 692.2c19.4 19.6 19.3 51.3-.3 70.7-19.5 19.3-50.9 19.3-70.4 0L499.6 676.6 308 868.1c-19.6 19.4-51.3 19.3-70.7-.3-19.3-19.5-19.3-50.9 0-70.4l191.6-191.5-191.6-191.6c-19.3-19.8-18.9-51.4.9-70.7 19.4-18.9 50.4-18.9 69.8 0l191.6 191.5 191.5-191.5c19.6-19.4 51.3-19.3 70.7.3 19.3 19.5 19.3 50.9 0 70.4L570.3 605.9l191.5 191.5z"/></svg></span>
+                        </button>
+                        <h1 id="modal-start-over_title">Starting over</h1>
+                        <div id="modal-start-over_desc">
+                            <p>Starting a new review will erase your answers for all dimensions. Are you sure you want to start a new review?</p>
+                        </div>
+                        </div>
+                        <div className="o-modal_footer">
+                        <div className="m-btn-group">
+                            <button className="a-btn" onClick={(e) => {this.clearLocalStorage()}} formAction={C.START_PAGE_RELATIVE_URL} >Yes</button>
+                            <button className="a-btn a-btn__link" onClick={(e) => {this.closestartOverModalDialog(); e.preventDefault();}}>No, return to current review</button>
+                        </div>
+                        </div>
+                    </span>
+                    </form>
+                </div>
             </div>
         </React.Fragment>
         );

--- a/teachers_digital_platform/crtool/src/js/components/dialogs/StartOverModal.js
+++ b/teachers_digital_platform/crtool/src/js/components/dialogs/StartOverModal.js
@@ -64,25 +64,23 @@ export default class StartOverModal extends React.Component {
                 aria-describedby="modal-start-over_desc">
                 <div className="o-modal_backdrop"></div>
                 <div className="o-modal_container">
-                    <form className="o-modal_content">
-                    <span ref={this.setWrapperRef}>
+                    <form className="o-modal_content" ref={this.setWrapperRef}>
                         <div className="o-modal_body">
-                        <button className="o-modal_close a-btn a-btn__link" onClick={(e) => {this.closestartOverModalDialog(); e.preventDefault();}}>
-                            Close
-                            &nbsp;<span className="a-icon a-icon__large"><svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 1000 1200" className="cf-icon-svg"><path d="M500 105.2c-276.1 0-500 223.9-500 500s223.9 500 500 500 500-223.9 500-500-223.9-500-500-500zm261.8 692.2c19.4 19.6 19.3 51.3-.3 70.7-19.5 19.3-50.9 19.3-70.4 0L499.6 676.6 308 868.1c-19.6 19.4-51.3 19.3-70.7-.3-19.3-19.5-19.3-50.9 0-70.4l191.6-191.5-191.6-191.6c-19.3-19.8-18.9-51.4.9-70.7 19.4-18.9 50.4-18.9 69.8 0l191.6 191.5 191.5-191.5c19.6-19.4 51.3-19.3 70.7.3 19.3 19.5 19.3 50.9 0 70.4L570.3 605.9l191.5 191.5z"/></svg></span>
-                        </button>
-                        <h1 id="modal-start-over_title">Starting over</h1>
-                        <div id="modal-start-over_desc">
-                            <p>Starting a new review will erase your answers for all dimensions. Are you sure you want to start a new review?</p>
-                        </div>
+                            <button className="o-modal_close a-btn a-btn__link" onClick={(e) => {this.closestartOverModalDialog(); e.preventDefault();}}>
+                                Close
+                                &nbsp;<span className="a-icon a-icon__large"><svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 1000 1200" className="cf-icon-svg"><path d="M500 105.2c-276.1 0-500 223.9-500 500s223.9 500 500 500 500-223.9 500-500-223.9-500-500-500zm261.8 692.2c19.4 19.6 19.3 51.3-.3 70.7-19.5 19.3-50.9 19.3-70.4 0L499.6 676.6 308 868.1c-19.6 19.4-51.3 19.3-70.7-.3-19.3-19.5-19.3-50.9 0-70.4l191.6-191.5-191.6-191.6c-19.3-19.8-18.9-51.4.9-70.7 19.4-18.9 50.4-18.9 69.8 0l191.6 191.5 191.5-191.5c19.6-19.4 51.3-19.3 70.7.3 19.3 19.5 19.3 50.9 0 70.4L570.3 605.9l191.5 191.5z"/></svg></span>
+                            </button>
+                            <h1 id="modal-start-over_title">Starting over</h1>
+                            <div id="modal-start-over_desc">
+                                <p>Starting a new review will erase your answers for all dimensions. Are you sure you want to start a new review?</p>
+                            </div>
                         </div>
                         <div className="o-modal_footer">
-                        <div className="m-btn-group">
-                            <button className="a-btn" onClick={(e) => {this.clearLocalStorage()}} formAction={C.START_PAGE_RELATIVE_URL} >Yes</button>
-                            <button className="a-btn a-btn__link" onClick={(e) => {this.closestartOverModalDialog(); e.preventDefault();}}>No, return to current review</button>
+                            <div className="m-btn-group">
+                                <button className="a-btn" onClick={(e) => {this.clearLocalStorage()}} formAction={C.START_PAGE_RELATIVE_URL} >Yes</button>
+                                <button className="a-btn a-btn__link" onClick={(e) => {this.closestartOverModalDialog(); e.preventDefault();}}>No, return to current review</button>
+                            </div>
                         </div>
-                        </div>
-                    </span>
                     </form>
                 </div>
             </div>

--- a/teachers_digital_platform/jinja2/teachers_digital_platform/crt-start.html
+++ b/teachers_digital_platform/jinja2/teachers_digital_platform/crt-start.html
@@ -401,7 +401,7 @@
             saveWorkModalWindow.classList.remove('o-modal__visible');
             document.removeEventListener('click', saveWorkOutsideClickListener);
         }
-        
+
         /*
          * Method to close New Review daialog if click outside
          */
@@ -410,7 +410,7 @@
             if (!openingNewReviewModal && !startOverModal.contains(event.target)) {
               closeNewReviewModalWindow();
             }
-            
+
             // Since it wants to close on open we need a use this flag on first trigger
             if (openingNewReviewModal) {
               openingNewReviewModal = false;
@@ -425,7 +425,7 @@
             if (!openingSaveWorkModal && !startOverModal.contains(event.target)) {
               closeSaveWorkModalWindow();
             }
-            
+
             // Since it wants to close on open we need a use this flag on first trigger
             if (openingSaveWorkModal) {
               openingSaveWorkModal = false;

--- a/teachers_digital_platform/jinja2/teachers_digital_platform/crt-start.html
+++ b/teachers_digital_platform/jinja2/teachers_digital_platform/crt-start.html
@@ -254,25 +254,25 @@
         aria-describedby="modal-save-work_desc">
         <div class="o-modal_backdrop"></div>
         <div class="o-modal_container">
-        <form class="o-modal_content">
-            <span id="modal-save-work-click-outside">
-            <div class="o-modal_body">
-                <button class="o-modal_close a-btn a-btn__link"  onclick="closeSaveWorkModalWindow(); return false;">
-                    Close
-                    &nbsp;<span class="a-icon a-icon__large"><svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 1000 1200" class="cf-icon-svg"><path d="M500 105.2c-276.1 0-500 223.9-500 500s223.9 500 500 500 500-223.9 500-500-223.9-500-500-500zm261.8 692.2c19.4 19.6 19.3 51.3-.3 70.7-19.5 19.3-50.9 19.3-70.4 0L499.6 676.6 308 868.1c-19.6 19.4-51.3 19.3-70.7-.3-19.3-19.5-19.3-50.9 0-70.4l191.6-191.5-191.6-191.6c-19.3-19.8-18.9-51.4.9-70.7 19.4-18.9 50.4-18.9 69.8 0l191.6 191.5 191.5-191.5c19.6-19.4 51.3-19.3 70.7.3 19.3 19.5 19.3 50.9 0 70.4L570.3 605.9l191.5 191.5z"/></svg></span>
-                </button>
-                <h1 id="modal-save-work_title">Saving your work</h1>
-                <div id="modal-save-work_desc">
-                    <p>This tool uses cookies to <strong>temporarily</strong> save your work. To see answers you’ve already completed, you need to use the same computer and browser, and don’t clear your cookies.</p>
-                    <p>To save a permanent copy of your work, please print the summary or save it as a PDF for every dimension as you complete it. You can also print or save a summary of the entire review. Learn how to <a href="https://www.consumerfinance.gov/consumer-tools/save-as-pdf-instructions/" target="_blank" rel="noopener noreferrer">save the summary as a PDF</a>.</p>
-                    <p>You can only work on a single curriculum at a time</p>
+            <form class="o-modal_content">
+                <span id="modal-save-work-click-outside">
+                <div class="o-modal_body">
+                    <button class="o-modal_close a-btn a-btn__link"  onclick="closeSaveWorkModalWindow(); return false;">
+                        Close
+                        &nbsp;<span class="a-icon a-icon__large"><svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 1000 1200" class="cf-icon-svg"><path d="M500 105.2c-276.1 0-500 223.9-500 500s223.9 500 500 500 500-223.9 500-500-223.9-500-500-500zm261.8 692.2c19.4 19.6 19.3 51.3-.3 70.7-19.5 19.3-50.9 19.3-70.4 0L499.6 676.6 308 868.1c-19.6 19.4-51.3 19.3-70.7-.3-19.3-19.5-19.3-50.9 0-70.4l191.6-191.5-191.6-191.6c-19.3-19.8-18.9-51.4.9-70.7 19.4-18.9 50.4-18.9 69.8 0l191.6 191.5 191.5-191.5c19.6-19.4 51.3-19.3 70.7.3 19.3 19.5 19.3 50.9 0 70.4L570.3 605.9l191.5 191.5z"/></svg></span>
+                    </button>
+                    <h1 id="modal-save-work_title">Saving your work</h1>
+                    <div id="modal-save-work_desc">
+                        <p>This tool uses cookies to <strong>temporarily</strong> save your work. To see answers you’ve already completed, you need to use the same computer and browser, and don’t clear your cookies.</p>
+                        <p>To save a permanent copy of your work, please print the summary or save it as a PDF for every dimension as you complete it. You can also print or save a summary of the entire review. Learn how to <a href="https://www.consumerfinance.gov/consumer-tools/save-as-pdf-instructions/" target="_blank" rel="noopener noreferrer">save the summary as a PDF</a>.</p>
+                        <p>You can only work on a single curriculum at a time</p>
+                    </div>
                 </div>
-            </div>
-            <div class="o-modal_footer">
-                <button class="a-btn" onclick="closeSaveWorkModalWindow(); return false;">Close</button>
-            </div>
-            </span>
-        </form>
+                <div class="o-modal_footer">
+                    <button class="a-btn" onclick="closeSaveWorkModalWindow(); return false;">Close</button>
+                </div>
+                </span>
+            </form>
         </div>
     </div>
 

--- a/teachers_digital_platform/jinja2/teachers_digital_platform/crt-start.html
+++ b/teachers_digital_platform/jinja2/teachers_digital_platform/crt-start.html
@@ -224,7 +224,6 @@
         <div class="o-modal_backdrop"></div>
         <div class="o-modal_container">
             <form class="o-modal_content">
-              <span id="modal-start-over-click-outside">
                 <div class="o-modal_body">
                     <button class="o-modal_close a-btn a-btn__link" onclick="closeNewReviewModalWindow();return false;">
                         Close
@@ -241,7 +240,6 @@
                         <button class="a-btn a-btn__link" onclick="closeNewReviewModalWindow(); return false;">No, return to current review</button>
                     </div>
                 </div>
-              </span>
             </form>
         </div>
     </div>
@@ -255,7 +253,6 @@
         <div class="o-modal_backdrop"></div>
         <div class="o-modal_container">
             <form class="o-modal_content">
-                <span id="modal-save-work-click-outside">
                 <div class="o-modal_body">
                     <button class="o-modal_close a-btn a-btn__link"  onclick="closeSaveWorkModalWindow(); return false;">
                         Close
@@ -271,7 +268,6 @@
                 <div class="o-modal_footer">
                     <button class="a-btn" onclick="closeSaveWorkModalWindow(); return false;">Close</button>
                 </div>
-                </span>
             </form>
         </div>
     </div>
@@ -406,7 +402,7 @@
          * Method to close New Review daialog if click outside
          */
         function newReviewOutsideClickListener(event) {
-            const startOverModal = document.getElementById("modal-start-over-click-outside");
+            const startOverModal = document.querySelector("#modal-start-over .o-modal_content");
             if (!openingNewReviewModal && !startOverModal.contains(event.target)) {
               closeNewReviewModalWindow();
             }
@@ -421,7 +417,7 @@
          * Method to close Save Work daialog if click outside
          */
         function saveWorkOutsideClickListener(event) {
-            const startOverModal = document.getElementById("modal-save-work-click-outside");
+            const startOverModal = document.querySelector("#modal-save-work .o-modal_content");
             if (!openingSaveWorkModal && !startOverModal.contains(event.target)) {
               closeSaveWorkModalWindow();
             }

--- a/teachers_digital_platform/jinja2/teachers_digital_platform/crt-start.html
+++ b/teachers_digital_platform/jinja2/teachers_digital_platform/crt-start.html
@@ -168,7 +168,7 @@
                 <button id="tdp-crt-begin-review-btn" class="a-btn" type="submit" onclick="beginReviewButtonClick();" formaction="../../tdp/crt-survey">
                     Start review
                 </button>
-                <button class="a-btn a-btn__link" onclick="openNewReviewModalWindow();return false;">Start over with a new review</button>
+                <button id="new-review-modal-dialog-btn" class="a-btn a-btn__link" onclick="openNewReviewModalWindow();return false;">Start over with a new review</button>
             </div>
         </form>
     </div>
@@ -224,6 +224,7 @@
         <div class="o-modal_backdrop"></div>
         <div class="o-modal_container">
             <form class="o-modal_content">
+              <span id="modal-start-over-click-outside">
                 <div class="o-modal_body">
                     <button class="o-modal_close a-btn a-btn__link" onclick="closeNewReviewModalWindow();return false;">
                         Close
@@ -240,6 +241,7 @@
                         <button class="a-btn a-btn__link" onclick="closeNewReviewModalWindow(); return false;">No, return to current review</button>
                     </div>
                 </div>
+              </span>
             </form>
         </div>
     </div>
@@ -253,6 +255,7 @@
         <div class="o-modal_backdrop"></div>
         <div class="o-modal_container">
         <form class="o-modal_content">
+            <span id="modal-save-work-click-outside">
             <div class="o-modal_body">
                 <button class="o-modal_close a-btn a-btn__link"  onclick="closeSaveWorkModalWindow(); return false;">
                     Close
@@ -268,6 +271,7 @@
             <div class="o-modal_footer">
                 <button class="a-btn" onclick="closeSaveWorkModalWindow(); return false;">Close</button>
             </div>
+            </span>
         </form>
         </div>
     </div>
@@ -365,9 +369,11 @@
         /*
          * Open New Review Warning Modal Dialog
          */
+        var openingNewReviewModal = false;
         function openNewReviewModalWindow() {
+            openingNewReviewModal = true;
             newReviewModalWindow.classList.add('o-modal__visible');
-            return false;
+            document.addEventListener('click', newReviewOutsideClickListener);
         }
 
         /*
@@ -375,15 +381,17 @@
          */
         function closeNewReviewModalWindow() {
             newReviewModalWindow.classList.remove('o-modal__visible');
-            return false;
+            document.removeEventListener('click', newReviewOutsideClickListener);
         }
 
         /*
          * Open Save Work Warning Modal Dialog
          */
-         function openSaveWorkModalWindow() {
+        var openingSaveWorkModal = false;
+        function openSaveWorkModalWindow() {
+            openingSaveWorkModal = true;
             saveWorkModalWindow.classList.add('o-modal__visible');
-            return false;
+            document.addEventListener('click', saveWorkOutsideClickListener);
         }
 
         /*
@@ -391,7 +399,31 @@
          */
         function closeSaveWorkModalWindow() {
             saveWorkModalWindow.classList.remove('o-modal__visible');
-            return false;
+            document.removeEventListener('click', saveWorkOutsideClickListener);
+        }
+        
+        function newReviewOutsideClickListener(event) {
+            const startOverModal = document.getElementById("modal-start-over-click-outside");
+            if (!openingNewReviewModal && !startOverModal.contains(event.target)) {
+              closeNewReviewModalWindow();
+            }
+            
+            // Since it wants to close on open we need a use this flag on first trigger
+            if (openingNewReviewModal) {
+              openingNewReviewModal = false;
+            }
+        }
+
+        function saveWorkOutsideClickListener(event) {
+            const startOverModal = document.getElementById("modal-save-work-click-outside");
+            if (!openingSaveWorkModal && !startOverModal.contains(event.target)) {
+              closeSaveWorkModalWindow();
+            }
+            
+            // Since it wants to close on open we need a use this flag on first trigger
+            if (openingSaveWorkModal) {
+              openingSaveWorkModal = false;
+            }
         }
     </script>
 {%- endblock javascript %}

--- a/teachers_digital_platform/jinja2/teachers_digital_platform/crt-start.html
+++ b/teachers_digital_platform/jinja2/teachers_digital_platform/crt-start.html
@@ -402,6 +402,9 @@
             document.removeEventListener('click', saveWorkOutsideClickListener);
         }
         
+        /*
+         * Method to close New Review daialog if click outside
+         */
         function newReviewOutsideClickListener(event) {
             const startOverModal = document.getElementById("modal-start-over-click-outside");
             if (!openingNewReviewModal && !startOverModal.contains(event.target)) {
@@ -414,6 +417,9 @@
             }
         }
 
+        /*
+         * Method to close Save Work daialog if click outside
+         */
         function saveWorkOutsideClickListener(event) {
             const startOverModal = document.getElementById("modal-save-work-click-outside");
             if (!openingSaveWorkModal && !startOverModal.contains(event.target)) {


### PR DESCRIPTION
The two modal dialogs we have were interfering with each other because they were accidentally using each others functions.

## Additions

- Duplicated the JavaScript functions that handles the click outside for the Modal Dialogs
- This was performed twice
  - On the Start page in pure JavaScript
  - On the Survey pages (in the dialogs/ folder)

## Testing

- Load the start page and verify
  - [ ] You can show both of the modal dialogs and close using the normal close buttons
  - [ ] You can close them by clicking outside of them (all 4 sides)
- Load any of the survey pages
  - [ ] You can show both of the modal dialogs and close using the normal close buttons
  - [ ] You can close them by clicking outside of them (all 4 sides)
  

## Review

- @dcmouyard 

[Preview this PR without the whitespace changes](?w=0)


## Checklist

* [ ] Changes are limited to a single goal (no scope creep)
* [ ] Code can be automatically merged (no conflicts)
* [ ] Code follows the standards laid out in the [front end playbook](https://github.com/cfpb/front-end)
* [ ] Passes all existing automated tests
* [ ] New functions include new tests
* [ ] New functions are documented (with a description, list of inputs, and expected output)
* [ ] Placeholder code is flagged
* [ ] Visually tested in supported browsers and devices
* [ ] Project documentation has been updated (including the "Unreleased" section of the CHANGELOG)
