### PR TITLE
Fix summary page content and styles

### DIFF
--- a/teachers_digital_platform/crtool/src/js/components/pages/QualitySummaryPage.js
+++ b/teachers_digital_platform/crtool/src/js/components/pages/QualitySummaryPage.js
@@ -54,7 +54,10 @@ export default class QualitySummaryPage extends React.Component {
                                 u-mb45
                                 u-mt30" />
                 <div className="l-survey-top">
-                    <button class="a-btn a-btn__link">View or edit responses</button>
+                    <button class="a-btn a-btn__link">
+                        <span className="a-icon a-icon__large"><svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 833.4 1200" class="cf-icon-svg"><path d="M233 203.1c-27.2-27.2-71.8-27.2-99 0L20.4 316.7c-27.2 27.2-27.2 71.8 0 99l89.7 89.7 212.7-212.7-89.8-89.6zM832.6 992.7l-48.6-216c-3.4-15.3-14.9-36.5-26-48.6l-1.8-1.8-121.8-121.9-110.6-110.6-165.7-165.7-54.8 54.8 400 400 21.4-21.4c5.3 6.4 11.9 18.9 13.5 25.6l21.4 95.2-60 60-95.2-21.4c-6.7-1.5-19.2-8.2-25.6-13.5l89.2-89.2-400-400-122.6 122.6 165.7 165.7 110.6 110.6 121.8 121.8 1.8 1.8c12.1 11.1 33.3 22.6 48.6 26l215.9 48.6c2.2.5 4.3.7 6.2.7 12.6.1 19.8-9.4 16.6-23.3z"/></svg></span>&nbsp;
+                        View or edit responses
+                    </button>
                 </div>
                 <h3 className="h2">Criterion 1: Accessibility</h3>
                 <p className="u-mb30">Curriculum materials are physically accessible to teachers and students in a typical school setting.</p>

--- a/teachers_digital_platform/crtool/src/js/components/pages/QualitySummaryPage.js
+++ b/teachers_digital_platform/crtool/src/js/components/pages/QualitySummaryPage.js
@@ -73,7 +73,7 @@ export default class QualitySummaryPage extends React.Component {
                                         <circle cx="11" cy="11" r="10" className="m-form-field_radio-icon-stroke"></circle>
                                         <circle cx="11" cy="11" r="7" className="m-form-field_radio-icon-fill"></circle>
                                     </svg>
-                                    <div>
+                                    <div className="m-form-field_radio-text is-active">
                                         <div><strong>Exceeds</strong></div>
                                         All essential components scored “yes”<br />
                                         At least one beneficial component scored “yes”
@@ -90,7 +90,7 @@ export default class QualitySummaryPage extends React.Component {
                                         <circle cx="11" cy="11" r="10" className="m-form-field_radio-icon-stroke"></circle>
                                         <circle cx="11" cy="11" r="7" className="m-form-field_radio-icon-fill"></circle>
                                     </svg>
-                                    <div>
+                                    <div className="m-form-field_radio-text">
                                         <div><strong>Meets</strong></div>
                                         All essential components scored “yes”<br />
                                         None of the beneficial components scored “yes”
@@ -107,7 +107,7 @@ export default class QualitySummaryPage extends React.Component {
                                         <circle cx="11" cy="11" r="10" className="m-form-field_radio-icon-stroke"></circle>
                                         <circle cx="11" cy="11" r="7" className="m-form-field_radio-icon-fill"></circle>
                                     </svg>
-                                    <div>
+                                    <div className="m-form-field_radio-text">
                                         <div><strong>Does not meet</strong></div>
                                         One or more essential components scored “no”
                                     </div>
@@ -161,7 +161,7 @@ export default class QualitySummaryPage extends React.Component {
                                         <circle cx="11" cy="11" r="10" className="m-form-field_radio-icon-stroke"></circle>
                                         <circle cx="11" cy="11" r="7" className="m-form-field_radio-icon-fill"></circle>
                                     </svg>
-                                    <div>
+                                    <div className="m-form-field_radio-text is-active">
                                         <div><strong>Meets</strong></div>
                                         All essential components scored “yes”
                                     </div>
@@ -177,7 +177,7 @@ export default class QualitySummaryPage extends React.Component {
                                         <circle cx="11" cy="11" r="10" className="m-form-field_radio-icon-stroke"></circle>
                                         <circle cx="11" cy="11" r="7" className="m-form-field_radio-icon-fill"></circle>
                                     </svg>
-                                    <div>
+                                    <div className="m-form-field_radio-text">
                                         <div><strong>Does not meet</strong></div>
                                         One or more essential components scored “no”
                                     </div>
@@ -226,7 +226,7 @@ export default class QualitySummaryPage extends React.Component {
                                         <circle cx="11" cy="11" r="10" className="m-form-field_radio-icon-stroke"></circle>
                                         <circle cx="11" cy="11" r="7" className="m-form-field_radio-icon-fill"></circle>
                                     </svg>
-                                    <div>
+                                    <div className="m-form-field_radio-text is-active">
                                         <div><strong>Exceeds</strong></div>
                                         All essential components scored “yes”<br />
                                         At least one beneficial component scored “yes”
@@ -243,7 +243,7 @@ export default class QualitySummaryPage extends React.Component {
                                         <circle cx="11" cy="11" r="10" className="m-form-field_radio-icon-stroke"></circle>
                                         <circle cx="11" cy="11" r="7" className="m-form-field_radio-icon-fill"></circle>
                                     </svg>
-                                    <div>
+                                    <div className="m-form-field_radio-text">
                                         <div><strong>Meets</strong></div>
                                         All essential components scored “yes”<br />
                                         None of the beneficial components scored “yes”
@@ -260,7 +260,7 @@ export default class QualitySummaryPage extends React.Component {
                                         <circle cx="11" cy="11" r="10" className="m-form-field_radio-icon-stroke"></circle>
                                         <circle cx="11" cy="11" r="7" className="m-form-field_radio-icon-fill"></circle>
                                     </svg>
-                                    <div>
+                                    <div className="m-form-field_radio-text">
                                         <div><strong>Does not meet</strong></div>
                                         One or more essential components scored “no”
                                     </div>
@@ -314,7 +314,7 @@ export default class QualitySummaryPage extends React.Component {
                                         <circle cx="11" cy="11" r="10" className="m-form-field_radio-icon-stroke"></circle>
                                         <circle cx="11" cy="11" r="7" className="m-form-field_radio-icon-fill"></circle>
                                     </svg>
-                                    <div>
+                                    <div className="m-form-field_radio-text is-active">
                                         <div><strong>Meets</strong></div>
                                         All essential components scored “yes”
                                     </div>
@@ -330,7 +330,7 @@ export default class QualitySummaryPage extends React.Component {
                                         <circle cx="11" cy="11" r="10" className="m-form-field_radio-icon-stroke"></circle>
                                         <circle cx="11" cy="11" r="7" className="m-form-field_radio-icon-fill"></circle>
                                     </svg>
-                                    <div>
+                                    <div className="m-form-field_radio-text">
                                         <div><strong>Does not meet</strong></div>
                                         One or more essential components scored “no”
                                     </div>
@@ -365,13 +365,6 @@ export default class QualitySummaryPage extends React.Component {
                 <hr className="hr
                                 u-mb45
                                 u-mt30" />
-
-
-
-
-
-
-
                 <div className="o-well u-mb30">
                     <h2>
                         <span className="a-icon a-icon__large"><svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 1000 1200" class="cf-icon-svg"><path d="M500 105.2c-276.1 0-500 223.9-500 500s223.9 500 500 500 500-223.9 500-500-223.9-500-500-500zm329.9 449.4l-68.7 63.5-69.3 64.1 27.5 138.5 9.1 45.9c10.1 50.9-18.7 71.9-64 46.5l-164.1-91.8-164.1 91.8c-45.3 25.4-74.1 4.4-64-46.5l9.1-45.9 9.1-45.9 18.4-92.6-69.3-64.1-34.4-31.8-34.4-31.8c-38.1-35.3-27.1-69.1 24.4-75.2l93-11 93.8-11.1L441.3 329l19.6-42.5c21.8-47.2 57.4-47.2 79.1 0l19.6 42.5 59.2 128.2 93.8 11.1 93 11c51.4 6.2 62.4 40.1 24.3 75.3z"/></svg></span>
@@ -390,7 +383,7 @@ export default class QualitySummaryPage extends React.Component {
                                         <circle cx="11" cy="11" r="10" className="m-form-field_radio-icon-stroke"></circle>
                                         <circle cx="11" cy="11" r="7" className="m-form-field_radio-icon-fill"></circle>
                                     </svg>
-                                    <div>
+                                    <div className="m-form-field_radio-text">
                                         <div><strong>Strong utility</strong></div>
                                         All 4 criteria were met, and at least one was exceeded
                                     </div>
@@ -406,7 +399,7 @@ export default class QualitySummaryPage extends React.Component {
                                         <circle cx="11" cy="11" r="10" className="m-form-field_radio-icon-stroke"></circle>
                                         <circle cx="11" cy="11" r="7" className="m-form-field_radio-icon-fill"></circle>
                                     </svg>
-                                    <div>
+                                    <div className="m-form-field_radio-text is-active">
                                         <div><strong>Moderate utility</strong></div>
                                         All 4 criteria were met
                                     </div>
@@ -422,7 +415,7 @@ export default class QualitySummaryPage extends React.Component {
                                         <circle cx="11" cy="11" r="10" className="m-form-field_radio-icon-stroke"></circle>
                                         <circle cx="11" cy="11" r="7" className="m-form-field_radio-icon-fill"></circle>
                                     </svg>
-                                    <div>
+                                    <div className="m-form-field_radio-text">
                                         <div><strong>Limited utility</strong></div>
                                         At least one of the criteria was not met
                                     </div>

--- a/teachers_digital_platform/crtool/src/js/components/pages/QualitySummaryPage.js
+++ b/teachers_digital_platform/crtool/src/js/components/pages/QualitySummaryPage.js
@@ -56,7 +56,7 @@ export default class QualitySummaryPage extends React.Component {
                 <div className="l-survey-top">
                     <button class="a-btn a-btn__link">View or edit responses</button>
                 </div>
-                <h3>Criterion 1: Accessibility</h3>
+                <h3 className="h2">Criterion 1: Accessibility</h3>
                 <p className="u-mb30">Curriculum materials are physically accessible to teachers and students in a typical school setting.</p>
                 <div className="m-curriculum-status">
                     <ul className="m-list__unstyled
@@ -144,7 +144,7 @@ export default class QualitySummaryPage extends React.Component {
                 <hr className="hr
                                 u-mb45
                                 u-mt30" />
-                <h3>Criterion 2: Accuracy and timeliness</h3>
+                <h3 className="h2">Criterion 2: Accuracy and timeliness</h3>
                 <p className="u-mb30">Curriculum materials are current and free of errors.</p>
                 <div className="m-curriculum-status">
                     <ul className="m-list__unstyled
@@ -209,7 +209,7 @@ export default class QualitySummaryPage extends React.Component {
                 <hr className="hr
                                 u-mb45
                                 u-mt30" />
-                <h3>Criterion 3: Objectivity</h3>
+                <h3 className="h2">Criterion 3: Objectivity</h3>
                 <p className="u-mb30">Curriculum materials are objective.</p>
                 <div className="m-curriculum-status">
                     <ul className="m-list__unstyled
@@ -297,7 +297,7 @@ export default class QualitySummaryPage extends React.Component {
                 <hr className="hr
                                 u-mb45
                                 u-mt30" />
-                <h3>Criterion 4: Visual appearance </h3>
+                <h3 className="h2">Criterion 4: Visual appearance </h3>
                 <p className="u-mb30">The visual appearance of the student materials is conducive to learning.</p>
                 <div className="m-curriculum-status">
                     <ul className="m-list__unstyled

--- a/teachers_digital_platform/css/cf-enhancements/molecules/form-fields.less
+++ b/teachers_digital_platform/css/cf-enhancements/molecules/form-fields.less
@@ -51,3 +51,11 @@
     fill: none;
     stroke: none;
 }
+
+.m-form-field_radio-text  {
+    color: @gray;
+
+    &.is-active {
+        color: @black;
+    }
+}

--- a/teachers_digital_platform/css/layout/survey-top.less
+++ b/teachers_digital_platform/css/layout/survey-top.less
@@ -7,5 +7,6 @@
 
     .respond-to-min(@bp-float, {
         float: right;
+        margin-left: unit( 15px / @base-font-size-px, em );
     });
 }


### PR DESCRIPTION
Fix summary page content and styles

## Additions

- Icon for edit links
- Active/inactive state for radio text

## Changes

- Left margin on `l-survey-top`
- Criterion headings now look like h2

## Review

- @rrstoll 

[Preview this PR without the whitespace changes](?w=0)
