### PR TITLE
Fix efficacy summary markup

### DIFF
--- a/teachers_digital_platform/crtool/src/__tests__/__snapshots__/EfficacyCriterionPage.test.js.snap
+++ b/teachers_digital_platform/crtool/src/__tests__/__snapshots__/EfficacyCriterionPage.test.js.snap
@@ -1219,7 +1219,7 @@ Array [
     </div>
     <button
       className="a-btn u-mb30"
-      disabled={true}
+      onClick={[Function]}
     >
       I’m done adding studies
     </button>

--- a/teachers_digital_platform/crtool/src/js/components/CustomerReviewToolComponent.js
+++ b/teachers_digital_platform/crtool/src/js/components/CustomerReviewToolComponent.js
@@ -191,7 +191,7 @@ export default class CustomerReviewToolComponent extends React.Component {
             utilityInProgress:this.state.utilityInProgress,
             qualityInProgress:this.state.qualityInProgress,
             efficacyInProgress:this.state.efficacyInProgress,
-            
+
             contentSummaryButton:this.state.contentSummaryButton,
             utilitySummaryButton:this.state.utilitySummaryButton,
             qualitySummaryButton:this.state.qualitySummaryButton,

--- a/teachers_digital_platform/crtool/src/js/components/CustomerReviewToolComponent.js
+++ b/teachers_digital_platform/crtool/src/js/components/CustomerReviewToolComponent.js
@@ -191,6 +191,7 @@ export default class CustomerReviewToolComponent extends React.Component {
             utilitySummaryButton:this.state.utilitySummaryButton,
             qualitySummaryButton:this.state.qualitySummaryButton,
             efficacySummaryButton:this.state.efficacySummaryButton,
+            finishAddingEfficacyStudies:this.state.finishAddingEfficacyStudies,
 
             clearLocalStorage:this.clearLocalStorage.bind(this),
             handleSummaryButtonClick:this.handleSummaryButtonClick.bind(this),

--- a/teachers_digital_platform/crtool/src/js/components/CustomerReviewToolComponent.js
+++ b/teachers_digital_platform/crtool/src/js/components/CustomerReviewToolComponent.js
@@ -187,6 +187,11 @@ export default class CustomerReviewToolComponent extends React.Component {
         const summaryButtonProps = {
             currentPage:this.state.currentPage,
 
+            contentInProgress:this.state.contentInProgress,
+            utilityInProgress:this.state.utilityInProgress,
+            qualityInProgress:this.state.qualityInProgress,
+            efficacyInProgress:this.state.efficacyInProgress,
+            
             contentSummaryButton:this.state.contentSummaryButton,
             utilitySummaryButton:this.state.utilitySummaryButton,
             qualitySummaryButton:this.state.qualitySummaryButton,

--- a/teachers_digital_platform/crtool/src/js/components/buttons/SummaryButton.js
+++ b/teachers_digital_platform/crtool/src/js/components/buttons/SummaryButton.js
@@ -9,7 +9,17 @@ export default class SummaryButton extends React.Component {
     }
 
     render() {
-        if (this.props.currentPage === C.CONTENT_PAGE &&
+        if ( (this.props.currentPage === C.CONTENT_PAGE && this.props.contentInProgress === C.STATUS_COMPLETE) || 
+             (this.props.currentPage === C.QUALITY_PAGE && this.props.qualityInProgress === C.STATUS_COMPLETE) || 
+             (this.props.currentPage === C.UTILITY_PAGE && this.props.utilityInProgress === C.STATUS_COMPLETE) || 
+             (this.props.currentPage === C.EFFICACY_PAGE && this.props.efficacyInProgress === C.STATUS_COMPLETE) ) {
+                return (
+                <button className="a-btn" onClick={(e) => {this.props.distinctiveClicked(C.FINAL_PRINT_PAGE); e.preventDefault();}}>
+                    Print or save summary
+                </button>
+            );
+        } 
+        else if (this.props.currentPage === C.CONTENT_PAGE &&
             this.props.contentSummaryButton === C.STATUS_COMPLETE) {
             return (
                 <button className="a-btn" onClick={(e) => {this.handleSummaryButtonClick()}} >
@@ -33,10 +43,10 @@ export default class SummaryButton extends React.Component {
                 </button>
             );
         }
-        else if (this.props.finishAddingEfficacyStudies) {
+        else if (this.props.currentPage === C.EFFICACY_PAGE && this.props.finishAddingEfficacyStudies) {
             return (
                 <button className="a-btn" onClick={(e) => {this.handleSummaryButtonClick()}} >
-                    Continue to efficacy summary
+                Continue to efficacy summary
                 </button>
             );
         }

--- a/teachers_digital_platform/crtool/src/js/components/buttons/SummaryButton.js
+++ b/teachers_digital_platform/crtool/src/js/components/buttons/SummaryButton.js
@@ -9,16 +9,16 @@ export default class SummaryButton extends React.Component {
     }
 
     render() {
-        if ( (this.props.currentPage === C.CONTENT_PAGE && this.props.contentInProgress === C.STATUS_COMPLETE) || 
-             (this.props.currentPage === C.QUALITY_PAGE && this.props.qualityInProgress === C.STATUS_COMPLETE) || 
-             (this.props.currentPage === C.UTILITY_PAGE && this.props.utilityInProgress === C.STATUS_COMPLETE) || 
+        if ( (this.props.currentPage === C.CONTENT_PAGE && this.props.contentInProgress === C.STATUS_COMPLETE) ||
+             (this.props.currentPage === C.QUALITY_PAGE && this.props.qualityInProgress === C.STATUS_COMPLETE) ||
+             (this.props.currentPage === C.UTILITY_PAGE && this.props.utilityInProgress === C.STATUS_COMPLETE) ||
              (this.props.currentPage === C.EFFICACY_PAGE && this.props.efficacyInProgress === C.STATUS_COMPLETE) ) {
                 return (
                 <button className="a-btn" onClick={(e) => {this.props.distinctiveClicked(C.FINAL_PRINT_PAGE); e.preventDefault();}}>
                     Print or save summary
                 </button>
             );
-        } 
+        }
         else if (this.props.currentPage === C.CONTENT_PAGE &&
             this.props.contentSummaryButton === C.STATUS_COMPLETE) {
             return (
@@ -46,7 +46,7 @@ export default class SummaryButton extends React.Component {
         else if (this.props.currentPage === C.EFFICACY_PAGE && this.props.finishAddingEfficacyStudies) {
             return (
                 <button className="a-btn" onClick={(e) => {this.handleSummaryButtonClick()}} >
-                Continue to efficacy summary
+                    Continue to efficacy summary
                 </button>
             );
         }
@@ -64,7 +64,7 @@ export default class SummaryButton extends React.Component {
                 return (null);
             } else {
                 return (
-                    <button className="a-btn" disabled >
+                    <button className="a-btn" disabled>
                         Continue to summary
                     </button>
                 );

--- a/teachers_digital_platform/crtool/src/js/components/buttons/SummaryButton.js
+++ b/teachers_digital_platform/crtool/src/js/components/buttons/SummaryButton.js
@@ -33,9 +33,15 @@ export default class SummaryButton extends React.Component {
                 </button>
             );
         }
-        else if (this.props.finishAddingEfficacyStudies === false ||
-                 (this.props.currentPage === C.EFFICACY_PAGE &&
-                  this.props.efficacySummaryButton === C.STATUS_COMPLETE)) {
+        else if (this.props.finishAddingEfficacyStudies) {
+            return (
+                <button className="a-btn" onClick={(e) => {this.handleSummaryButtonClick()}} >
+                    Continue to efficacy summary
+                </button>
+            );
+        }
+        else if (this.props.currentPage === C.EFFICACY_PAGE &&
+                  this.props.efficacySummaryButton === C.STATUS_COMPLETE) {
             return (
                 <button className="a-btn" onClick={(e) => {this.handleSummaryButtonClick()}} >
                     Continue to efficacy summary

--- a/teachers_digital_platform/crtool/src/js/components/pages/EfficacyCriterionPage.js
+++ b/teachers_digital_platform/crtool/src/js/components/pages/EfficacyCriterionPage.js
@@ -96,7 +96,7 @@ export default class EfficacyCriterionPage extends React.Component {
     }
 
     renderWarningContinueWithout2and3() {
-        if (!this.props.finishAddingEfficacyStudies) {
+        if (!this.props.finishAddingEfficacyStudies || this.twoStrongStudiesExist()) {
             return (null);
         } else {
             return (

--- a/teachers_digital_platform/crtool/src/js/components/pages/EfficacyCriterionPage.js
+++ b/teachers_digital_platform/crtool/src/js/components/pages/EfficacyCriterionPage.js
@@ -79,7 +79,7 @@ export default class EfficacyCriterionPage extends React.Component {
     }
 
     renderDoneAddingStoriesButton() {
-        if (this.props.finishAddingEfficacyStudies || this.twoStrongStudiesExist() || !this.twoCompleteStudiesExist()) {
+        if (this.props.finishAddingEfficacyStudies) {
             return (
                 <button className="a-btn u-mb30" disabled >
                     I’m done adding studies
@@ -96,7 +96,7 @@ export default class EfficacyCriterionPage extends React.Component {
     }
 
     renderWarningContinueWithout2and3() {
-        if (!this.props.finishAddingEfficacyStudies || this.twoStrongStudiesExist()) {
+        if (!this.props.finishAddingEfficacyStudies) {
             return (null);
         } else {
             return (

--- a/teachers_digital_platform/crtool/src/js/components/pages/EfficacySummaryPage.js
+++ b/teachers_digital_platform/crtool/src/js/components/pages/EfficacySummaryPage.js
@@ -98,17 +98,16 @@ export default class EfficacySummaryPage extends React.Component {
                     Print or save summary
                 </button>
                 <CurriculumInformation {...this.props} reviewedOnDate={this.props.distinctiveCompletedDate[C.EFFICACY_PAGE]} />
-                <div className="l-survey-top">
-                <button className="a-btn a-btn__link" onClick={(e) => {this.props.setDistinctiveBackToInProgress(C.EFFICACY_PAGE);}}>
+                <h3 className="h2">Based on your answers, the efficacy score for this curriculum is:</h3>
+                <p>
+                    <a href="#">
+                        How efficacy is scored.
                         <SvgIcon
-                            icon="pencil"
-                            islarge="true"
-                            hasSpaceAfter="true" />
-                        View or edit responses
-                    </button>
-                </div>
-                <h3 className="h2">Criterion 1: Strength of study (inclusion criteria)</h3>
-                <p className="u-mb30">Is the study strong? Only strong studies (those that meet rigorous standards) can be used to determine the efficacy of a curriculum. The inclusion criteria will help you determine whether or not a study meets these standards of a strong study.</p>
+                            icon="document"
+                            hasSpaceBefore="true" />
+                    </a>
+                </p>
+                <h4 className="h3">Score for scope of evidence</h4>
                 <div className="m-curriculum-status">
                     <ul className="m-list__unstyled
                                     u-mb0">
@@ -117,14 +116,12 @@ export default class EfficacySummaryPage extends React.Component {
                                             m-form-field__radio
                                             m-form-field__display">
                                 <div className="a-label">
-                                    <svg className={this.criterionClassNameFor("1", "exceeds")} viewBox="0 0 22 22">
+                                    <svg className="m-form-field_radio-icon is-active" viewBox="0 0 22 22">
                                         <circle cx="11" cy="11" r="10" className="m-form-field_radio-icon-stroke"></circle>
                                         <circle cx="11" cy="11" r="7" className="m-form-field_radio-icon-fill"></circle>
                                     </svg>
                                     <div className="m-form-field_radio-text is-active">
-                                        <div><strong>Exceeds</strong></div>
-                                        All essential components scored “yes”<br />
-                                        At least one beneficial component scored “yes”
+                                        Large body of evidence
                                     </div>
                                 </div>
                             </div>
@@ -134,216 +131,32 @@ export default class EfficacySummaryPage extends React.Component {
                                             m-form-field__radio
                                             m-form-field__display">
                                 <div className="a-label">
-                                    <svg className={this.criterionClassNameFor("1", "meets")} viewBox="0 0 22 22">
+                                    <svg className="m-form-field_radio-icon" viewBox="0 0 22 22">
                                         <circle cx="11" cy="11" r="10" className="m-form-field_radio-icon-stroke"></circle>
                                         <circle cx="11" cy="11" r="7" className="m-form-field_radio-icon-fill"></circle>
                                     </svg>
                                     <div className="m-form-field_radio-text">
-                                        <div><strong>Meets</strong></div>
-                                        All essential components scored “yes”<br />
-                                        None of the beneficial components scored “yes”
+                                        Moderate body of evidence
                                     </div>
                                 </div>
                             </div>
                         </li>
-                        <li className="u-mb30">
+                        <li>
                             <div className="m-form-field
                                             m-form-field__radio
                                             m-form-field__display">
                                 <div className="a-label">
-                                    <svg className={this.criterionClassNameFor("1", "doesnotmeet")} viewBox="0 0 22 22">
+                                    <svg className="m-form-field_radio-icon"viewBox="0 0 22 22">
                                         <circle cx="11" cy="11" r="10" className="m-form-field_radio-icon-stroke"></circle>
                                         <circle cx="11" cy="11" r="7" className="m-form-field_radio-icon-fill"></circle>
                                     </svg>
                                     <div className="m-form-field_radio-text">
-                                        <div><strong>Does not meet</strong></div>
-                                        One or more essential components scored “no”
+                                        Small body of evidence
                                     </div>
                                 </div>
                             </div>
                         </li>
                     </ul>
-                    <div className="m-curriculum-status_components">
-                        <p><b>Your answers for <em>essential</em> components:</b></p>
-                        <ul className="m-component-list">
-                            <li><b>{this.props.criterionScores["efficacy-crt-1-0"].essential_total_yes}</b> Yes</li>
-                            <li><b>{this.props.criterionScores["efficacy-crt-1-0"].essential_total_no}</b> No</li>
-                        </ul>
-                        <p><b>Your answers for <em>beneficial</em> components:</b></p>
-                        <ul className="m-component-list">
-                            <li><b>{this.props.criterionScores["efficacy-crt-1-0"].beneficial_total_yes}</b> Yes</li>
-                            <li><b>{this.props.criterionScores["efficacy-crt-1-0"].beneficial_total_no}</b> No</li>
-                        </ul>
-                    </div>
-                </div>
-                <div className="m-form-field m-form-field__textarea">
-                    <label className="a-label a-label__heading" htmlFor="efficacy-crt-notes-optional-1">
-                        My notes
-                        &nbsp;<small className="a-label_helper">(optional)</small>
-                        <small className="a-label_helper a-label_helper__block">
-                            Anything you want to note about this criterion? Please do not share any Personally Identifiable Information (PII), including, but not limited to, your name, address, phone number, email address, Social Security number, etc.
-                        </small>
-                    </label>
-                    <textarea className="a-text-input a-text-input__full"
-                        rows="6"
-                        id="efficacy-crt-notes-optional-1"
-                        ref="efficacy-crt-notes-optional-1"
-                        value={this.props.criterionAnswers['efficacy-crt-notes-optional-1']}
-                        onChange={e=>this.criterionAnswerChanged('efficacy-crt-notes-optional-1', e.target.value)} >
-                    </textarea>
-                </div>
-                <hr className="hr
-                                u-mb45
-                                u-mt30" />
-                <h3 className="h2">Criterion 2: Saving and investing</h3>
-                <p className="u-mb30">Is there enough evidence (when looking at all the strong studies as a whole) to support the research that this is an effective curriculum?</p>
-                <div className="m-curriculum-status">
-                    <ul className="m-list__unstyled
-                                    u-mb0">
-                        <li className="u-mb30">
-                            <div className="m-form-field
-                                            m-form-field__radio
-                                            m-form-field__display">
-                                <div className="a-label">
-                                    <svg className={this.criterionClassNameFor("2", "meets")} viewBox="0 0 22 22">
-                                        <circle cx="11" cy="11" r="10" className="m-form-field_radio-icon-stroke"></circle>
-                                        <circle cx="11" cy="11" r="7" className="m-form-field_radio-icon-fill"></circle>
-                                    </svg>
-                                    <div className="m-form-field_radio-text is-active">
-                                        <div><strong>Meets</strong></div>
-                                        All essential components scored “yes”
-                                    </div>
-                                </div>
-                            </div>
-                        </li>
-                        <li className="u-mb30">
-                            <div className="m-form-field
-                                            m-form-field__radio
-                                            m-form-field__display">
-                                <div className="a-label">
-                                    <svg className={this.criterionClassNameFor("2", "doesnotmeet")} viewBox="0 0 22 22">
-                                        <circle cx="11" cy="11" r="10" className="m-form-field_radio-icon-stroke"></circle>
-                                        <circle cx="11" cy="11" r="7" className="m-form-field_radio-icon-fill"></circle>
-                                    </svg>
-                                    <div className="m-form-field_radio-text">
-                                        <div><strong>Does not meet</strong></div>
-                                        One or more essential components scored “no”
-                                    </div>
-                                </div>
-                            </div>
-                        </li>
-                    </ul>
-                    <div className="m-curriculum-status_components">
-                        <p><b>Your answers for <em>essential</em> components:</b></p>
-                        <ul className="m-component-list">
-                            <li><b>{this.props.criterionScores["efficacy-crt-2"].beneficial_total_yes}</b> Yes</li>
-                            <li><b>{this.props.criterionScores["efficacy-crt-2"].beneficial_total_no}</b> No</li>
-                        </ul>
-                    </div>
-                </div>
-                <div className="m-form-field m-form-field__textarea">
-                    <label className="a-label a-label__heading" htmlFor="efficacy-crt-notes-optional-2">
-                        My notes
-                        &nbsp;<small className="a-label_helper">(optional)</small>
-                        <small className="a-label_helper a-label_helper__block">
-                            Anything you want to note about this criterion? Please do not share any Personally Identifiable Information (PII), including, but not limited to, your name, address, phone number, email address, Social Security number, etc.
-                        </small>
-                    </label>
-                    <textarea className="a-text-input a-text-input__full"
-                        rows="6"
-                        id="efficacy-crt-notes-optional-2"
-                        ref="efficacy-crt-notes-optional-2"
-                        value={this.props.criterionAnswers['efficacy-crt-notes-optional-2']}
-                        onChange={e=>this.criterionAnswerChanged('efficacy-crt-notes-optional-2', e.target.value)} >
-                    </textarea>
-                </div>
-                <hr className="hr
-                                u-mb45
-                                u-mt30" />
-                <h3 className="h2">Criterion 3: Impact</h3>
-                <p className="u-mb30">Is there enough evidence to support conclusions of consistent, strong, positive impact?</p>
-                <div className="m-curriculum-status">
-                    <ul className="m-list__unstyled
-                                    u-mb0">
-                        <li className="u-mb30">
-                            <div className="m-form-field
-                                            m-form-field__radio
-                                            m-form-field__display">
-                                <div className="a-label">
-                                    <svg className={this.criterionClassNameFor("3", "exceeds")} viewBox="0 0 22 22">
-                                        <circle cx="11" cy="11" r="10" className="m-form-field_radio-icon-stroke"></circle>
-                                        <circle cx="11" cy="11" r="7" className="m-form-field_radio-icon-fill"></circle>
-                                    </svg>
-                                    <div className="m-form-field_radio-text is-active">
-                                        <div><strong>Exceeds</strong></div>
-                                        All essential components scored “yes”<br />
-                                        At least one beneficial component scored “yes”
-                                    </div>
-                                </div>
-                            </div>
-                        </li>
-                        <li className="u-mb30">
-                            <div className="m-form-field
-                                            m-form-field__radio
-                                            m-form-field__display">
-                                <div className="a-label">
-                                    <svg className={this.criterionClassNameFor("3", "meets")} viewBox="0 0 22 22">
-                                        <circle cx="11" cy="11" r="10" className="m-form-field_radio-icon-stroke"></circle>
-                                        <circle cx="11" cy="11" r="7" className="m-form-field_radio-icon-fill"></circle>
-                                    </svg>
-                                    <div className="m-form-field_radio-text">
-                                        <div><strong>Meets</strong></div>
-                                        All essential components scored “yes”<br />
-                                        None of the beneficial components scored “yes”
-                                    </div>
-                                </div>
-                            </div>
-                        </li>
-                        <li className="u-mb30">
-                            <div className="m-form-field
-                                            m-form-field__radio
-                                            m-form-field__display">
-                                <div className="a-label">
-                                    <svg className={this.criterionClassNameFor("3", "doesnotmeet")} viewBox="0 0 22 22">
-                                        <circle cx="11" cy="11" r="10" className="m-form-field_radio-icon-stroke"></circle>
-                                        <circle cx="11" cy="11" r="7" className="m-form-field_radio-icon-fill"></circle>
-                                    </svg>
-                                    <div className="m-form-field_radio-text">
-                                        <div><strong>Does not meet</strong></div>
-                                        One or more essential components scored “no”
-                                    </div>
-                                </div>
-                            </div>
-                        </li>
-                    </ul>
-                    <div className="m-curriculum-status_components">
-                    <p><b>Your answers for <em>essential</em> components:</b></p>
-                    <ul className="m-component-list">
-                        <li><b>{this.props.criterionScores["efficacy-crt-3"].essential_total_yes}</b> Yes</li>
-                        <li><b>{this.props.criterionScores["efficacy-crt-3"].essential_total_no}</b> No</li>
-                    </ul>
-                    <p><b>Your answers for <em>beneficial</em> components:</b></p>
-                    <ul className="m-component-list">
-                        <li><b>{this.props.criterionScores["efficacy-crt-3"].beneficial_total_yes}</b> Yes</li>
-                        <li><b>{this.props.criterionScores["efficacy-crt-3"].beneficial_total_no}</b> No</li>
-                    </ul>
-                    </div>
-                </div>
-                <div className="m-form-field m-form-field__textarea">
-                    <label className="a-label a-label__heading" htmlFor="efficacy-crt-notes-optional-3">
-                        My notes
-                        &nbsp;<small className="a-label_helper">(optional)</small>
-                        <small className="a-label_helper a-label_helper__block">
-                            Anything you want to note about this criterion? Please do not share any Personally Identifiable Information (PII), including, but not limited to, your name, address, phone number, email address, Social Security number, etc.
-                        </small>
-                    </label>
-                    <textarea className="a-text-input a-text-input__full"
-                        rows="6"
-                        id="efficacy-crt-notes-optional-3"
-                        ref="efficacy-crt-notes-optional-3"
-                        value={this.props.criterionAnswers['efficacy-crt-notes-optional-3']}
-                        onChange={e=>this.criterionAnswerChanged('efficacy-crt-notes-optional-3', e.target.value)} >
-                    </textarea>
                 </div>
                 <hr className="hr
                                 u-mb45

--- a/teachers_digital_platform/crtool/src/js/components/pages/EfficacySummaryPage.js
+++ b/teachers_digital_platform/crtool/src/js/components/pages/EfficacySummaryPage.js
@@ -241,7 +241,6 @@ export default class EfficacySummaryPage extends React.Component {
                                     </svg>
                                     <div className="m-form-field_radio-text">
                                         <div><strong>Strong efficacy</strong></div>
-                                        All 4 criteria were met, and at least one was exceeded
                                     </div>
                                 </div>
                             </div>
@@ -257,7 +256,6 @@ export default class EfficacySummaryPage extends React.Component {
                                     </svg>
                                     <div className="m-form-field_radio-text is-active">
                                         <div><strong>Moderate efficacy</strong></div>
-                                        All 4 criteria were met
                                     </div>
                                 </div>
                             </div>
@@ -273,7 +271,6 @@ export default class EfficacySummaryPage extends React.Component {
                                     </svg>
                                     <div className="m-form-field_radio-text">
                                         <div><strong>Mixed efficacy</strong></div>
-                                        At least one of the criteria was not met
                                     </div>
                                 </div>
                             </div>
@@ -289,7 +286,6 @@ export default class EfficacySummaryPage extends React.Component {
                                     </svg>
                                     <div className="m-form-field_radio-text">
                                         <div><strong>Limited efficacy</strong></div>
-                                        At least one of the criteria was not met
                                     </div>
                                 </div>
                             </div>
@@ -305,7 +301,6 @@ export default class EfficacySummaryPage extends React.Component {
                                     </svg>
                                     <div className="m-form-field_radio-text">
                                         <div><strong>Not enough information</strong></div>
-                                        No studies met criterion 1
                                     </div>
                                 </div>
                             </div>

--- a/teachers_digital_platform/crtool/src/js/components/pages/EfficacySummaryPage.js
+++ b/teachers_digital_platform/crtool/src/js/components/pages/EfficacySummaryPage.js
@@ -15,7 +15,18 @@ export default class EfficacySummaryPage extends React.Component {
         let isLarge = this.scoreIsLarge(hasTwoStrongStudies);
         let criterionThreeScore = this.props.criterionScores["efficacy-crt-3"];
 
-
+        if (criterionThreeScore === undefined) {
+            criterionThreeScore = {
+                criterionName:"efficacy-crt-3",
+                has_beneficial:true,
+                all_essential_yes:false,
+                essential_total_yes:0,
+                essential_total_no:0,
+                beneficial_total_yes:0,
+                beneficial_total_no:0,
+                answered_all_complete:true,
+            };
+        }
 
         let className = "m-form-field_radio-icon";
         if (level === "strong" && 
@@ -25,13 +36,13 @@ export default class EfficacySummaryPage extends React.Component {
 
             className = className + " is-active";
         } else if (level === "moderate" &&
-        isLarge && 
+                    isLarge && 
                     criterionThreeScore.all_essential_yes && 
                     criterionThreeScore.beneficial_total_no === 1) {
                         
             className = className + " is-active";
         } else if (level === "mixed" && 
-        isLarge && 
+                    isLarge && 
                     criterionThreeScore.essential_total_yes < 2) {
 
             className = className + " is-active";
@@ -146,7 +157,7 @@ export default class EfficacySummaryPage extends React.Component {
                 </div>
                 <h3 className="h2">Based on your answers, the efficacy score for this curriculum is:</h3>
                 <p>
-                    <a href="#">
+                    <a>
                         How efficacy is scored.
                         <SvgIcon
                             icon="document"

--- a/teachers_digital_platform/crtool/src/js/components/pages/EfficacySummaryPage.js
+++ b/teachers_digital_platform/crtool/src/js/components/pages/EfficacySummaryPage.js
@@ -155,7 +155,7 @@ export default class EfficacySummaryPage extends React.Component {
                         View or edit responses
                     </button>
                 </div>
-                <h3 className="h2">Based on your answers, the efficacy score for this curriculum is:</h3>
+                <h2 className="h2">Based on your answers, the efficacy score for this curriculum is:</h2>
                 <p>
                     <a>
                         How efficacy is scored.

--- a/teachers_digital_platform/crtool/src/js/components/pages/EfficacySummaryPage.js
+++ b/teachers_digital_platform/crtool/src/js/components/pages/EfficacySummaryPage.js
@@ -11,50 +11,87 @@ export default class EfficacySummaryPage extends React.Component {
     }
 
     criterionOveralScoreClassName(level) {
+        let hasTwoStrongStudies = this.twoStrongStudiesExist();
+        let isLarge = this.scoreIsLarge(hasTwoStrongStudies);
+        let criterionThreeScore = this.props.criterionScores["efficacy-crt-3"];
 
-        let isLimited = false;
-        if (this.props.criterionScores["efficacy-crt-1-0"].doesnotmeet ||
-            this.props.criterionScores["efficacy-crt-2"].doesnotmeet ||
-            this.props.criterionScores["efficacy-crt-3"].doesnotmeet ) {
 
-            isLimited = true;
-        }
-
-        let isModerate = false;
-        if (this.props.criterionScores["efficacy-crt-1-0"].meets &&
-            this.props.criterionScores["efficacy-crt-2"].meets &&
-            this.props.criterionScores["efficacy-crt-3"].meets ) {
-
-            isModerate = true;
-        }
 
         let className = "m-form-field_radio-icon";
-        if (level === "limited" && isLimited) {
+        if (level === "strong" && 
+            isLarge && 
+            criterionThreeScore.all_essential_yes && 
+            criterionThreeScore.beneficial_total_no === 0) {
+
             className = className + " is-active";
-        } else if (level === "moderate" && isModerate) {
+        } else if (level === "moderate" &&
+        isLarge && 
+                    criterionThreeScore.all_essential_yes && 
+                    criterionThreeScore.beneficial_total_no === 1) {
+                        
             className = className + " is-active";
-        } else if (level === "strong" && !isLimited && !isModerate) {
+        } else if (level === "mixed" && 
+        isLarge && 
+                    criterionThreeScore.essential_total_yes < 2) {
+
+            className = className + " is-active";
+        } else if (level === "limited" && 
+                    !isLarge && 
+                    criterionThreeScore.essential_total_yes === 0 && 
+                    criterionThreeScore.beneficial_total_yes === 1) {
+
+            className = className + " is-active";
+        } else if (level === "notenoughinfo" && 
+                    !isLarge) {
+
             className = className + " is-active";
         }
 
         return className;
     }
 
-    criterionClassNameFor(criterion, level) {
-        let criterionGroupName = "efficacy-crt-" + criterion;
-        if (criterion === "1") {
-            criterionGroupName += "-0";
+    twoStrongStudiesExist() {
+        let count = 0;
+        for (var score in this.props.criterionScores) {
+            if (score.includes("efficacy-crt-1") && this.props.criterionScores[score].all_essential_yes)
+            {
+                count += 1;
+                if (count === 2) {
+                    return true;
+                }
+            }
         }
 
-        let criterionScore = this.props.criterionScores[criterionGroupName];
-        let className = "m-form-field_radio-icon";
+        return false;
+    }
 
-        if (level === "exceeds" && criterionScore.exceeds) {
+    scoreIsLarge(hasTwoStrongStudies) {
+        return (hasTwoStrongStudies && 
+                this.props.criterionScores["efficacy-crt-2"].beneficial_total_yes > 0);
+    }
+
+    scoreIsModerate(hasTwoStrongStudies) {
+        return (hasTwoStrongStudies &&
+                this.props.criterionScores["efficacy-crt-2"].beneficial_total_yes === 0);
+    }
+
+    scoreIsLimited(hasTwoStrongStudies) {
+        return (!hasTwoStrongStudies);
+    }
+
+    scoreScopeOfEvidenceClassName(level) {
+        let className = "m-form-field_radio-icon";
+        let hasTwoStrongStudies = this.twoStrongStudiesExist();
+
+        if (this.scoreIsLarge(hasTwoStrongStudies) && level === "large") {
             className = className + " is-active";
-        } else if (level === "meets" && criterionScore.meets) {
+
+        } else if (this.scoreIsModerate(hasTwoStrongStudies) && level === "moderate") {
             className = className + " is-active";
-        } else if (level === "doesnotmeet" && criterionScore !== undefined && criterionScore.doesnotmeet) {
+
+        } else if (this.scoreIsLimited(hasTwoStrongStudies)  && level === "small") {
             className = className + " is-active";
+
         }
 
         return className;
@@ -98,6 +135,15 @@ export default class EfficacySummaryPage extends React.Component {
                     Print or save summary
                 </button>
                 <CurriculumInformation {...this.props} reviewedOnDate={this.props.distinctiveCompletedDate[C.EFFICACY_PAGE]} />
+                <div className="l-survey-top">
+                    <button className="a-btn a-btn__link" onClick={(e) => {this.props.setDistinctiveBackToInProgress(C.EFFICACY_PAGE);}}>
+                        <SvgIcon
+                            icon="pencil"
+                            islarge="true"
+                            hasSpaceAfter="true" />
+                        View or edit responses
+                    </button>
+                </div>
                 <h3 className="h2">Based on your answers, the efficacy score for this curriculum is:</h3>
                 <p>
                     <a href="#">
@@ -116,7 +162,7 @@ export default class EfficacySummaryPage extends React.Component {
                                             m-form-field__radio
                                             m-form-field__display">
                                 <div className="a-label">
-                                    <svg className="m-form-field_radio-icon is-active" viewBox="0 0 22 22">
+                                    <svg className={this.scoreScopeOfEvidenceClassName("large")} viewBox="0 0 22 22">
                                         <circle cx="11" cy="11" r="10" className="m-form-field_radio-icon-stroke"></circle>
                                         <circle cx="11" cy="11" r="7" className="m-form-field_radio-icon-fill"></circle>
                                     </svg>
@@ -131,7 +177,7 @@ export default class EfficacySummaryPage extends React.Component {
                                             m-form-field__radio
                                             m-form-field__display">
                                 <div className="a-label">
-                                    <svg className="m-form-field_radio-icon" viewBox="0 0 22 22">
+                                    <svg className={this.scoreScopeOfEvidenceClassName("moderate")} viewBox="0 0 22 22">
                                         <circle cx="11" cy="11" r="10" className="m-form-field_radio-icon-stroke"></circle>
                                         <circle cx="11" cy="11" r="7" className="m-form-field_radio-icon-fill"></circle>
                                     </svg>
@@ -146,7 +192,7 @@ export default class EfficacySummaryPage extends React.Component {
                                             m-form-field__radio
                                             m-form-field__display">
                                 <div className="a-label">
-                                    <svg className="m-form-field_radio-icon"viewBox="0 0 22 22">
+                                    <svg className={this.scoreScopeOfEvidenceClassName("small")} viewBox="0 0 22 22">
                                         <circle cx="11" cy="11" r="10" className="m-form-field_radio-icon-stroke"></circle>
                                         <circle cx="11" cy="11" r="7" className="m-form-field_radio-icon-fill"></circle>
                                     </svg>
@@ -210,6 +256,22 @@ export default class EfficacySummaryPage extends React.Component {
                                         m-form-field__radio
                                         m-form-field__display">
                                 <div className="a-label">
+                                    <svg className={this.criterionOveralScoreClassName("mixed")} viewBox="0 0 22 22">
+                                        <circle cx="11" cy="11" r="10" className="m-form-field_radio-icon-stroke"></circle>
+                                        <circle cx="11" cy="11" r="7" className="m-form-field_radio-icon-fill"></circle>
+                                    </svg>
+                                    <div className="m-form-field_radio-text">
+                                        <div><strong>Mixed efficacy</strong></div>
+                                        At least one of the criteria was not met
+                                    </div>
+                                </div>
+                            </div>
+                        </li>
+                        <li className="u-mb30">
+                            <div className="m-form-field
+                                        m-form-field__radio
+                                        m-form-field__display">
+                                <div className="a-label">
                                     <svg className={this.criterionOveralScoreClassName("limited")} viewBox="0 0 22 22">
                                         <circle cx="11" cy="11" r="10" className="m-form-field_radio-icon-stroke"></circle>
                                         <circle cx="11" cy="11" r="7" className="m-form-field_radio-icon-fill"></circle>
@@ -217,6 +279,22 @@ export default class EfficacySummaryPage extends React.Component {
                                     <div className="m-form-field_radio-text">
                                         <div><strong>Limited efficacy</strong></div>
                                         At least one of the criteria was not met
+                                    </div>
+                                </div>
+                            </div>
+                        </li>
+                        <li className="u-mb30">
+                            <div className="m-form-field
+                                        m-form-field__radio
+                                        m-form-field__display">
+                                <div className="a-label">
+                                    <svg className={this.criterionOveralScoreClassName("notenoughinfo")} viewBox="0 0 22 22">
+                                        <circle cx="11" cy="11" r="10" className="m-form-field_radio-icon-stroke"></circle>
+                                        <circle cx="11" cy="11" r="7" className="m-form-field_radio-icon-fill"></circle>
+                                    </svg>
+                                    <div className="m-form-field_radio-text">
+                                        <div><strong>Not enough information</strong></div>
+                                        No studies met criterion 1
                                     </div>
                                 </div>
                             </div>

--- a/teachers_digital_platform/crtool/src/js/components/pages/EfficacySummaryPage.js
+++ b/teachers_digital_platform/crtool/src/js/components/pages/EfficacySummaryPage.js
@@ -10,7 +10,7 @@ export default class EfficacySummaryPage extends React.Component {
         this.props.criterionAnswerChanged(C.EFFICACY_PAGE, key, checkedValue);
     }
 
-    criterionOveralScoreClassName(level) {
+    criterionOveralScoreClassName(level, type) {
         let hasTwoStrongStudies = this.twoStrongStudiesExist();
         let isLarge = this.scoreIsLarge(hasTwoStrongStudies);
         let criterionThreeScore = this.props.criterionScores["efficacy-crt-3"];
@@ -29,6 +29,8 @@ export default class EfficacySummaryPage extends React.Component {
         }
 
         let className = "m-form-field_radio-icon";
+        if (type === "text") className = "m-form-field_radio-text";
+
         if (level === "strong" && 
             isLarge && 
             criterionThreeScore.all_essential_yes && 
@@ -90,8 +92,10 @@ export default class EfficacySummaryPage extends React.Component {
         return (!hasTwoStrongStudies);
     }
 
-    scoreScopeOfEvidenceClassName(level) {
+    scoreScopeOfEvidenceClassName(level, type) {
         let className = "m-form-field_radio-icon";
+        if (type === "text") className = "m-form-field_radio-text";
+
         let hasTwoStrongStudies = this.twoStrongStudiesExist();
 
         if (this.scoreIsLarge(hasTwoStrongStudies) && level === "large") {
@@ -177,7 +181,7 @@ export default class EfficacySummaryPage extends React.Component {
                                         <circle cx="11" cy="11" r="10" className="m-form-field_radio-icon-stroke"></circle>
                                         <circle cx="11" cy="11" r="7" className="m-form-field_radio-icon-fill"></circle>
                                     </svg>
-                                    <div className="m-form-field_radio-text is-active">
+                                    <div className={this.scoreScopeOfEvidenceClassName("large", "text")}>
                                         Large body of evidence
                                     </div>
                                 </div>
@@ -192,7 +196,7 @@ export default class EfficacySummaryPage extends React.Component {
                                         <circle cx="11" cy="11" r="10" className="m-form-field_radio-icon-stroke"></circle>
                                         <circle cx="11" cy="11" r="7" className="m-form-field_radio-icon-fill"></circle>
                                     </svg>
-                                    <div className="m-form-field_radio-text">
+                                    <div className={this.scoreScopeOfEvidenceClassName("moderate", "text")}>
                                         Moderate body of evidence
                                     </div>
                                 </div>
@@ -207,7 +211,7 @@ export default class EfficacySummaryPage extends React.Component {
                                         <circle cx="11" cy="11" r="10" className="m-form-field_radio-icon-stroke"></circle>
                                         <circle cx="11" cy="11" r="7" className="m-form-field_radio-icon-fill"></circle>
                                     </svg>
-                                    <div className="m-form-field_radio-text">
+                                    <div className={this.scoreScopeOfEvidenceClassName("small", "text")}>
                                         Small body of evidence
                                     </div>
                                 </div>
@@ -239,7 +243,7 @@ export default class EfficacySummaryPage extends React.Component {
                                         <circle cx="11" cy="11" r="10" className="m-form-field_radio-icon-stroke"></circle>
                                         <circle cx="11" cy="11" r="7" className="m-form-field_radio-icon-fill"></circle>
                                     </svg>
-                                    <div className="m-form-field_radio-text">
+                                    <div className={this.criterionOveralScoreClassName("strong", "text")}>
                                         <div><strong>Strong efficacy</strong></div>
                                     </div>
                                 </div>
@@ -254,7 +258,7 @@ export default class EfficacySummaryPage extends React.Component {
                                         <circle cx="11" cy="11" r="10" className="m-form-field_radio-icon-stroke"></circle>
                                         <circle cx="11" cy="11" r="7" className="m-form-field_radio-icon-fill"></circle>
                                     </svg>
-                                    <div className="m-form-field_radio-text is-active">
+                                    <div className={this.criterionOveralScoreClassName("moderate", "text")}>
                                         <div><strong>Moderate efficacy</strong></div>
                                     </div>
                                 </div>
@@ -269,7 +273,7 @@ export default class EfficacySummaryPage extends React.Component {
                                         <circle cx="11" cy="11" r="10" className="m-form-field_radio-icon-stroke"></circle>
                                         <circle cx="11" cy="11" r="7" className="m-form-field_radio-icon-fill"></circle>
                                     </svg>
-                                    <div className="m-form-field_radio-text">
+                                    <div className={this.criterionOveralScoreClassName("mixed", "text")}>
                                         <div><strong>Mixed efficacy</strong></div>
                                     </div>
                                 </div>
@@ -284,7 +288,7 @@ export default class EfficacySummaryPage extends React.Component {
                                         <circle cx="11" cy="11" r="10" className="m-form-field_radio-icon-stroke"></circle>
                                         <circle cx="11" cy="11" r="7" className="m-form-field_radio-icon-fill"></circle>
                                     </svg>
-                                    <div className="m-form-field_radio-text">
+                                    <div className={this.criterionOveralScoreClassName("limited", "text")}>
                                         <div><strong>Limited efficacy</strong></div>
                                     </div>
                                 </div>
@@ -299,7 +303,7 @@ export default class EfficacySummaryPage extends React.Component {
                                         <circle cx="11" cy="11" r="10" className="m-form-field_radio-icon-stroke"></circle>
                                         <circle cx="11" cy="11" r="7" className="m-form-field_radio-icon-fill"></circle>
                                     </svg>
-                                    <div className="m-form-field_radio-text">
+                                    <div className={this.criterionOveralScoreClassName("notenoughinfo", "text")}>
                                         <div><strong>Not enough information</strong></div>
                                     </div>
                                 </div>

--- a/teachers_digital_platform/crtool/src/js/components/pages/EfficacySummaryPage.js
+++ b/teachers_digital_platform/crtool/src/js/components/pages/EfficacySummaryPage.js
@@ -31,30 +31,30 @@ export default class EfficacySummaryPage extends React.Component {
         let className = "m-form-field_radio-icon";
         if (type === "text") className = "m-form-field_radio-text";
 
-        if (level === "strong" && 
-            isLarge && 
-            criterionThreeScore.all_essential_yes && 
+        if (level === "strong" &&
+            isLarge &&
+            criterionThreeScore.all_essential_yes &&
             criterionThreeScore.beneficial_total_no === 0) {
 
             className = className + " is-active";
         } else if (level === "moderate" &&
-                    isLarge && 
-                    criterionThreeScore.all_essential_yes && 
+                    isLarge &&
+                    criterionThreeScore.all_essential_yes &&
                     criterionThreeScore.beneficial_total_no === 1) {
-                        
+
             className = className + " is-active";
-        } else if (level === "mixed" && 
-                    isLarge && 
+        } else if (level === "mixed" &&
+                    isLarge &&
                     criterionThreeScore.essential_total_yes < 2) {
 
             className = className + " is-active";
-        } else if (level === "limited" && 
-                    !isLarge && 
-                    criterionThreeScore.essential_total_yes === 0 && 
+        } else if (level === "limited" &&
+                    !isLarge &&
+                    criterionThreeScore.essential_total_yes === 0 &&
                     criterionThreeScore.beneficial_total_yes === 1) {
 
             className = className + " is-active";
-        } else if (level === "notenoughinfo" && 
+        } else if (level === "notenoughinfo" &&
                     !isLarge) {
 
             className = className + " is-active";
@@ -79,7 +79,7 @@ export default class EfficacySummaryPage extends React.Component {
     }
 
     scoreIsLarge(hasTwoStrongStudies) {
-        return (hasTwoStrongStudies && 
+        return (hasTwoStrongStudies &&
                 this.props.criterionScores["efficacy-crt-2"].beneficial_total_yes > 0);
     }
 

--- a/teachers_digital_platform/crtool/src/js/components/pages/QualitySummaryPage.js
+++ b/teachers_digital_platform/crtool/src/js/components/pages/QualitySummaryPage.js
@@ -10,7 +10,7 @@ export default class QualitySummaryPage extends React.Component {
         this.props.criterionAnswerChanged(C.QUALITY_PAGE, key, checkedValue);
     }
 
-    criterionOveralScoreClassName(level) {
+    criterionOveralScoreClassName(level, type) {
 
         let isLimited = false;
         if (this.props.criterionScores["quality-crt-1"].doesnotmeet ||
@@ -31,6 +31,8 @@ export default class QualitySummaryPage extends React.Component {
         }
 
         let className = "m-form-field_radio-icon";
+        if (type === "text") className = "m-form-field_radio-text";
+
         if (level === "limited" && isLimited) {
             className = className + " is-active";
         } else if (level === "moderate" && isModerate) {
@@ -42,10 +44,12 @@ export default class QualitySummaryPage extends React.Component {
         return className;
     }
 
-    criterionClassNameFor(criterion, level) {
+    criterionClassNameFor(criterion, level, type) {
         let criterionGroupName = "quality-crt-" + criterion;
         let criterionScore = this.props.criterionScores[criterionGroupName];
+
         let className = "m-form-field_radio-icon";
+        if (type === "text") className = "m-form-field_radio-text";
 
         if (level === "exceeds" && criterionScore.exceeds) {
             className = className + " is-active";
@@ -122,7 +126,7 @@ export default class QualitySummaryPage extends React.Component {
                                         <circle cx="11" cy="11" r="10" className="m-form-field_radio-icon-stroke"></circle>
                                         <circle cx="11" cy="11" r="7" className="m-form-field_radio-icon-fill"></circle>
                                     </svg>
-                                    <div className="m-form-field_radio-text is-active">
+                                    <div className={this.criterionClassNameFor("1", "exceeds", "text")}>
                                         <div><strong>Exceeds</strong></div>
                                         All essential components scored “yes”<br />
                                         At least one beneficial component scored “yes”
@@ -139,7 +143,7 @@ export default class QualitySummaryPage extends React.Component {
                                         <circle cx="11" cy="11" r="10" className="m-form-field_radio-icon-stroke"></circle>
                                         <circle cx="11" cy="11" r="7" className="m-form-field_radio-icon-fill"></circle>
                                     </svg>
-                                    <div className="m-form-field_radio-text">
+                                    <div className={this.criterionClassNameFor("1", "meets", "text")}>
                                         <div><strong>Meets</strong></div>
                                         All essential components scored “yes”<br />
                                         None of the beneficial components scored “yes”
@@ -156,7 +160,7 @@ export default class QualitySummaryPage extends React.Component {
                                         <circle cx="11" cy="11" r="10" className="m-form-field_radio-icon-stroke"></circle>
                                         <circle cx="11" cy="11" r="7" className="m-form-field_radio-icon-fill"></circle>
                                     </svg>
-                                    <div className="m-form-field_radio-text">
+                                    <div className={this.criterionClassNameFor("1", "doesnotmeet", "text")}>
                                         <div><strong>Does not meet</strong></div>
                                         One or more essential components scored “no”
                                     </div>
@@ -219,7 +223,7 @@ export default class QualitySummaryPage extends React.Component {
                                         <circle cx="11" cy="11" r="10" className="m-form-field_radio-icon-stroke"></circle>
                                         <circle cx="11" cy="11" r="7" className="m-form-field_radio-icon-fill"></circle>
                                     </svg>
-                                    <div className="m-form-field_radio-text is-active">
+                                    <div className={this.criterionClassNameFor("2", "exceeds", "text")}>
                                         <div><strong>Meets</strong></div>
                                         All essential components scored “yes”
                                     </div>
@@ -235,7 +239,7 @@ export default class QualitySummaryPage extends React.Component {
                                         <circle cx="11" cy="11" r="10" className="m-form-field_radio-icon-stroke"></circle>
                                         <circle cx="11" cy="11" r="7" className="m-form-field_radio-icon-fill"></circle>
                                     </svg>
-                                    <div className="m-form-field_radio-text">
+                                    <div className={this.criterionClassNameFor("2", "doesnotmeet", "text")}>
                                         <div><strong>Does not meet</strong></div>
                                         One or more essential components scored “no”
                                     </div>
@@ -293,7 +297,7 @@ export default class QualitySummaryPage extends React.Component {
                                         <circle cx="11" cy="11" r="10" className="m-form-field_radio-icon-stroke"></circle>
                                         <circle cx="11" cy="11" r="7" className="m-form-field_radio-icon-fill"></circle>
                                     </svg>
-                                    <div className="m-form-field_radio-text is-active">
+                                    <div className={this.criterionClassNameFor("3", "exceeds", "text")}>
                                         <div><strong>Exceeds</strong></div>
                                         All essential components scored “yes”<br />
                                         At least one beneficial component scored “yes”
@@ -310,7 +314,7 @@ export default class QualitySummaryPage extends React.Component {
                                         <circle cx="11" cy="11" r="10" className="m-form-field_radio-icon-stroke"></circle>
                                         <circle cx="11" cy="11" r="7" className="m-form-field_radio-icon-fill"></circle>
                                     </svg>
-                                    <div className="m-form-field_radio-text">
+                                    <div className={this.criterionClassNameFor("3", "meets", "text")}>
                                         <div><strong>Meets</strong></div>
                                         All essential components scored “yes”<br />
                                         None of the beneficial components scored “yes”
@@ -327,7 +331,7 @@ export default class QualitySummaryPage extends React.Component {
                                         <circle cx="11" cy="11" r="10" className="m-form-field_radio-icon-stroke"></circle>
                                         <circle cx="11" cy="11" r="7" className="m-form-field_radio-icon-fill"></circle>
                                     </svg>
-                                    <div className="m-form-field_radio-text">
+                                    <div className={this.criterionClassNameFor("3", "doesnotmeet", "text")}>
                                         <div><strong>Does not meet</strong></div>
                                         One or more essential components scored “no”
                                     </div>
@@ -390,7 +394,7 @@ export default class QualitySummaryPage extends React.Component {
                                         <circle cx="11" cy="11" r="10" className="m-form-field_radio-icon-stroke"></circle>
                                         <circle cx="11" cy="11" r="7" className="m-form-field_radio-icon-fill"></circle>
                                     </svg>
-                                    <div className="m-form-field_radio-text is-active">
+                                    <div className={this.criterionClassNameFor("4", "meets", "text")}>
                                         <div><strong>Meets</strong></div>
                                         All essential components scored “yes”
                                     </div>
@@ -406,7 +410,7 @@ export default class QualitySummaryPage extends React.Component {
                                         <circle cx="11" cy="11" r="10" className="m-form-field_radio-icon-stroke"></circle>
                                         <circle cx="11" cy="11" r="7" className="m-form-field_radio-icon-fill"></circle>
                                     </svg>
-                                    <div className="m-form-field_radio-text">
+                                    <div className={this.criterionClassNameFor("4", "doesnotmeet", "text")}>
                                         <div><strong>Does not meet</strong></div>
                                         One or more essential components scored “no”
                                     </div>
@@ -462,7 +466,7 @@ export default class QualitySummaryPage extends React.Component {
                                         <circle cx="11" cy="11" r="10" className="m-form-field_radio-icon-stroke"></circle>
                                         <circle cx="11" cy="11" r="7" className="m-form-field_radio-icon-fill"></circle>
                                     </svg>
-                                    <div className="m-form-field_radio-text">
+                                    <div className={this.criterionOveralScoreClassName("strong", "text")}>
                                         <div><strong>Strong utility</strong></div>
                                         All 4 criteria were met, and at least one was exceeded
                                     </div>
@@ -478,7 +482,7 @@ export default class QualitySummaryPage extends React.Component {
                                         <circle cx="11" cy="11" r="10" className="m-form-field_radio-icon-stroke"></circle>
                                         <circle cx="11" cy="11" r="7" className="m-form-field_radio-icon-fill"></circle>
                                     </svg>
-                                    <div className="m-form-field_radio-text is-active">
+                                    <div className={this.criterionOveralScoreClassName("moderate", "text")}>
                                         <div><strong>Moderate utility</strong></div>
                                         All 4 criteria were met
                                     </div>
@@ -494,7 +498,7 @@ export default class QualitySummaryPage extends React.Component {
                                         <circle cx="11" cy="11" r="10" className="m-form-field_radio-icon-stroke"></circle>
                                         <circle cx="11" cy="11" r="7" className="m-form-field_radio-icon-fill"></circle>
                                     </svg>
-                                    <div className="m-form-field_radio-text">
+                                    <div className={this.criterionOveralScoreClassName("limited", "text")}>
                                         <div><strong>Limited utility</strong></div>
                                         At least one of the criteria was not met
                                     </div>

--- a/teachers_digital_platform/crtool/src/js/components/pages/QualitySummaryPage.js
+++ b/teachers_digital_platform/crtool/src/js/components/pages/QualitySummaryPage.js
@@ -100,7 +100,7 @@ export default class QualitySummaryPage extends React.Component {
                                 u-mb45
                                 u-mt30" />
                 <div className="l-survey-top">
-                <button className="a-btn a-btn__link" onClick={(e) => {this.props.setDistinctiveBackToInProgress(C.QUALITY_PAGE);}}>
+                    <button className="a-btn a-btn__link" onClick={(e) => {this.props.setDistinctiveBackToInProgress(C.QUALITY_PAGE);}}>
                         <SvgIcon
                             icon="pencil"
                             islarge="true"
@@ -196,6 +196,15 @@ export default class QualitySummaryPage extends React.Component {
                 <hr className="hr
                                 u-mb45
                                 u-mt30" />
+                <div className="l-survey-top">
+                    <button className="a-btn a-btn__link" onClick={(e) => {this.props.setDistinctiveBackToInProgress(C.QUALITY_PAGE);}}>
+                        <SvgIcon
+                            icon="pencil"
+                            islarge="true"
+                            hasSpaceAfter="true" />
+                        View or edit responses
+                    </button>
+                </div>
                 <h3 className="h2">Criterion 2: Accuracy and timeliness</h3>
                 <p className="u-mb30">Curriculum materials are current and free of errors.</p>
                 <div className="m-curriculum-status">
@@ -261,6 +270,15 @@ export default class QualitySummaryPage extends React.Component {
                 <hr className="hr
                                 u-mb45
                                 u-mt30" />
+                <div className="l-survey-top">
+                    <button className="a-btn a-btn__link" onClick={(e) => {this.props.setDistinctiveBackToInProgress(C.QUALITY_PAGE);}}>
+                        <SvgIcon
+                            icon="pencil"
+                            islarge="true"
+                            hasSpaceAfter="true" />
+                        View or edit responses
+                    </button>
+                </div>
                 <h3 className="h2">Criterion 3: Objectivity</h3>
                 <p className="u-mb30">Curriculum materials are objective.</p>
                 <div className="m-curriculum-status">
@@ -349,6 +367,15 @@ export default class QualitySummaryPage extends React.Component {
                 <hr className="hr
                                 u-mb45
                                 u-mt30" />
+                <div className="l-survey-top">
+                    <button className="a-btn a-btn__link" onClick={(e) => {this.props.setDistinctiveBackToInProgress(C.QUALITY_PAGE);}}>
+                        <SvgIcon
+                            icon="pencil"
+                            islarge="true"
+                            hasSpaceAfter="true" />
+                        View or edit responses
+                    </button>
+                </div>
                 <h3 className="h2">Criterion 4: Visual appearance </h3>
                 <p className="u-mb30">The visual appearance of the student materials is conducive to learning.</p>
                 <div className="m-curriculum-status">

--- a/teachers_digital_platform/crtool/src/js/components/pages/UtilitySummaryPage.js
+++ b/teachers_digital_platform/crtool/src/js/components/pages/UtilitySummaryPage.js
@@ -172,6 +172,15 @@ export default class UtilitySummaryPage extends React.Component {
                 <hr className="hr
                                 u-mb45
                                 u-mt30" />
+                <div className="l-survey-top">
+                    <button className="a-btn a-btn__link" onClick={(e) => {this.props.setDistinctiveBackToInProgress(C.UTILITY_PAGE);}}>
+                        <SvgIcon
+                            icon="pencil"
+                            islarge="true"
+                            hasSpaceAfter="true" />
+                        View or edit responses
+                    </button>
+                </div>
                 <h3 className="h2">Criterion 2: Differentiated instruction for diverse populations</h3>
                 <p className="u-mb30">Do materials support engagement among a diverse population of students by providing suggestions to differentiate instruction, exercises, and activities? Consider students’ race, ethnicity, gender, socioeconomic circumstances, special education needs, and English language proficiency.</p>
                 <div className="m-curriculum-status">
@@ -260,6 +269,15 @@ export default class UtilitySummaryPage extends React.Component {
                 <hr className="hr
                                 u-mb45
                                 u-mt30" />
+                <div className="l-survey-top">
+                    <button className="a-btn a-btn__link" onClick={(e) => {this.props.setDistinctiveBackToInProgress(C.UTILITY_PAGE);}}>
+                        <SvgIcon
+                            icon="pencil"
+                            islarge="true"
+                            hasSpaceAfter="true" />
+                        View or edit responses
+                    </button>
+                </div>
                 <h3 className="h2">Criterion 3: Quality materials for lesson planning</h3>
                 <p className="u-mb30">Do materials allow teachers to easily plan and deliver financial education instruction to students and integrate lessons into other subjects?</p>
                 <div className="m-curriculum-status">
@@ -348,7 +366,15 @@ export default class UtilitySummaryPage extends React.Component {
                 <hr className="hr
                                 u-mb45
                                 u-mt30" />
-
+                <div className="l-survey-top">
+                    <button className="a-btn a-btn__link" onClick={(e) => {this.props.setDistinctiveBackToInProgress(C.UTILITY_PAGE);}}>
+                        <SvgIcon
+                            icon="pencil"
+                            islarge="true"
+                            hasSpaceAfter="true" />
+                        View or edit responses
+                    </button>
+                </div>
                 <h3 className="h2">Criterion 4: Materials to assess mastery</h3>
                 <p className="u-mb30">Do materials include a range of formative and summative assessments to support teaching and help teachers assess mastery?</p>
                 <div className="m-curriculum-status">
@@ -437,6 +463,15 @@ export default class UtilitySummaryPage extends React.Component {
                 <hr className="hr
                                 u-mb45
                                 u-mt30" />
+                <div className="l-survey-top">
+                    <button className="a-btn a-btn__link" onClick={(e) => {this.props.setDistinctiveBackToInProgress(C.UTILITY_PAGE);}}>
+                        <SvgIcon
+                            icon="pencil"
+                            islarge="true"
+                            hasSpaceAfter="true" />
+                        View or edit responses
+                    </button>
+                </div>
                 <h3 className="h2">Criterion 5: Instructional supports</h3>
                 <p className="u-mb30">Are curriculum materials instructional for teachers, in terms of helping them provide clear and accurate financial education instruction to students?</p>
                 <div className="m-curriculum-status">

--- a/teachers_digital_platform/crtool/src/js/components/pages/UtilitySummaryPage.js
+++ b/teachers_digital_platform/crtool/src/js/components/pages/UtilitySummaryPage.js
@@ -10,7 +10,7 @@ export default class UtilitySummaryPage extends React.Component {
         this.props.criterionAnswerChanged(C.UTILITY_PAGE, key, checkedValue);
     }
 
-    criterionOveralScoreClassName(level) {
+    criterionOveralScoreClassName(level, type) {
 
         let isLimited = false;
         if (this.props.criterionScores["utility-crt-1"].doesnotmeet ||
@@ -33,6 +33,8 @@ export default class UtilitySummaryPage extends React.Component {
         }
 
         let className = "m-form-field_radio-icon";
+        if (type === "text") className = "m-form-field_radio-text";
+
         if (level === "limited" && isLimited) {
             className = className + " is-active";
         } else if (level === "moderate" && isModerate) {
@@ -44,10 +46,12 @@ export default class UtilitySummaryPage extends React.Component {
         return className;
     }
 
-    criterionClassNameFor(criterion, level) {
+    criterionClassNameFor(criterion, level, type) {
         let criterionGroupName = "utility-crt-" + criterion;
         let criterionScore = this.props.criterionScores[criterionGroupName];
+
         let className = "m-form-field_radio-icon";
+        if (type === "text") className = "m-form-field_radio-text";
 
         if (level === "exceeds" && criterionScore.exceeds) {
             className = className + " is-active";
@@ -121,7 +125,7 @@ export default class UtilitySummaryPage extends React.Component {
                                         <circle cx="11" cy="11" r="10" className="m-form-field_radio-icon-stroke"></circle>
                                         <circle cx="11" cy="11" r="7" className="m-form-field_radio-icon-fill"></circle>
                                     </svg>
-                                    <div className="m-form-field_radio-text is-active">
+                                    <div className={this.criterionClassNameFor("1", "meets", "text")} >
                                         <div><strong>Meets</strong></div>
                                         All essential components scored “yes”
                                     </div>
@@ -137,7 +141,7 @@ export default class UtilitySummaryPage extends React.Component {
                                         <circle cx="11" cy="11" r="10" className="m-form-field_radio-icon-stroke"></circle>
                                         <circle cx="11" cy="11" r="7" className="m-form-field_radio-icon-fill"></circle>
                                     </svg>
-                                    <div className="m-form-field_radio-text">
+                                    <div className={this.criterionClassNameFor("1", "doesnotmeet", "text")} >
                                         <div><strong>Does not meet</strong></div>
                                         One or more essential components scored “no”
                                     </div>
@@ -195,7 +199,7 @@ export default class UtilitySummaryPage extends React.Component {
                                         <circle cx="11" cy="11" r="10" className="m-form-field_radio-icon-stroke"></circle>
                                         <circle cx="11" cy="11" r="7" className="m-form-field_radio-icon-fill"></circle>
                                     </svg>
-                                    <div className="m-form-field_radio-text is-active">
+                                    <div className={this.criterionClassNameFor("2", "exceeds", "text")} >
                                         <div><strong>Exceeds</strong></div>
                                         All essential components scored “yes”<br />
                                         At least one beneficial component scored “yes”
@@ -212,7 +216,7 @@ export default class UtilitySummaryPage extends React.Component {
                                         <circle cx="11" cy="11" r="10" className="m-form-field_radio-icon-stroke"></circle>
                                         <circle cx="11" cy="11" r="7" className="m-form-field_radio-icon-fill"></circle>
                                     </svg>
-                                    <div className="m-form-field_radio-text">
+                                    <div className={this.criterionClassNameFor("2", "meets", "text")} >
                                         <div><strong>Meets</strong></div>
                                         All essential components scored “yes”<br />
                                         None of the beneficial components scored “yes”
@@ -229,7 +233,7 @@ export default class UtilitySummaryPage extends React.Component {
                                         <circle cx="11" cy="11" r="10" className="m-form-field_radio-icon-stroke"></circle>
                                         <circle cx="11" cy="11" r="7" className="m-form-field_radio-icon-fill"></circle>
                                     </svg>
-                                    <div className="m-form-field_radio-text">
+                                    <div className={this.criterionClassNameFor("2", "doesnotmeet", "text")} >
                                         <div><strong>Does not meet</strong></div>
                                         One or more essential components scored “no”
                                     </div>
@@ -292,7 +296,7 @@ export default class UtilitySummaryPage extends React.Component {
                                         <circle cx="11" cy="11" r="10" className="m-form-field_radio-icon-stroke"></circle>
                                         <circle cx="11" cy="11" r="7" className="m-form-field_radio-icon-fill"></circle>
                                     </svg>
-                                    <div className="m-form-field_radio-text is-active">
+                                    <div className={this.criterionClassNameFor("3", "exceeds", "text")} >
                                         <div><strong>Exceeds</strong></div>
                                         All essential components scored “yes”<br />
                                         At least one beneficial component scored “yes”
@@ -309,7 +313,7 @@ export default class UtilitySummaryPage extends React.Component {
                                         <circle cx="11" cy="11" r="10" className="m-form-field_radio-icon-stroke"></circle>
                                         <circle cx="11" cy="11" r="7" className="m-form-field_radio-icon-fill"></circle>
                                     </svg>
-                                    <div className="m-form-field_radio-text">
+                                    <div className={this.criterionClassNameFor("3", "meets", "text")} >
                                         <div><strong>Meets</strong></div>
                                         All essential components scored “yes”<br />
                                         None of the beneficial components scored “yes”
@@ -326,7 +330,7 @@ export default class UtilitySummaryPage extends React.Component {
                                         <circle cx="11" cy="11" r="10" className="m-form-field_radio-icon-stroke"></circle>
                                         <circle cx="11" cy="11" r="7" className="m-form-field_radio-icon-fill"></circle>
                                     </svg>
-                                    <div className="m-form-field_radio-text">
+                                    <div className={this.criterionClassNameFor("3", "doesnotmeet", "text")} >
                                         <div><strong>Does not meet</strong></div>
                                         One or more essential components scored “no”
                                     </div>
@@ -389,7 +393,7 @@ export default class UtilitySummaryPage extends React.Component {
                                         <circle cx="11" cy="11" r="10" className="m-form-field_radio-icon-stroke"></circle>
                                         <circle cx="11" cy="11" r="7" className="m-form-field_radio-icon-fill"></circle>
                                     </svg>
-                                    <div className="m-form-field_radio-text is-active">
+                                    <div className={this.criterionClassNameFor("4", "exceeds", "text")} >
                                         <div><strong>Exceeds</strong></div>
                                         All essential components scored “yes”<br />
                                         At least one beneficial component scored “yes”
@@ -406,7 +410,7 @@ export default class UtilitySummaryPage extends React.Component {
                                         <circle cx="11" cy="11" r="10" className="m-form-field_radio-icon-stroke"></circle>
                                         <circle cx="11" cy="11" r="7" className="m-form-field_radio-icon-fill"></circle>
                                     </svg>
-                                    <div className="m-form-field_radio-text">
+                                    <div className={this.criterionClassNameFor("4", "meets", "text")} >
                                         <div><strong>Meets</strong></div>
                                         All essential components scored “yes”<br />
                                         None of the beneficial components scored “yes”
@@ -423,7 +427,7 @@ export default class UtilitySummaryPage extends React.Component {
                                         <circle cx="11" cy="11" r="10" className="m-form-field_radio-icon-stroke"></circle>
                                         <circle cx="11" cy="11" r="7" className="m-form-field_radio-icon-fill"></circle>
                                     </svg>
-                                    <div className="m-form-field_radio-text">
+                                    <div className={this.criterionClassNameFor("4", "doesnotmeet", "text")} >
                                         <div><strong>Does not meet</strong></div>
                                         One or more essential components scored “no”
                                     </div>
@@ -486,7 +490,7 @@ export default class UtilitySummaryPage extends React.Component {
                                         <circle cx="11" cy="11" r="10" className="m-form-field_radio-icon-stroke"></circle>
                                         <circle cx="11" cy="11" r="7" className="m-form-field_radio-icon-fill"></circle>
                                     </svg>
-                                    <div className="m-form-field_radio-text is-active">
+                                    <div className={this.criterionClassNameFor("5", "exceeds", "text")} >
                                         <div><strong>Exceeds</strong></div>
                                         All essential components scored “yes”<br />
                                         At least one beneficial component scored “yes”
@@ -503,7 +507,7 @@ export default class UtilitySummaryPage extends React.Component {
                                         <circle cx="11" cy="11" r="10" className="m-form-field_radio-icon-stroke"></circle>
                                         <circle cx="11" cy="11" r="7" className="m-form-field_radio-icon-fill"></circle>
                                     </svg>
-                                    <div className="m-form-field_radio-text">
+                                    <div className={this.criterionClassNameFor("5", "meets", "text")} >
                                         <div><strong>Meets</strong></div>
                                         All essential components scored “yes”<br />
                                         None of the beneficial components scored “yes”
@@ -520,7 +524,7 @@ export default class UtilitySummaryPage extends React.Component {
                                         <circle cx="11" cy="11" r="10" className="m-form-field_radio-icon-stroke"></circle>
                                         <circle cx="11" cy="11" r="7" className="m-form-field_radio-icon-fill"></circle>
                                     </svg>
-                                    <div className="m-form-field_radio-text">
+                                    <div className={this.criterionClassNameFor("5", "doesnotmeet", "text")} >
                                         <div><strong>Does not meet</strong></div>
                                         One or more essential components scored “no”
                                     </div>
@@ -581,7 +585,7 @@ export default class UtilitySummaryPage extends React.Component {
                                         <circle cx="11" cy="11" r="10" className="m-form-field_radio-icon-stroke"></circle>
                                         <circle cx="11" cy="11" r="7" className="m-form-field_radio-icon-fill"></circle>
                                     </svg>
-                                    <div className="m-form-field_radio-text">
+                                    <div className={this.criterionOveralScoreClassName("strong", "text")} >
                                         <div><strong>Strong utility</strong></div>
                                         All 5 criteria were met, and at least one was exceeded
                                     </div>
@@ -597,7 +601,7 @@ export default class UtilitySummaryPage extends React.Component {
                                         <circle cx="11" cy="11" r="10" className="m-form-field_radio-icon-stroke"></circle>
                                         <circle cx="11" cy="11" r="7" className="m-form-field_radio-icon-fill"></circle>
                                     </svg>
-                                    <div className="m-form-field_radio-text is-active">
+                                    <div className={this.criterionOveralScoreClassName("moderate", "text")} >
                                         <div><strong>Moderate utility</strong></div>
                                         All 5 criteria were met
                                     </div>
@@ -613,7 +617,7 @@ export default class UtilitySummaryPage extends React.Component {
                                         <circle cx="11" cy="11" r="10" className="m-form-field_radio-icon-stroke"></circle>
                                         <circle cx="11" cy="11" r="7" className="m-form-field_radio-icon-fill"></circle>
                                     </svg>
-                                    <div className="m-form-field_radio-text">
+                                    <div className={this.criterionOveralScoreClassName("limited", "text")} >
                                         <div><strong>Limited utility</strong></div>
                                         At least one of the criteria was not met
                                     </div>

--- a/teachers_digital_platform/crtool/src/js/components/pages/content/ContentElementarySummaryPage.js
+++ b/teachers_digital_platform/crtool/src/js/components/pages/content/ContentElementarySummaryPage.js
@@ -192,6 +192,15 @@ export default class ContentElementarySummaryPage extends React.Component {
                 <hr className="hr
                                 u-mb45
                                 u-mt30" />
+                <div className="l-survey-top">
+                <button class="a-btn a-btn__link" onClick={(e) => {this.props.setDistinctiveBackToInProgress(C.CONTENT_PAGE);}}>
+                    <SvgIcon
+                        icon="pencil"
+                        islarge="true"
+                        hasSpaceAfter="true" />
+                    View or edit responses
+                </button>
+                </div>
                 <h3 className="h2">Criterion 2: Saving and investing</h3>
                 <p className="u-mb30">The curriculum addresses grade-level appropriate topics for saving and investing.</p>
                 <div className="m-curriculum-status">
@@ -273,6 +282,15 @@ export default class ContentElementarySummaryPage extends React.Component {
                 <hr className="hr
                                 u-mb45
                                 u-mt30" />
+                <div className="l-survey-top">
+                <button class="a-btn a-btn__link" onClick={(e) => {this.props.setDistinctiveBackToInProgress(C.CONTENT_PAGE);}}>
+                    <SvgIcon
+                        icon="pencil"
+                        islarge="true"
+                        hasSpaceAfter="true" />
+                    View or edit responses
+                </button>
+                </div>
                 <h3 className="h2">Criterion 3: Spending</h3>
                 <p className="u-mb30">The curriculum addresses grade-level appropriate topics for spending.</p>
                 <div className="m-curriculum-status">
@@ -354,6 +372,15 @@ export default class ContentElementarySummaryPage extends React.Component {
                 <hr className="hr
                                 u-mb45
                                 u-mt30" />
+                <div className="l-survey-top">
+                <button class="a-btn a-btn__link" onClick={(e) => {this.props.setDistinctiveBackToInProgress(C.CONTENT_PAGE);}}>
+                    <SvgIcon
+                        icon="pencil"
+                        islarge="true"
+                        hasSpaceAfter="true" />
+                    View or edit responses
+                </button>
+                </div>
                 <h3 className="h2">Criterion 4: Borrowing and credit</h3>
                 <p className="u-mb30">The curriculum addresses grade-level appropriate topics for borrowing and credit.</p>
                 <div className="m-curriculum-status">
@@ -435,6 +462,15 @@ export default class ContentElementarySummaryPage extends React.Component {
                 <hr className="hr
                                 u-mb45
                                 u-mt30" />
+                <div className="l-survey-top">
+                <button class="a-btn a-btn__link" onClick={(e) => {this.props.setDistinctiveBackToInProgress(C.CONTENT_PAGE);}}>
+                    <SvgIcon
+                        icon="pencil"
+                        islarge="true"
+                        hasSpaceAfter="true" />
+                    View or edit responses
+                </button>
+                </div>
                 <h3 className="h2">Criterion 5: Managing financial risk</h3>
                 <p className="u-mb30">The curriculum addresses grade-level appropriate topics for managing potential financial risk, including insurance.</p>
                 <div className="m-curriculum-status">
@@ -516,6 +552,15 @@ export default class ContentElementarySummaryPage extends React.Component {
                 <hr className="hr
                                 u-mb45
                                 u-mt30" />
+                <div className="l-survey-top">
+                <button class="a-btn a-btn__link" onClick={(e) => {this.props.setDistinctiveBackToInProgress(C.CONTENT_PAGE);}}>
+                    <SvgIcon
+                        icon="pencil"
+                        islarge="true"
+                        hasSpaceAfter="true" />
+                    View or edit responses
+                </button>
+                </div>
                 <h3 className="h2">Criterion 6: Financial responsibility and money management</h3>
                 <p className="u-mb30">The curriculum addresses grade-level appropriate topics for financial responsibility, money management, and financial decisions.</p>
                 <div className="m-curriculum-status">

--- a/teachers_digital_platform/crtool/src/js/components/pages/content/ContentElementarySummaryPage.js
+++ b/teachers_digital_platform/crtool/src/js/components/pages/content/ContentElementarySummaryPage.js
@@ -10,7 +10,7 @@ export default class ContentElementarySummaryPage extends React.Component {
         this.props.criterionAnswerChanged(C.CONTENT_PAGE, key, checkedValue);
     }
 
-    criterionOveralScoreClassName(level) {
+    criterionOveralScoreClassName(level, type) {
         let isLimited = false;
         if (this.props.criterionScores["content-elementary-crt-1"].doesnotmeet ||
             this.props.criterionScores["content-elementary-crt-2"].doesnotmeet ||
@@ -34,6 +34,8 @@ export default class ContentElementarySummaryPage extends React.Component {
         }
 
         let className = "m-form-field_radio-icon";
+        if (type === "text") className = "m-form-field_radio-text";
+
         if (level === "limited" && isLimited) {
             className = className + " is-active";
         } else if (level === "moderate" && isModerate) {
@@ -45,10 +47,12 @@ export default class ContentElementarySummaryPage extends React.Component {
         return className;
     }
 
-    criterionClassNameFor(criterion, level) {
+    criterionClassNameFor(criterion, level, type) {
         let criterionGroupName = "content-elementary-crt-" + criterion;
         let criterionScore = this.props.criterionScores[criterionGroupName];
+
         let className = "m-form-field_radio-icon";
+        if (type === "text") className = "m-form-field_radio-text";
 
         if (level === "exceeds" && criterionScore.exceeds) {
             className = className + " is-active";
@@ -125,7 +129,7 @@ export default class ContentElementarySummaryPage extends React.Component {
                                         <circle cx="11" cy="11" r="10" className="m-form-field_radio-icon-stroke"></circle>
                                         <circle cx="11" cy="11" r="7" className="m-form-field_radio-icon-fill"></circle>
                                     </svg>
-                                    <div className="m-form-field_radio-text is-active">
+                                    <div className={this.criterionClassNameFor("1", "exceeds", "text")} >
                                         <div><strong>Exceeds</strong></div>
                                         Both components were addressed
                                     </div>
@@ -141,7 +145,7 @@ export default class ContentElementarySummaryPage extends React.Component {
                                         <circle cx="11" cy="11" r="10" className="m-form-field_radio-icon-stroke"></circle>
                                         <circle cx="11" cy="11" r="7" className="m-form-field_radio-icon-fill"></circle>
                                     </svg>
-                                    <div className="m-form-field_radio-text">
+                                    <div className={this.criterionClassNameFor("1", "meets", "text")} >
                                         <div><strong>Meets</strong></div>
                                         1 component was addressed
                                     </div>
@@ -157,7 +161,7 @@ export default class ContentElementarySummaryPage extends React.Component {
                                         <circle cx="11" cy="11" r="10" className="m-form-field_radio-icon-stroke"></circle>
                                         <circle cx="11" cy="11" r="7" className="m-form-field_radio-icon-fill"></circle>
                                     </svg>
-                                    <div className="m-form-field_radio-text">
+                                    <div className={this.criterionClassNameFor("1", "doesnotmeet", "text")} >
                                         <div><strong>Does not meet</strong></div>
                                         0 components were addressed
                                     </div>
@@ -215,7 +219,7 @@ export default class ContentElementarySummaryPage extends React.Component {
                                         <circle cx="11" cy="11" r="10" className="m-form-field_radio-icon-stroke"></circle>
                                         <circle cx="11" cy="11" r="7" className="m-form-field_radio-icon-fill"></circle>
                                     </svg>
-                                    <div className="m-form-field_radio-text is-active">
+                                    <div className={this.criterionClassNameFor("2", "exceeds", "text")} >
                                         <div><strong>Exceeds</strong></div>
                                         All 4 components were addressed
                                     </div>
@@ -231,7 +235,7 @@ export default class ContentElementarySummaryPage extends React.Component {
                                         <circle cx="11" cy="11" r="10" className="m-form-field_radio-icon-stroke"></circle>
                                         <circle cx="11" cy="11" r="7" className="m-form-field_radio-icon-fill"></circle>
                                     </svg>
-                                    <div className="m-form-field_radio-text">
+                                    <div className={this.criterionClassNameFor("2", "meets", "text")} >
                                         <div><strong>Meets</strong></div>
                                         3 components were addressed
                                     </div>
@@ -247,7 +251,7 @@ export default class ContentElementarySummaryPage extends React.Component {
                                         <circle cx="11" cy="11" r="10" className="m-form-field_radio-icon-stroke"></circle>
                                         <circle cx="11" cy="11" r="7" className="m-form-field_radio-icon-fill"></circle>
                                     </svg>
-                                    <div className="m-form-field_radio-text">
+                                    <div className={this.criterionClassNameFor("2", "doesnotmeet", "text")} >
                                         <div><strong>Does not meet</strong></div>
                                         Less than 3 components were addressed
                                     </div>
@@ -305,7 +309,7 @@ export default class ContentElementarySummaryPage extends React.Component {
                                         <circle cx="11" cy="11" r="10" className="m-form-field_radio-icon-stroke"></circle>
                                         <circle cx="11" cy="11" r="7" className="m-form-field_radio-icon-fill"></circle>
                                     </svg>
-                                    <div className="m-form-field_radio-text is-active">
+                                    <div className={this.criterionClassNameFor("3", "exceeds", "text")} >
                                         <div><strong>Exceeds</strong></div>
                                         5 or more components were addressed
                                     </div>
@@ -321,7 +325,7 @@ export default class ContentElementarySummaryPage extends React.Component {
                                         <circle cx="11" cy="11" r="10" className="m-form-field_radio-icon-stroke"></circle>
                                         <circle cx="11" cy="11" r="7" className="m-form-field_radio-icon-fill"></circle>
                                     </svg>
-                                    <div className="m-form-field_radio-text">
+                                    <div className={this.criterionClassNameFor("3", "meets", "text")} >
                                         <div><strong>Meets</strong></div>
                                         4 components were addressed
                                     </div>
@@ -337,7 +341,7 @@ export default class ContentElementarySummaryPage extends React.Component {
                                         <circle cx="11" cy="11" r="10" className="m-form-field_radio-icon-stroke"></circle>
                                         <circle cx="11" cy="11" r="7" className="m-form-field_radio-icon-fill"></circle>
                                     </svg>
-                                    <div className="m-form-field_radio-text">
+                                    <div className={this.criterionClassNameFor("3", "doesnotmeet", "text")} >
                                         <div><strong>Does not meet</strong></div>
                                         Less than 4 components were addressed
                                     </div>
@@ -391,11 +395,11 @@ export default class ContentElementarySummaryPage extends React.Component {
                                             m-form-field__radio
                                             m-form-field__display">
                                 <div className="a-label">
-                                    <svg className={this.criterionClassNameFor("4", "exceeds")}  viewBox="0 0 22 22">
+                                    <svg className={this.criterionClassNameFor("4", "exceeds")} viewBox="0 0 22 22">
                                         <circle cx="11" cy="11" r="10" className="m-form-field_radio-icon-stroke"></circle>
                                         <circle cx="11" cy="11" r="7" className="m-form-field_radio-icon-fill"></circle>
                                     </svg>
-                                    <div className="m-form-field_radio-text is-active">
+                                    <div className={this.criterionClassNameFor("4", "exceeds", "text")} >
                                         <div><strong>Exceeds</strong></div>
                                         Both components were addressed
                                     </div>
@@ -411,7 +415,7 @@ export default class ContentElementarySummaryPage extends React.Component {
                                         <circle cx="11" cy="11" r="10" className="m-form-field_radio-icon-stroke"></circle>
                                         <circle cx="11" cy="11" r="7" className="m-form-field_radio-icon-fill"></circle>
                                     </svg>
-                                    <div className="m-form-field_radio-text">
+                                    <div className={this.criterionClassNameFor("4", "meets", "text")} >
                                         <div><strong>Meets</strong></div>
                                         1 component was addressed
                                     </div>
@@ -427,7 +431,7 @@ export default class ContentElementarySummaryPage extends React.Component {
                                         <circle cx="11" cy="11" r="10" className="m-form-field_radio-icon-stroke"></circle>
                                         <circle cx="11" cy="11" r="7" className="m-form-field_radio-icon-fill"></circle>
                                     </svg>
-                                    <div className="m-form-field_radio-text">
+                                    <div className={this.criterionClassNameFor("4", "doesnotmeet", "text")} >
                                         <div><strong>Does not meet</strong></div>
                                         0 components were addressed
                                     </div>
@@ -485,7 +489,7 @@ export default class ContentElementarySummaryPage extends React.Component {
                                         <circle cx="11" cy="11" r="10" className="m-form-field_radio-icon-stroke"></circle>
                                         <circle cx="11" cy="11" r="7" className="m-form-field_radio-icon-fill"></circle>
                                     </svg>
-                                    <div className="m-form-field_radio-text is-active">
+                                    <div className={this.criterionClassNameFor("5", "exceeds", "text")} >
                                         <div><strong>Exceeds</strong></div>
                                         Both components were addressed
                                     </div>
@@ -501,7 +505,7 @@ export default class ContentElementarySummaryPage extends React.Component {
                                         <circle cx="11" cy="11" r="10" className="m-form-field_radio-icon-stroke"></circle>
                                         <circle cx="11" cy="11" r="7" className="m-form-field_radio-icon-fill"></circle>
                                     </svg>
-                                    <div className="m-form-field_radio-text">
+                                    <div className={this.criterionClassNameFor("5", "meets", "text")} >
                                         <div><strong>Meets</strong></div>
                                         1 component was addressed
                                     </div>
@@ -517,7 +521,7 @@ export default class ContentElementarySummaryPage extends React.Component {
                                         <circle cx="11" cy="11" r="10" className="m-form-field_radio-icon-stroke"></circle>
                                         <circle cx="11" cy="11" r="7" className="m-form-field_radio-icon-fill"></circle>
                                     </svg>
-                                    <div className="m-form-field_radio-text">
+                                    <div className={this.criterionClassNameFor("5", "doesnotmeet", "text")} >
                                         <div><strong>Does not meet</strong></div>
                                         0 components were addressed
                                     </div>
@@ -575,7 +579,7 @@ export default class ContentElementarySummaryPage extends React.Component {
                                         <circle cx="11" cy="11" r="10" className="m-form-field_radio-icon-stroke"></circle>
                                         <circle cx="11" cy="11" r="7" className="m-form-field_radio-icon-fill"></circle>
                                     </svg>
-                                    <div className="m-form-field_radio-text is-active">
+                                    <div className={this.criterionClassNameFor("6", "meets", "text")} >
                                         <div><strong>Meets</strong></div>
                                         1 component was addressed
                                     </div>
@@ -587,11 +591,11 @@ export default class ContentElementarySummaryPage extends React.Component {
                                             m-form-field__radio
                                             m-form-field__display">
                                 <div className="a-label">
-                                    <svg className={this.criterionClassNameFor("5", "doesnotmeet")} viewBox="0 0 22 22">
+                                    <svg className={this.criterionClassNameFor("6", "doesnotmeet")} viewBox="0 0 22 22">
                                         <circle cx="11" cy="11" r="10" className="m-form-field_radio-icon-stroke"></circle>
                                         <circle cx="11" cy="11" r="7" className="m-form-field_radio-icon-fill"></circle>
                                     </svg>
-                                    <div className="m-form-field_radio-text">
+                                    <div className={this.criterionClassNameFor("6", "doesnotmeet", "text")} >
                                         <div><strong>Does not meet</strong></div>
                                         0 components were addressed
                                     </div>
@@ -647,7 +651,7 @@ export default class ContentElementarySummaryPage extends React.Component {
                                         <circle cx="11" cy="11" r="10" className="m-form-field_radio-icon-stroke"></circle>
                                         <circle cx="11" cy="11" r="7" className="m-form-field_radio-icon-fill"></circle>
                                     </svg>
-                                    <div className="m-form-field_radio-text">
+                                    <div className={this.criterionOveralScoreClassName("strong", "text")} >
                                         <div><strong>Strong content</strong></div>
                                         All 6 criteria were met, and at least one was exceeded
                                     </div>
@@ -663,7 +667,7 @@ export default class ContentElementarySummaryPage extends React.Component {
                                         <circle cx="11" cy="11" r="10" className="m-form-field_radio-icon-stroke"></circle>
                                         <circle cx="11" cy="11" r="7" className="m-form-field_radio-icon-fill"></circle>
                                     </svg>
-                                    <div className="m-form-field_radio-text is-active">
+                                    <div className={this.criterionOveralScoreClassName("moderate", "text")} >
                                         <div><strong>Moderate content</strong></div>
                                         All 6 criteria were met
                                     </div>
@@ -679,7 +683,7 @@ export default class ContentElementarySummaryPage extends React.Component {
                                         <circle cx="11" cy="11" r="10" className="m-form-field_radio-icon-stroke"></circle>
                                         <circle cx="11" cy="11" r="7" className="m-form-field_radio-icon-fill"></circle>
                                     </svg>
-                                    <div className="m-form-field_radio-text">
+                                    <div className={this.criterionOveralScoreClassName("limited", "text")} >
                                         <div><strong>Limited content</strong></div>
                                         At least one of the criteria was not met
                                     </div>

--- a/teachers_digital_platform/crtool/src/js/components/pages/content/ContentHighSummaryPage.js
+++ b/teachers_digital_platform/crtool/src/js/components/pages/content/ContentHighSummaryPage.js
@@ -189,6 +189,15 @@ export default class ContentHighSummaryPage extends React.Component {
                 <hr className="hr
                                 u-mb45
                                 u-mt30" />
+                <div className="l-survey-top">
+                <button class="a-btn a-btn__link" onClick={(e) => {this.props.setDistinctiveBackToInProgress(C.CONTENT_PAGE);}}>
+                    <SvgIcon
+                        icon="pencil"
+                        islarge="true"
+                        hasSpaceAfter="true" />
+                    View or edit responses
+                </button>
+                </div>
                 <h3 className="h2">Criterion 2: Saving and investing</h3>
                 <p className="u-mb30">The curriculum addresses grade-level appropriate topics for saving and investing.</p>
                 <div className="m-curriculum-status">
@@ -270,6 +279,15 @@ export default class ContentHighSummaryPage extends React.Component {
                 <hr className="hr
                                 u-mb45
                                 u-mt30" />
+                <div className="l-survey-top">
+                <button class="a-btn a-btn__link" onClick={(e) => {this.props.setDistinctiveBackToInProgress(C.CONTENT_PAGE);}}>
+                    <SvgIcon
+                        icon="pencil"
+                        islarge="true"
+                        hasSpaceAfter="true" />
+                    View or edit responses
+                </button>
+                </div>
                 <h3 className="h2">Criterion 3: Spending</h3>
                 <p className="u-mb30">The curriculum addresses grade-level appropriate topics for spending.</p>
                 <div className="m-curriculum-status">
@@ -351,6 +369,15 @@ export default class ContentHighSummaryPage extends React.Component {
                 <hr className="hr
                                 u-mb45
                                 u-mt30" />
+                <div className="l-survey-top">
+                <button class="a-btn a-btn__link" onClick={(e) => {this.props.setDistinctiveBackToInProgress(C.CONTENT_PAGE);}}>
+                    <SvgIcon
+                        icon="pencil"
+                        islarge="true"
+                        hasSpaceAfter="true" />
+                    View or edit responses
+                </button>
+                </div>
                 <h3 className="h2">Criterion 4: Borrowing and credit</h3>
                 <p className="u-mb30">The curriculum addresses grade-level appropriate topics for borrowing and credit.</p>
                 <div className="m-curriculum-status">
@@ -432,6 +459,15 @@ export default class ContentHighSummaryPage extends React.Component {
                 <hr className="hr
                                 u-mb45
                                 u-mt30" />
+                <div className="l-survey-top">
+                <button class="a-btn a-btn__link" onClick={(e) => {this.props.setDistinctiveBackToInProgress(C.CONTENT_PAGE);}}>
+                    <SvgIcon
+                        icon="pencil"
+                        islarge="true"
+                        hasSpaceAfter="true" />
+                    View or edit responses
+                </button>
+                </div>
                 <h3 className="h2">Criterion 5: Managing financial risk</h3>
                 <p className="u-mb30">The curriculum addresses grade-level appropriate topics for managing potential financial risk, including insurance.</p>
                 <div className="m-curriculum-status">
@@ -513,6 +549,15 @@ export default class ContentHighSummaryPage extends React.Component {
                 <hr className="hr
                                 u-mb45
                                 u-mt30" />
+                <div className="l-survey-top">
+                <button class="a-btn a-btn__link" onClick={(e) => {this.props.setDistinctiveBackToInProgress(C.CONTENT_PAGE);}}>
+                    <SvgIcon
+                        icon="pencil"
+                        islarge="true"
+                        hasSpaceAfter="true" />
+                    View or edit responses
+                </button>
+                </div>
                 <h3 className="h2">Criterion 6: Financial responsibility and money management</h3>
                 <p className="u-mb30">The curriculum addresses grade-level appropriate topics for financial responsibility, money management, and financial decisions.</p>
                 <div className="m-curriculum-status">

--- a/teachers_digital_platform/crtool/src/js/components/pages/content/ContentHighSummaryPage.js
+++ b/teachers_digital_platform/crtool/src/js/components/pages/content/ContentHighSummaryPage.js
@@ -10,7 +10,7 @@ export default class ContentHighSummaryPage extends React.Component {
         this.props.criterionAnswerChanged(C.CONTENT_PAGE, key, checkedValue);
     }
 
-    criterionOveralScoreClassName(level) {
+    criterionOveralScoreClassName(level, type) {
         let isLimited = false;
         if (this.props.criterionScores["content-high-crt-1"].doesnotmeet ||
             this.props.criterionScores["content-high-crt-2"].doesnotmeet ||
@@ -34,6 +34,8 @@ export default class ContentHighSummaryPage extends React.Component {
         }
 
         let className = "m-form-field_radio-icon";
+        if (type === "text") className = "m-form-field_radio-text";
+
         if (level === "limited" && isLimited) {
             className = className + " is-active";
         } else if (level === "moderate" && isModerate) {
@@ -45,10 +47,12 @@ export default class ContentHighSummaryPage extends React.Component {
         return className;
     }
 
-    criterionClassNameFor(criterion, level) {
+    criterionClassNameFor(criterion, level, type) {
         let criterionGroupName = "content-high-crt-" + criterion;
         let criterionScore = this.props.criterionScores[criterionGroupName];
+
         let className = "m-form-field_radio-icon";
+        if (type === "text") className = "m-form-field_radio-text";
 
         if (level === "exceeds" && criterionScore.exceeds) {
             className = className + " is-active";
@@ -122,7 +126,7 @@ export default class ContentHighSummaryPage extends React.Component {
                                         <circle cx="11" cy="11" r="10" className="m-form-field_radio-icon-stroke"></circle>
                                         <circle cx="11" cy="11" r="7" className="m-form-field_radio-icon-fill"></circle>
                                     </svg>
-                                    <div className="m-form-field_radio-text is-active">
+                                    <div className={this.criterionClassNameFor("1", "exceeds", "text")} >
                                         <div><strong>Exceeds</strong></div>
                                         All 3 components were addressed
                                     </div>
@@ -138,7 +142,7 @@ export default class ContentHighSummaryPage extends React.Component {
                                         <circle cx="11" cy="11" r="10" className="m-form-field_radio-icon-stroke"></circle>
                                         <circle cx="11" cy="11" r="7" className="m-form-field_radio-icon-fill"></circle>
                                     </svg>
-                                    <div className="m-form-field_radio-text">
+                                    <div className={this.criterionClassNameFor("1", "meets", "text")} >
                                         <div><strong>Meets</strong></div>
                                         2 components were addressed
                                     </div>
@@ -154,7 +158,7 @@ export default class ContentHighSummaryPage extends React.Component {
                                         <circle cx="11" cy="11" r="10" className="m-form-field_radio-icon-stroke"></circle>
                                         <circle cx="11" cy="11" r="7" className="m-form-field_radio-icon-fill"></circle>
                                     </svg>
-                                    <div className="m-form-field_radio-text">
+                                    <div className={this.criterionClassNameFor("1", "doesnotmeet", "text")} >
                                         <div><strong>Does not meet</strong></div>
                                         Less than 2 components were addressed
                                     </div>
@@ -212,7 +216,7 @@ export default class ContentHighSummaryPage extends React.Component {
                                         <circle cx="11" cy="11" r="10" className="m-form-field_radio-icon-stroke"></circle>
                                         <circle cx="11" cy="11" r="7" className="m-form-field_radio-icon-fill"></circle>
                                     </svg>
-                                    <div className="m-form-field_radio-text is-active">
+                                    <div className={this.criterionClassNameFor("2", "exceeds", "text")} >
                                         <div><strong>Exceeds</strong></div>
                                         7 or more components were addressed
                                     </div>
@@ -228,7 +232,7 @@ export default class ContentHighSummaryPage extends React.Component {
                                         <circle cx="11" cy="11" r="10" className="m-form-field_radio-icon-stroke"></circle>
                                         <circle cx="11" cy="11" r="7" className="m-form-field_radio-icon-fill"></circle>
                                     </svg>
-                                    <div className="m-form-field_radio-text">
+                                    <div className={this.criterionClassNameFor("2", "meets", "text")} >
                                         <div><strong>Meets</strong></div>
                                         5 or 6 components were addressed
                                     </div>
@@ -244,7 +248,7 @@ export default class ContentHighSummaryPage extends React.Component {
                                         <circle cx="11" cy="11" r="10" className="m-form-field_radio-icon-stroke"></circle>
                                         <circle cx="11" cy="11" r="7" className="m-form-field_radio-icon-fill"></circle>
                                     </svg>
-                                    <div className="m-form-field_radio-text">
+                                    <div className={this.criterionClassNameFor("2", "doesnotmeet", "text")} >
                                         <div><strong>Does not meet</strong></div>
                                         Less than 5 components were addressed
                                     </div>
@@ -302,7 +306,7 @@ export default class ContentHighSummaryPage extends React.Component {
                                         <circle cx="11" cy="11" r="10" className="m-form-field_radio-icon-stroke"></circle>
                                         <circle cx="11" cy="11" r="7" className="m-form-field_radio-icon-fill"></circle>
                                     </svg>
-                                    <div className="m-form-field_radio-text is-active">
+                                    <div className={this.criterionClassNameFor("3", "exceeds", "text")} >
                                         <div><strong>Exceeds</strong></div>
                                         All 5 components were addressed
                                     </div>
@@ -318,7 +322,7 @@ export default class ContentHighSummaryPage extends React.Component {
                                         <circle cx="11" cy="11" r="10" className="m-form-field_radio-icon-stroke"></circle>
                                         <circle cx="11" cy="11" r="7" className="m-form-field_radio-icon-fill"></circle>
                                     </svg>
-                                    <div className="m-form-field_radio-text">
+                                    <div className={this.criterionClassNameFor("3", "meets", "text")} >
                                         <div><strong>Meets</strong></div>
                                         4 components were addressed
                                     </div>
@@ -334,7 +338,7 @@ export default class ContentHighSummaryPage extends React.Component {
                                         <circle cx="11" cy="11" r="10" className="m-form-field_radio-icon-stroke"></circle>
                                         <circle cx="11" cy="11" r="7" className="m-form-field_radio-icon-fill"></circle>
                                     </svg>
-                                    <div className="m-form-field_radio-text">
+                                    <div className={this.criterionClassNameFor("3", "doesnotmeet", "text")} >
                                         <div><strong>Does not meet</strong></div>
                                         Less than 4 components were addressed
                                     </div>
@@ -392,7 +396,7 @@ export default class ContentHighSummaryPage extends React.Component {
                                         <circle cx="11" cy="11" r="10" className="m-form-field_radio-icon-stroke"></circle>
                                         <circle cx="11" cy="11" r="7" className="m-form-field_radio-icon-fill"></circle>
                                     </svg>
-                                    <div className="m-form-field_radio-text is-active">
+                                    <div className={this.criterionClassNameFor("4", "exceeds", "text")} >
                                         <div><strong>Exceeds</strong></div>
                                         6 or more components were addressed
                                     </div>
@@ -408,7 +412,7 @@ export default class ContentHighSummaryPage extends React.Component {
                                         <circle cx="11" cy="11" r="10" className="m-form-field_radio-icon-stroke"></circle>
                                         <circle cx="11" cy="11" r="7" className="m-form-field_radio-icon-fill"></circle>
                                     </svg>
-                                    <div className="m-form-field_radio-text">
+                                    <div className={this.criterionClassNameFor("4", "meets", "text")} >
                                         <div><strong>Meets</strong></div>
                                         5 components were addressed
                                     </div>
@@ -424,7 +428,7 @@ export default class ContentHighSummaryPage extends React.Component {
                                         <circle cx="11" cy="11" r="10" className="m-form-field_radio-icon-stroke"></circle>
                                         <circle cx="11" cy="11" r="7" className="m-form-field_radio-icon-fill"></circle>
                                     </svg>
-                                    <div className="m-form-field_radio-text">
+                                    <div className={this.criterionClassNameFor("4", "doesnotmeet", "text")} >
                                         <div><strong>Does not meet</strong></div>
                                         Less than 5 components were addressed
                                     </div>
@@ -482,7 +486,7 @@ export default class ContentHighSummaryPage extends React.Component {
                                         <circle cx="11" cy="11" r="10" className="m-form-field_radio-icon-stroke"></circle>
                                         <circle cx="11" cy="11" r="7" className="m-form-field_radio-icon-fill"></circle>
                                     </svg>
-                                    <div className="m-form-field_radio-text is-active">
+                                    <div className={this.criterionClassNameFor("5", "exceeds", "text")} >
                                         <div><strong>Exceeds</strong></div>
                                         All 4 components were addressed
                                     </div>
@@ -498,7 +502,7 @@ export default class ContentHighSummaryPage extends React.Component {
                                         <circle cx="11" cy="11" r="10" className="m-form-field_radio-icon-stroke"></circle>
                                         <circle cx="11" cy="11" r="7" className="m-form-field_radio-icon-fill"></circle>
                                     </svg>
-                                    <div className="m-form-field_radio-text">
+                                    <div className={this.criterionClassNameFor("5", "meets", "text")} >
                                         <div><strong>Meets</strong></div>
                                         3 components were addressed
                                     </div>
@@ -514,7 +518,7 @@ export default class ContentHighSummaryPage extends React.Component {
                                         <circle cx="11" cy="11" r="10" className="m-form-field_radio-icon-stroke"></circle>
                                         <circle cx="11" cy="11" r="7" className="m-form-field_radio-icon-fill"></circle>
                                     </svg>
-                                    <div className="m-form-field_radio-text">
+                                    <div className={this.criterionClassNameFor("5", "doesnotmeet", "text")} >
                                         <div><strong>Does not meet</strong></div>
                                         Less than 3 components were addressed
                                     </div>
@@ -572,7 +576,7 @@ export default class ContentHighSummaryPage extends React.Component {
                                         <circle cx="11" cy="11" r="10" className="m-form-field_radio-icon-stroke"></circle>
                                         <circle cx="11" cy="11" r="7" className="m-form-field_radio-icon-fill"></circle>
                                     </svg>
-                                    <div className="m-form-field_radio-text is-active">
+                                    <div className={this.criterionClassNameFor("6", "exceeds", "text")} >
                                         <div><strong>Exceeds</strong></div>
                                         both components were addressed
                                     </div>
@@ -588,7 +592,7 @@ export default class ContentHighSummaryPage extends React.Component {
                                         <circle cx="11" cy="11" r="10" className="m-form-field_radio-icon-stroke"></circle>
                                         <circle cx="11" cy="11" r="7" className="m-form-field_radio-icon-fill"></circle>
                                     </svg>
-                                    <div className="m-form-field_radio-text is-active">
+                                    <div className={this.criterionClassNameFor("6", "meets", "text")} >
                                         <div><strong>Meets</strong></div>
                                         1 components was addressed
                                     </div>
@@ -604,7 +608,7 @@ export default class ContentHighSummaryPage extends React.Component {
                                         <circle cx="11" cy="11" r="10" className="m-form-field_radio-icon-stroke"></circle>
                                         <circle cx="11" cy="11" r="7" className="m-form-field_radio-icon-fill"></circle>
                                     </svg>
-                                    <div className="m-form-field_radio-text">
+                                    <div className={this.criterionClassNameFor("6", "doesnotmeet", "text")} >
                                         <div><strong>Does not meet</strong></div>
                                         0 components were addressed
                                     </div>
@@ -660,7 +664,7 @@ export default class ContentHighSummaryPage extends React.Component {
                                         <circle cx="11" cy="11" r="10" className="m-form-field_radio-icon-stroke"></circle>
                                         <circle cx="11" cy="11" r="7" className="m-form-field_radio-icon-fill"></circle>
                                     </svg>
-                                    <div className="m-form-field_radio-text">
+                                    <div className={this.criterionOveralScoreClassName("strong", "text")} >
                                         <div><strong>Strong content</strong></div>
                                         All 6 criteria were met, and at least one was exceeded
                                     </div>
@@ -676,7 +680,7 @@ export default class ContentHighSummaryPage extends React.Component {
                                         <circle cx="11" cy="11" r="10" className="m-form-field_radio-icon-stroke"></circle>
                                         <circle cx="11" cy="11" r="7" className="m-form-field_radio-icon-fill"></circle>
                                     </svg>
-                                    <div className="m-form-field_radio-text is-active">
+                                    <div className={this.criterionOveralScoreClassName("moderate", "text")} >
                                         <div><strong>Moderate content</strong></div>
                                         All 6 criteria were met
                                     </div>
@@ -692,7 +696,7 @@ export default class ContentHighSummaryPage extends React.Component {
                                         <circle cx="11" cy="11" r="10" className="m-form-field_radio-icon-stroke"></circle>
                                         <circle cx="11" cy="11" r="7" className="m-form-field_radio-icon-fill"></circle>
                                     </svg>
-                                    <div className="m-form-field_radio-text">
+                                    <div className={this.criterionOveralScoreClassName("limited", "text")} >
                                         <div><strong>Limited content</strong></div>
                                         At least one of the criteria was not met
                                     </div>

--- a/teachers_digital_platform/crtool/src/js/components/pages/content/ContentMiddleSummaryPage.js
+++ b/teachers_digital_platform/crtool/src/js/components/pages/content/ContentMiddleSummaryPage.js
@@ -189,6 +189,15 @@ export default class ContentMiddleSummaryPage extends React.Component {
                 <hr className="hr
                                 u-mb45
                                 u-mt30" />
+                                <div className="l-survey-top">
+                <button class="a-btn a-btn__link" onClick={(e) => {this.props.setDistinctiveBackToInProgress(C.CONTENT_PAGE);}}>
+                    <SvgIcon
+                        icon="pencil"
+                        islarge="true"
+                        hasSpaceAfter="true" />
+                    View or edit responses
+                </button>
+                </div>
                 <h3 className="h2">Criterion 2: Saving and investing</h3>
                 <p className="u-mb30">The curriculum addresses grade-level appropriate topics for saving and investing.</p>
                 <div className="m-curriculum-status">
@@ -270,6 +279,15 @@ export default class ContentMiddleSummaryPage extends React.Component {
                 <hr className="hr
                                 u-mb45
                                 u-mt30" />
+                <div className="l-survey-top">
+                <button class="a-btn a-btn__link" onClick={(e) => {this.props.setDistinctiveBackToInProgress(C.CONTENT_PAGE);}}>
+                    <SvgIcon
+                        icon="pencil"
+                        islarge="true"
+                        hasSpaceAfter="true" />
+                    View or edit responses
+                </button>
+                </div>
                 <h3 className="h2">Criterion 3: Spending</h3>
                 <p className="u-mb30">The curriculum addresses grade-level appropriate topics for spending.</p>
                 <div className="m-curriculum-status">
@@ -351,6 +369,15 @@ export default class ContentMiddleSummaryPage extends React.Component {
                 <hr className="hr
                                 u-mb45
                                 u-mt30" />
+                <div className="l-survey-top">
+                <button class="a-btn a-btn__link" onClick={(e) => {this.props.setDistinctiveBackToInProgress(C.CONTENT_PAGE);}}>
+                    <SvgIcon
+                        icon="pencil"
+                        islarge="true"
+                        hasSpaceAfter="true" />
+                    View or edit responses
+                </button>
+                </div>
                 <h3 className="h2">Criterion 4: Borrowing and credit</h3>
                 <p className="u-mb30">The curriculum addresses grade-level appropriate topics for borrowing and credit.</p>
                 <div className="m-curriculum-status">
@@ -432,6 +459,15 @@ export default class ContentMiddleSummaryPage extends React.Component {
                 <hr className="hr
                                 u-mb45
                                 u-mt30" />
+                <div className="l-survey-top">
+                <button class="a-btn a-btn__link" onClick={(e) => {this.props.setDistinctiveBackToInProgress(C.CONTENT_PAGE);}}>
+                    <SvgIcon
+                        icon="pencil"
+                        islarge="true"
+                        hasSpaceAfter="true" />
+                    View or edit responses
+                </button>
+                </div>
                 <h3 className="h2">Criterion 5: Managing financial risk</h3>
                 <p className="u-mb30">The curriculum addresses grade-level appropriate topics for managing potential financial risk, including insurance.</p>
                 <div className="m-curriculum-status">
@@ -513,6 +549,15 @@ export default class ContentMiddleSummaryPage extends React.Component {
                 <hr className="hr
                                 u-mb45
                                 u-mt30" />
+                <div className="l-survey-top">
+                <button class="a-btn a-btn__link" onClick={(e) => {this.props.setDistinctiveBackToInProgress(C.CONTENT_PAGE);}}>
+                    <SvgIcon
+                        icon="pencil"
+                        islarge="true"
+                        hasSpaceAfter="true" />
+                    View or edit responses
+                </button>
+                </div>
                 <h3 className="h2">Criterion 6: Financial responsibility and money management</h3>
                 <p className="u-mb30">The curriculum addresses grade-level appropriate topics for financial responsibility, money management, and financial decisions.</p>
                 <div className="m-curriculum-status">

--- a/teachers_digital_platform/crtool/src/js/components/pages/content/ContentMiddleSummaryPage.js
+++ b/teachers_digital_platform/crtool/src/js/components/pages/content/ContentMiddleSummaryPage.js
@@ -10,7 +10,7 @@ export default class ContentMiddleSummaryPage extends React.Component {
         this.props.criterionAnswerChanged(C.CONTENT_PAGE, key, checkedValue);
     }
 
-    criterionOveralScoreClassName(level) {
+    criterionOveralScoreClassName(level, type) {
         let isLimited = false;
         if (this.props.criterionScores["content-middle-crt-1"].doesnotmeet ||
             this.props.criterionScores["content-middle-crt-2"].doesnotmeet ||
@@ -34,6 +34,8 @@ export default class ContentMiddleSummaryPage extends React.Component {
         }
 
         let className = "m-form-field_radio-icon";
+        if (type === "text") className = "m-form-field_radio-text";
+
         if (level === "limited" && isLimited) {
             className = className + " is-active";
         } else if (level === "moderate" && isModerate) {
@@ -45,10 +47,12 @@ export default class ContentMiddleSummaryPage extends React.Component {
         return className;
     }
 
-    criterionClassNameFor(criterion, level) {
+    criterionClassNameFor(criterion, level, type) {
         let criterionGroupName = "content-middle-crt-" + criterion;
         let criterionScore = this.props.criterionScores[criterionGroupName];
+
         let className = "m-form-field_radio-icon";
+        if (type === "text") className = "m-form-field_radio-text";
 
         if (level === "exceeds" && criterionScore.exceeds) {
             className = className + " is-active";
@@ -122,7 +126,7 @@ export default class ContentMiddleSummaryPage extends React.Component {
                                         <circle cx="11" cy="11" r="10" className="m-form-field_radio-icon-stroke"></circle>
                                         <circle cx="11" cy="11" r="7" className="m-form-field_radio-icon-fill"></circle>
                                     </svg>
-                                    <div className="m-form-field_radio-text is-active">
+                                    <div className={this.criterionClassNameFor("1", "exceeds", "text")} >
                                         <div><strong>Exceeds</strong></div>
                                         All 3 components were addressed
                                     </div>
@@ -138,7 +142,7 @@ export default class ContentMiddleSummaryPage extends React.Component {
                                         <circle cx="11" cy="11" r="10" className="m-form-field_radio-icon-stroke"></circle>
                                         <circle cx="11" cy="11" r="7" className="m-form-field_radio-icon-fill"></circle>
                                     </svg>
-                                    <div className="m-form-field_radio-text">
+                                    <div className={this.criterionClassNameFor("1", "meets", "text")} >
                                         <div><strong>Meets</strong></div>
                                         2 components were addressed
                                     </div>
@@ -154,7 +158,7 @@ export default class ContentMiddleSummaryPage extends React.Component {
                                         <circle cx="11" cy="11" r="10" className="m-form-field_radio-icon-stroke"></circle>
                                         <circle cx="11" cy="11" r="7" className="m-form-field_radio-icon-fill"></circle>
                                     </svg>
-                                    <div className="m-form-field_radio-text">
+                                    <div className={this.criterionClassNameFor("1", "doesnotmeet", "text")} >
                                         <div><strong>Does not meet</strong></div>
                                         2 components were addressed
                                     </div>
@@ -212,7 +216,7 @@ export default class ContentMiddleSummaryPage extends React.Component {
                                         <circle cx="11" cy="11" r="10" className="m-form-field_radio-icon-stroke"></circle>
                                         <circle cx="11" cy="11" r="7" className="m-form-field_radio-icon-fill"></circle>
                                     </svg>
-                                    <div className="m-form-field_radio-text is-active">
+                                    <div className={this.criterionClassNameFor("2", "exceeds", "text")} >
                                         <div><strong>Exceeds</strong></div>
                                         7 or more components were addressed
                                     </div>
@@ -228,7 +232,7 @@ export default class ContentMiddleSummaryPage extends React.Component {
                                         <circle cx="11" cy="11" r="10" className="m-form-field_radio-icon-stroke"></circle>
                                         <circle cx="11" cy="11" r="7" className="m-form-field_radio-icon-fill"></circle>
                                     </svg>
-                                    <div className="m-form-field_radio-text">
+                                    <div className={this.criterionClassNameFor("2", "meets", "text")} >
                                         <div><strong>Meets</strong></div>
                                         5 or 6 components were addressed
                                     </div>
@@ -244,7 +248,7 @@ export default class ContentMiddleSummaryPage extends React.Component {
                                         <circle cx="11" cy="11" r="10" className="m-form-field_radio-icon-stroke"></circle>
                                         <circle cx="11" cy="11" r="7" className="m-form-field_radio-icon-fill"></circle>
                                     </svg>
-                                    <div className="m-form-field_radio-text">
+                                    <div className={this.criterionClassNameFor("2", "doesnotmeet", "text")} >
                                         <div><strong>Does not meet</strong></div>
                                         Less than 5 components were addressed
                                     </div>
@@ -302,7 +306,7 @@ export default class ContentMiddleSummaryPage extends React.Component {
                                         <circle cx="11" cy="11" r="10" className="m-form-field_radio-icon-stroke"></circle>
                                         <circle cx="11" cy="11" r="7" className="m-form-field_radio-icon-fill"></circle>
                                     </svg>
-                                    <div className="m-form-field_radio-text is-active">
+                                    <div className={this.criterionClassNameFor("3", "exceeds", "text")} >
                                         <div><strong>Exceeds</strong></div>
                                         All 5 components were addressed
                                     </div>
@@ -318,7 +322,7 @@ export default class ContentMiddleSummaryPage extends React.Component {
                                         <circle cx="11" cy="11" r="10" className="m-form-field_radio-icon-stroke"></circle>
                                         <circle cx="11" cy="11" r="7" className="m-form-field_radio-icon-fill"></circle>
                                     </svg>
-                                    <div className="m-form-field_radio-text">
+                                    <div className={this.criterionClassNameFor("3", "meets", "text")} >
                                         <div><strong>Meets</strong></div>
                                         4 components were addressed
                                     </div>
@@ -334,7 +338,7 @@ export default class ContentMiddleSummaryPage extends React.Component {
                                         <circle cx="11" cy="11" r="10" className="m-form-field_radio-icon-stroke"></circle>
                                         <circle cx="11" cy="11" r="7" className="m-form-field_radio-icon-fill"></circle>
                                     </svg>
-                                    <div className="m-form-field_radio-text">
+                                    <div className={this.criterionClassNameFor("3", "doesnotmeet", "text")} >
                                         <div><strong>Does not meet</strong></div>
                                         Less than 4 components were addressed
                                     </div>
@@ -392,7 +396,7 @@ export default class ContentMiddleSummaryPage extends React.Component {
                                         <circle cx="11" cy="11" r="10" className="m-form-field_radio-icon-stroke"></circle>
                                         <circle cx="11" cy="11" r="7" className="m-form-field_radio-icon-fill"></circle>
                                     </svg>
-                                    <div className="m-form-field_radio-text is-active">
+                                    <div className={this.criterionClassNameFor("4", "exceeds", "text")} >
                                         <div><strong>Exceeds</strong></div>
                                         6 or more components were addressed
                                     </div>
@@ -408,7 +412,7 @@ export default class ContentMiddleSummaryPage extends React.Component {
                                         <circle cx="11" cy="11" r="10" className="m-form-field_radio-icon-stroke"></circle>
                                         <circle cx="11" cy="11" r="7" className="m-form-field_radio-icon-fill"></circle>
                                     </svg>
-                                    <div className="m-form-field_radio-text">
+                                    <div className={this.criterionClassNameFor("4", "meets", "text")} >
                                         <div><strong>Meets</strong></div>
                                         5 components were addressed
                                     </div>
@@ -424,7 +428,7 @@ export default class ContentMiddleSummaryPage extends React.Component {
                                         <circle cx="11" cy="11" r="10" className="m-form-field_radio-icon-stroke"></circle>
                                         <circle cx="11" cy="11" r="7" className="m-form-field_radio-icon-fill"></circle>
                                     </svg>
-                                    <div className="m-form-field_radio-text">
+                                    <div className={this.criterionClassNameFor("4", "doesnotmeet", "text")} >
                                         <div><strong>Does not meet</strong></div>
                                         Less than 5 components were addressed
                                     </div>
@@ -482,7 +486,7 @@ export default class ContentMiddleSummaryPage extends React.Component {
                                         <circle cx="11" cy="11" r="10" className="m-form-field_radio-icon-stroke"></circle>
                                         <circle cx="11" cy="11" r="7" className="m-form-field_radio-icon-fill"></circle>
                                     </svg>
-                                    <div className="m-form-field_radio-text is-active">
+                                    <div className={this.criterionClassNameFor("5", "exceeds", "text")} >
                                         <div><strong>Exceeds</strong></div>
                                         All 4 components were addressed
                                     </div>
@@ -498,7 +502,7 @@ export default class ContentMiddleSummaryPage extends React.Component {
                                         <circle cx="11" cy="11" r="10" className="m-form-field_radio-icon-stroke"></circle>
                                         <circle cx="11" cy="11" r="7" className="m-form-field_radio-icon-fill"></circle>
                                     </svg>
-                                    <div className="m-form-field_radio-text">
+                                    <div className={this.criterionClassNameFor("5", "meets", "text")} >
                                         <div><strong>Meets</strong></div>
                                         3 components were addressed
                                     </div>
@@ -514,7 +518,7 @@ export default class ContentMiddleSummaryPage extends React.Component {
                                         <circle cx="11" cy="11" r="10" className="m-form-field_radio-icon-stroke"></circle>
                                         <circle cx="11" cy="11" r="7" className="m-form-field_radio-icon-fill"></circle>
                                     </svg>
-                                    <div className="m-form-field_radio-text">
+                                    <div className={this.criterionClassNameFor("5", "doesnotmeet", "text")} >
                                         <div><strong>Does not meet</strong></div>
                                         Less than 3 components were addressed
                                     </div>
@@ -572,7 +576,7 @@ export default class ContentMiddleSummaryPage extends React.Component {
                                         <circle cx="11" cy="11" r="10" className="m-form-field_radio-icon-stroke"></circle>
                                         <circle cx="11" cy="11" r="7" className="m-form-field_radio-icon-fill"></circle>
                                     </svg>
-                                    <div className="m-form-field_radio-text is-active">
+                                    <div className={this.criterionClassNameFor("6", "exceeds", "text")} >
                                         <div><strong>Exceeds</strong></div>
                                         2 component was addressed
                                     </div>
@@ -588,7 +592,7 @@ export default class ContentMiddleSummaryPage extends React.Component {
                                         <circle cx="11" cy="11" r="10" className="m-form-field_radio-icon-stroke"></circle>
                                         <circle cx="11" cy="11" r="7" className="m-form-field_radio-icon-fill"></circle>
                                     </svg>
-                                    <div className="m-form-field_radio-text is-active">
+                                    <div className={this.criterionClassNameFor("6", "meets", "text")} >
                                         <div><strong>Meets</strong></div>
                                         1 component was addressed
                                     </div>
@@ -604,7 +608,7 @@ export default class ContentMiddleSummaryPage extends React.Component {
                                         <circle cx="11" cy="11" r="10" className="m-form-field_radio-icon-stroke"></circle>
                                         <circle cx="11" cy="11" r="7" className="m-form-field_radio-icon-fill"></circle>
                                     </svg>
-                                    <div className="m-form-field_radio-text">
+                                    <div className={this.criterionClassNameFor("6", "doesnotmeet", "text")} >
                                         <div><strong>Does not meet</strong></div>
                                         0 components were addressed
                                     </div>
@@ -660,7 +664,7 @@ export default class ContentMiddleSummaryPage extends React.Component {
                                         <circle cx="11" cy="11" r="10" className="m-form-field_radio-icon-stroke"></circle>
                                         <circle cx="11" cy="11" r="7" className="m-form-field_radio-icon-fill"></circle>
                                     </svg>
-                                    <div className="m-form-field_radio-text is-active">
+                                    <div className={this.criterionOveralScoreClassName("strong", "text")} >
                                         <div><strong>Strong content</strong></div>
                                         All 6 criteria were met, and at least one was exceeded
                                     </div>
@@ -676,7 +680,7 @@ export default class ContentMiddleSummaryPage extends React.Component {
                                         <circle cx="11" cy="11" r="10" className="m-form-field_radio-icon-stroke"></circle>
                                         <circle cx="11" cy="11" r="7" className="m-form-field_radio-icon-fill"></circle>
                                     </svg>
-                                    <div className="m-form-field_radio-text">
+                                    <div className={this.criterionOveralScoreClassName("moderate", "text")} >
                                         <div><strong>Moderate content</strong></div>
                                         All 6 criteria were met
                                     </div>
@@ -692,7 +696,7 @@ export default class ContentMiddleSummaryPage extends React.Component {
                                         <circle cx="11" cy="11" r="10" className="m-form-field_radio-icon-stroke"></circle>
                                         <circle cx="11" cy="11" r="7" className="m-form-field_radio-icon-fill"></circle>
                                     </svg>
-                                    <div className="m-form-field_radio-text">
+                                    <div className={this.criterionOveralScoreClassName("limited", "text")} >
                                         <div><strong>Limited content</strong></div>
                                         At least one of the criteria was not met
                                     </div>


### PR DESCRIPTION
Implemented Efficacy Summary page with stylings and correct calculations.  Also fixed the button enabling on the Efficacy Survey page

## Testing

- Implemented Efficacy Summary page
- Fixed Efficacy Survey page button enablings
  - "I'm done adding studies" always enabled (till you click it)
  - "Continue to Summary" enabled once "I'm done adding studies" is clicked
  - If two strong studies exist when clicking "I'm done adding studies" you see Criterion 2.  If not you see a green warning saying you can continue to summary

## Review

- @dcmouyard 

[Preview this PR without the whitespace changes](?w=0)

