### PR TITLE
Implemented conditional for inline styling with json content

### DIFF
--- a/teachers_digital_platform/crtool/src/js/components/CustomerReviewToolComponent.js
+++ b/teachers_digital_platform/crtool/src/js/components/CustomerReviewToolComponent.js
@@ -115,8 +115,6 @@ export default class CustomerReviewToolComponent extends React.Component {
      * Verify all the criteria for a whole distinctive has been met
      */
     isDistinctiveComplete(alteredCriterionObjects, changedDistinctive) {
-
-        console.log("changedDistinctive: " + changedDistinctive);
         for (var statusKey in this.state.criterionCompletionStatuses) {
             if (this.isCriterionInDistinctive(statusKey, changedDistinctive) &&
                 this.state.criterionCompletionStatuses[statusKey] !== C.ICON_CHECK_ROUND) {

--- a/teachers_digital_platform/crtool/src/js/components/criterion/CriterionAnswerArea.js
+++ b/teachers_digital_platform/crtool/src/js/components/criterion/CriterionAnswerArea.js
@@ -12,11 +12,19 @@ export default class CriterionAnswerArea extends React.Component {
         return null;
     }
 
+    renderComponentText() {
+        if (this.props.componentData.hasInlineHtml) {
+            return (<span dangerouslySetInnerHTML={{__html: this.props.componentData.componentText}} />);
+        } else {
+            return (this.props.componentData.componentText);
+        }
+    }
+
     render() {
         return (
             <div class="o-survey_component">
                 <div class="o-survey_question">
-                    <p><span dangerouslySetInnerHTML={{__html: this.props.componentData.componentText}} /></p>
+                    <p>{this.renderComponentText()}</p>
                     {this.showBeneficialText()}
                 </div>
                 <div class="o-survey_answer">

--- a/teachers_digital_platform/crtool/src/js/content_data/utilityContent.js
+++ b/teachers_digital_platform/crtool/src/js/content_data/utilityContent.js
@@ -12,18 +12,21 @@ export const UtilityContent = {
                         showNaButton:false,
                         showBenifitialText:false,
                         criterionRefId:"utility-crt-question-1.1.1",
+                        hasInlineHtml:true,
                         componentText:"Are there multiple activities for <strong>conceptual learning</strong> that describe underlying ideas in writing and verbally? (e.g., being an informed consumer)",
                     },
                     {
                         showNaButton:false,
                         showBenifitialText:false,
                         criterionRefId:"utility-crt-question-1.1.2",
+                        hasInlineHtml:true,
                         componentText:"Are there multiple activities for <strong>procedural learning</strong>, such as memorizing content or practicing processes accurately and quickly? (e.g., knowing how to calculate interest or define a student loan)",
                     },
                     {
                         showNaButton:false,
                         showBenifitialText:false,
                         criterionRefId:"utility-crt-question-1.1.3",
+                        hasInlineHtml:true,
                         componentText:"Are there multiple <strong>application</strong> activities that allow students to independently use knowledge and skills in simulated or real situations, choosing a strategy to solve problems with persistence? (e.g., making a budget)",
                     },
                 ]


### PR DESCRIPTION
Implemented a CONDITIONAL on printing html styling inline with print criterion content

## Additions

- Added flag "hasInlineHtml" to the json content in order to use the 'dangerouslySetInnerHTML()' method when rendering the content

-  There is an example of this in the ".../content_data/utilityContent.js" file.  See the screen shot

## Review

- @dcmouyard @rrstoll 

[Preview this PR without the whitespace changes](?w=0)

## Screenshots
![screen shot 2018-04-19 at 10 06 25 am](https://user-images.githubusercontent.com/2790037/38996485-4c301a46-43b9-11e8-8c28-20ace305e310.png)

