### PR TITLE
Implemented Quality addition text values for print pages

### DIFF
--- a/teachers_digital_platform/crtool/src/js/components/criterion/CriterionAnswerArea.js
+++ b/teachers_digital_platform/crtool/src/js/components/criterion/CriterionAnswerArea.js
@@ -20,11 +20,29 @@ export default class CriterionAnswerArea extends React.Component {
         }
     }
 
+    renderTextFieldValue() {
+        if (this.props.componentData.criterionTextRefId !== undefined &&
+            this.props.criterionAnswers[this.props.componentData.criterionTextRefId] !== undefined) {
+            return (
+                <React.Fragment>
+                    <p>
+                        <strong>
+                            {this.props.criterionAnswers[this.props.componentData.criterionTextRefId]}
+                        </strong>
+                    </p>
+                </React.Fragment>
+            );
+        } else {
+            return null;
+        }
+    }
+
     render() {
         return (
             <div class="o-survey_component">
                 <div class="o-survey_question">
                     {this.renderComponentText()}
+                    {this.renderTextFieldValue()}
                     {this.showBeneficialText()}
                 </div>
                 <div class="o-survey_answer">

--- a/teachers_digital_platform/crtool/src/js/content_data/qualityContent.js
+++ b/teachers_digital_platform/crtool/src/js/content_data/qualityContent.js
@@ -14,6 +14,7 @@ export const QualityContent = {
                             showBeneficialText: false,
                             criterionRefId: "quality-crt-question-1.1.1",
                             hasInlineHtml: true,
+                            criterionTextRefId: "quality-crt-text-optional-1.1.1",
                             componentText: "<p>If there are <strong>paper-based materials:</strong></p><p>Are paper-based materials available at no cost or for a clearly stated price?</p>",
                         },
                         {
@@ -21,6 +22,7 @@ export const QualityContent = {
                             showBeneficialText: false,
                             criterionRefId: "quality-crt-question-1.1.2",
                             hasInlineHtml: true,
+                            criterionTextRefId: "quality-crt-text-optional-1.1.2",
                             componentText: "<p>If there are <strong>links</strong>:</p><p>Do the links take the user to the appropriate, live website?</p>",
                         },
                         {
@@ -28,6 +30,7 @@ export const QualityContent = {
                             showBeneficialText: true,
                             criterionRefId: "quality-crt-question-1.1.3",
                             hasInlineHtml: true,
+                            criterionTextRefId: "quality-crt-text-optional-1.1.3",
                             componentText: "<p>If there are <strong>web-based materials:</strong></p><p>Can web-based material be accessed without purchasing specialized software?</p>",
                         },
                     ]
@@ -61,6 +64,7 @@ export const QualityContent = {
                             showBeneficialText: false,
                             criterionRefId: "quality-crt-question-1.3.1",
                             hasInlineHtml: false,
+                            criterionTextRefId: "quality-crt-text-optional-1.3.1",
                             componentText: "Do the materials include any special needs formats? (e.g., Braille)",
                         },
                         {
@@ -68,6 +72,7 @@ export const QualityContent = {
                             showBeneficialText: true,
                             criterionRefId: "quality-crt-question-1.3.2",
                             hasInlineHtml: false,
+                            criterionTextRefId: "quality-crt-text-optional-1.3.2",
                             componentText: "Are the materials available in languages other than English?",
                         },
                         {


### PR DESCRIPTION
On print screen Implemented a mechanism to show the text field values on the Quality Dimension

## Additions

- Added criterionTextRefId field to the json, so we know what to print
- Added function to CriterionAnswerArea.js that detects new field and prints it to screen



## Review

- @dcmouyard 

[Preview this PR without the whitespace changes](?w=0)


## Notes

- The new method that returns/prints the value to the screen will need some UI attention.  Hoping Dan can help with this.

