### PR TITLE
Fix content print page

### DIFF
--- a/teachers_digital_platform/crtool/src/js/business.logic/summary/contentElementaryCalculationService.js
+++ b/teachers_digital_platform/crtool/src/js/business.logic/summary/contentElementaryCalculationService.js
@@ -34,8 +34,9 @@ const ContentElementaryCalculationService = {
         if (component.state.criterionScores["content-elementary-crt-1"] === undefined ||
             component.state.criterionScores["content-elementary-crt-2"] === undefined ||
             component.state.criterionScores["content-elementary-crt-3"] === undefined ||
-            component.state.criterionScores["content-elementary-crt-4"] === undefined||
-            component.state.criterionScores["content-elementary-crt-5"] === undefined ) {
+            component.state.criterionScores["content-elementary-crt-4"] === undefined ||
+            component.state.criterionScores["content-elementary-crt-5"] === undefined ||
+            component.state.criterionScores["content-elementary-crt-6"] === undefined ) {
 
             score = "limited";
         } else {

--- a/teachers_digital_platform/crtool/src/js/business.logic/summary/contentHighCalculationService.js
+++ b/teachers_digital_platform/crtool/src/js/business.logic/summary/contentHighCalculationService.js
@@ -34,8 +34,9 @@ const ContentHighCalculationService = {
         if (component.state.criterionScores["content-high-crt-1"] === undefined ||
             component.state.criterionScores["content-high-crt-2"] === undefined ||
             component.state.criterionScores["content-high-crt-3"] === undefined ||
-            component.state.criterionScores["content-high-crt-4"] === undefined||
-            component.state.criterionScores["content-high-crt-5"] === undefined ) {
+            component.state.criterionScores["content-high-crt-4"] === undefined ||
+            component.state.criterionScores["content-high-crt-5"] === undefined ||
+            component.state.criterionScores["content-high-crt-6"] === undefined ) {
 
             score = "limited";
         } else {

--- a/teachers_digital_platform/crtool/src/js/business.logic/summary/contentMiddleCalculationService.js
+++ b/teachers_digital_platform/crtool/src/js/business.logic/summary/contentMiddleCalculationService.js
@@ -34,8 +34,9 @@ const ContentMiddleCalculationService = {
         if (component.state.criterionScores["content-middle-crt-1"] === undefined ||
             component.state.criterionScores["content-middle-crt-2"] === undefined ||
             component.state.criterionScores["content-middle-crt-3"] === undefined ||
-            component.state.criterionScores["content-middle-crt-4"] === undefined||
-            component.state.criterionScores["content-middle-crt-5"] === undefined ) {
+            component.state.criterionScores["content-middle-crt-4"] === undefined ||
+            component.state.criterionScores["content-middle-crt-5"] === undefined ||
+            component.state.criterionScores["content-middle-crt-6"] === undefined ) {
 
             score = "limited";
         } else {

--- a/teachers_digital_platform/crtool/src/js/components/pages/ContentPrintElementaryPage.js
+++ b/teachers_digital_platform/crtool/src/js/components/pages/ContentPrintElementaryPage.js
@@ -1,0 +1,133 @@
+import React from "react";
+
+import C from "../../business.logic/constants";
+import PrintIntroComponent from "../pages/partial.pages/PrintIntroComponent";
+import CriterionScoreBlock from "./summary/CriterionScoreBlock";
+import DimensionScoreBlock from "./summary/DimensionScoreBlock";
+import DimensionInformation from "../common/DimensionInformation";
+import ContentCriterionBlockSummary from "../../components/pages/summary/ContentCriterionBlockSummary";
+
+export default class ContentPrintElementaryPage extends React.Component {
+    componentDidMount() {
+        this.props.resetPrintButtonState(C.CONTENT_PAGE);
+    }
+
+    render() {
+        let contentDimensionKey = "content-high-crt-";
+        if (this.props.gradeRange === C.GRADE_ELEMENTARY) {
+            contentDimensionKey = "content-elementary-crt-";
+        } else if (this.props.gradeRange === C.GRADE_MIDDLE) {
+            contentDimensionKey = "content-middle-crt-";
+        }
+        return (
+            <React.Fragment>
+                {this.props.showPrintIntro && <PrintIntroComponent {...this.props} />}
+
+                <DimensionInformation
+                    dimensionName={C.CONTENT_PAGE}
+                    dimensionSummary="The content dimension evaluates the supports for using the curriculum. Such supports include guidance for teachers, materials that facilitate strong and effective instruction, and assessments to measure student mastery of skills and knowledge."
+                    {...this.props}
+                    reviewedOnDate={this.props.distinctiveCompletedDate[C.CONTENT_PAGE]} />
+
+                {/* Criterion 1 */}
+                <CriterionScoreBlock
+                    showExceeds={true}
+                    showBeneficial={true}
+                    dimensionKey={contentDimensionKey}
+                    dimensionPage={C.CONTENT_PAGE}
+                    criterionNumber="1"
+                    criterionName="Criterion 1:  Earning, income, and careers"
+                    criterionLead="The curriculum addresses grade-level appropriate topics for earning, income, and careers."
+                    criterionExceedsText="All essential components scored “yes”<br />At least one beneficial component scored “yes”"
+                    criterionMeetsText="All essential components scored “yes”<br />None of the beneficial components scored “yes”"
+                    criterionDoesNotMeetText="One or more essential components scored “no”"
+                    {...this.props} />
+
+                {/* Criterion 2 */}
+                <CriterionScoreBlock
+                    showExceeds={true}
+                    showBeneficial={true}
+                    dimensionKey={contentDimensionKey}
+                    dimensionPage={C.CONTENT_PAGE}
+                    criterionNumber="2"
+                    criterionName="Criterion 2: Saving and investing"
+                    criterionLead="The curriculum addresses grade-level appropriate topics for saving and investing."
+                    criterionExceedsText="All essential components scored “yes”<br />At least one beneficial component scored “yes”"
+                    criterionMeetsText="All essential components scored “yes”<br />None of the beneficial components scored “yes”"
+                    criterionDoesNotMeetText="One or more essential components scored “no”"
+                    {...this.props} />
+
+                {/* Criterion 3 */}
+                <CriterionScoreBlock
+                    showExceeds={true}
+                    showBeneficial={true}
+                    dimensionKey={contentDimensionKey}
+                    dimensionPage={C.CONTENT_PAGE}
+                    criterionNumber="3"
+                    criterionName="Criterion 3: Spending"
+                    criterionLead="The curriculum addresses grade-level appropriate topics for spending."
+                    criterionExceedsText="All essential components scored “yes”<br />At least one beneficial component scored “yes”"
+                    criterionMeetsText="All essential components scored “yes”<br />None of the beneficial components scored “yes”"
+                    criterionDoesNotMeetText="One or more essential components scored “no”"
+                    {...this.props} />
+
+                {/* Criterion 4 */}
+                <CriterionScoreBlock
+                    showExceeds={true}
+                    showBeneficial={true}
+                    dimensionKey={contentDimensionKey}
+                    dimensionPage={C.CONTENT_PAGE}
+                    criterionNumber="4"
+                    criterionName="Criterion 4: Borrowing and credit"
+                    criterionLead="The curriculum addresses grade-level appropriate topics for borrowing and credit."
+                    criterionExceedsText="All essential components scored “yes”<br />At least one beneficial component scored “yes”"
+                    criterionMeetsText="All essential components scored “yes”<br />None of the beneficial components scored “yes”"
+                    criterionDoesNotMeetText="One or more essential components scored “no”"
+                    {...this.props} />
+
+                {/* Criterion 5 */}
+                <CriterionScoreBlock
+                    showExceeds={true}
+                    showBeneficial={true}
+                    dimensionKey={contentDimensionKey}
+                    dimensionPage={C.CONTENT_PAGE}
+                    criterionNumber="5"
+                    criterionName="Criterion 5: Managing financial risk"
+                    criterionLead="The curriculum addresses grade-level appropriate topics for managing potential financial risk, including insurance."
+                    criterionExceedsText="All essential components scored “yes”<br />At least one beneficial component scored “yes”"
+                    criterionMeetsText="All essential components scored “yes”<br />None of the beneficial components scored “yes”"
+                    criterionDoesNotMeetText="One or more essential components scored “no”"
+                    {...this.props} />
+
+                {/* Criterion 6 */}
+                <CriterionScoreBlock
+                    showExceeds={true}
+                    showBeneficial={true}
+                    dimensionKey={contentDimensionKey}
+                    dimensionPage={C.CONTENT_PAGE}
+                    criterionNumber="6"
+                    criterionName="Criterion 6: Financial responsibility and money management"
+                    criterionLead="The curriculum addresses grade-level appropriate topics for financial responsibility, money management, and financial decisions."
+                    criterionExceedsText="All essential components scored “yes”<br />At least one beneficial component scored “yes”"
+                    criterionMeetsText="All essential components scored “yes”<br />None of the beneficial components scored “yes”"
+                    criterionDoesNotMeetText="One or more essential components scored “no”"
+                    {...this.props} />
+
+                {/* Content Overall Score */}
+                <DimensionScoreBlock
+                    dimensionPage={C.CONTENT_PAGE}
+                    dimensionKey={contentDimensionKey}
+                    dimensionName="Content"
+                    dimensionLead="How does this curriculum meet the criteria for content:"
+                    {...this.props} />
+
+                {/* Forced Page Break */}
+                <div className="u-page-break-before">
+
+                    {/* Content individual Criterion Q&A for all Criterion*/}
+                    <ContentCriterionBlockSummary {...this.props} /> {/* Criterion Information */}
+                </div>
+            </React.Fragment>
+        );
+    }
+}

--- a/teachers_digital_platform/crtool/src/js/components/pages/ContentPrintElementaryPage.js
+++ b/teachers_digital_platform/crtool/src/js/components/pages/ContentPrintElementaryPage.js
@@ -13,12 +13,6 @@ export default class ContentPrintElementaryPage extends React.Component {
     }
 
     render() {
-        let contentDimensionKey = "content-high-crt-";
-        if (this.props.gradeRange === C.GRADE_ELEMENTARY) {
-            contentDimensionKey = "content-elementary-crt-";
-        } else if (this.props.gradeRange === C.GRADE_MIDDLE) {
-            contentDimensionKey = "content-middle-crt-";
-        }
         return (
             <React.Fragment>
                 {this.props.showPrintIntro && <PrintIntroComponent {...this.props} />}
@@ -29,96 +23,93 @@ export default class ContentPrintElementaryPage extends React.Component {
                     {...this.props}
                     reviewedOnDate={this.props.distinctiveCompletedDate[C.CONTENT_PAGE]} />
 
-                {/* Criterion 1 */}
                 <CriterionScoreBlock
                     showExceeds={true}
                     showBeneficial={true}
-                    dimensionKey={contentDimensionKey}
+                    dimensionKey="content-elementary-crt-"
                     dimensionPage={C.CONTENT_PAGE}
                     criterionNumber="1"
                     criterionName="Criterion 1:  Earning, income, and careers"
                     criterionLead="The curriculum addresses grade-level appropriate topics for earning, income, and careers."
-                    criterionExceedsText="All essential components scored “yes”<br />At least one beneficial component scored “yes”"
-                    criterionMeetsText="All essential components scored “yes”<br />None of the beneficial components scored “yes”"
-                    criterionDoesNotMeetText="One or more essential components scored “no”"
-                    {...this.props} />
+                    criterionExceedsText="Both components were addressed"
+                    criterionMeetsText="1 component was addressed"
+                    criterionDoesNotMeetText="0 components were addressed"
+                {...this.props} />
 
-                {/* Criterion 2 */}
                 <CriterionScoreBlock
                     showExceeds={true}
                     showBeneficial={true}
-                    dimensionKey={contentDimensionKey}
+                    dimensionKey="content-elementary-crt-"
                     dimensionPage={C.CONTENT_PAGE}
                     criterionNumber="2"
                     criterionName="Criterion 2: Saving and investing"
                     criterionLead="The curriculum addresses grade-level appropriate topics for saving and investing."
-                    criterionExceedsText="All essential components scored “yes”<br />At least one beneficial component scored “yes”"
-                    criterionMeetsText="All essential components scored “yes”<br />None of the beneficial components scored “yes”"
-                    criterionDoesNotMeetText="One or more essential components scored “no”"
+                    criterionExceedsText="All 4 components were addressed"
+                    criterionMeetsText="3 components were addressed"
+                    criterionDoesNotMeetText="Less than 3 components were addressed"
                     {...this.props} />
 
-                {/* Criterion 3 */}
+
                 <CriterionScoreBlock
                     showExceeds={true}
                     showBeneficial={true}
-                    dimensionKey={contentDimensionKey}
+                    dimensionKey="content-elementary-crt-"
                     dimensionPage={C.CONTENT_PAGE}
                     criterionNumber="3"
                     criterionName="Criterion 3: Spending"
                     criterionLead="The curriculum addresses grade-level appropriate topics for spending."
-                    criterionExceedsText="All essential components scored “yes”<br />At least one beneficial component scored “yes”"
-                    criterionMeetsText="All essential components scored “yes”<br />None of the beneficial components scored “yes”"
-                    criterionDoesNotMeetText="One or more essential components scored “no”"
+                    criterionExceedsText="5 or more components were addressed"
+                    criterionMeetsText="4 components were addressed"
+                    criterionDoesNotMeetText="Less than 4 components were addressed"
                     {...this.props} />
 
-                {/* Criterion 4 */}
                 <CriterionScoreBlock
                     showExceeds={true}
                     showBeneficial={true}
-                    dimensionKey={contentDimensionKey}
+                    dimensionKey="content-elementary-crt-"
                     dimensionPage={C.CONTENT_PAGE}
                     criterionNumber="4"
                     criterionName="Criterion 4: Borrowing and credit"
                     criterionLead="The curriculum addresses grade-level appropriate topics for borrowing and credit."
-                    criterionExceedsText="All essential components scored “yes”<br />At least one beneficial component scored “yes”"
-                    criterionMeetsText="All essential components scored “yes”<br />None of the beneficial components scored “yes”"
-                    criterionDoesNotMeetText="One or more essential components scored “no”"
+                    criterionExceedsText="Both components were addressed"
+                    criterionMeetsText="1 component was addressed"
+                    criterionDoesNotMeetText="0 components were addressed"
                     {...this.props} />
 
-                {/* Criterion 5 */}
                 <CriterionScoreBlock
                     showExceeds={true}
                     showBeneficial={true}
-                    dimensionKey={contentDimensionKey}
+                    dimensionKey="content-elementary-crt-"
                     dimensionPage={C.CONTENT_PAGE}
                     criterionNumber="5"
                     criterionName="Criterion 5: Managing financial risk"
                     criterionLead="The curriculum addresses grade-level appropriate topics for managing potential financial risk, including insurance."
-                    criterionExceedsText="All essential components scored “yes”<br />At least one beneficial component scored “yes”"
-                    criterionMeetsText="All essential components scored “yes”<br />None of the beneficial components scored “yes”"
-                    criterionDoesNotMeetText="One or more essential components scored “no”"
+                    criterionExceedsText="Both components were addressed"
+                    criterionMeetsText="1 component was addressed"
+                    criterionDoesNotMeetText="0 components were addressed"
                     {...this.props} />
 
-                {/* Criterion 6 */}
                 <CriterionScoreBlock
-                    showExceeds={true}
-                    showBeneficial={true}
-                    dimensionKey={contentDimensionKey}
+                    showExceeds={false}
+                    showBeneficial={false}
+                    dimensionKey="content-elementary-crt-"
                     dimensionPage={C.CONTENT_PAGE}
                     criterionNumber="6"
                     criterionName="Criterion 6: Financial responsibility and money management"
                     criterionLead="The curriculum addresses grade-level appropriate topics for financial responsibility, money management, and financial decisions."
-                    criterionExceedsText="All essential components scored “yes”<br />At least one beneficial component scored “yes”"
-                    criterionMeetsText="All essential components scored “yes”<br />None of the beneficial components scored “yes”"
-                    criterionDoesNotMeetText="One or more essential components scored “no”"
+                    criterionMeetsText="1 component was addressed"
+                    criterionDoesNotMeetText="0 components were addressed"
                     {...this.props} />
 
-                {/* Content Overall Score */}
+
                 <DimensionScoreBlock
                     dimensionPage={C.CONTENT_PAGE}
-                    dimensionKey={contentDimensionKey}
+                    dimensionKey="content-elementary-crt-"
                     dimensionName="Content"
                     dimensionLead="How does this curriculum meet the criteria for content:"
+                    strongText="All 6 criteria were met, and at least one was exceeded"
+                    moderateText="All 6 criteria were met"
+                    limitedText="At least one criterion was not met"
                     {...this.props} />
 
                 {/* Forced Page Break */}

--- a/teachers_digital_platform/crtool/src/js/components/pages/ContentPrintHighPage.js
+++ b/teachers_digital_platform/crtool/src/js/components/pages/ContentPrintHighPage.js
@@ -13,12 +13,6 @@ export default class ContentPrintHighPage extends React.Component {
     }
 
     render() {
-        let contentDimensionKey = "content-high-crt-";
-        if (this.props.gradeRange === C.GRADE_ELEMENTARY) {
-            contentDimensionKey = "content-elementary-crt-";
-        } else if (this.props.gradeRange === C.GRADE_MIDDLE) {
-            contentDimensionKey = "content-middle-crt-";
-        }
         return (
             <React.Fragment>
                 {this.props.showPrintIntro && <PrintIntroComponent {...this.props} />}
@@ -29,96 +23,93 @@ export default class ContentPrintHighPage extends React.Component {
                     {...this.props}
                     reviewedOnDate={this.props.distinctiveCompletedDate[C.CONTENT_PAGE]} />
 
-                {/* Criterion 1 */}
                 <CriterionScoreBlock
                     showExceeds={true}
                     showBeneficial={true}
-                    dimensionKey={contentDimensionKey}
+                    dimensionKey="content-high-crt-"
                     dimensionPage={C.CONTENT_PAGE}
                     criterionNumber="1"
                     criterionName="Criterion 1:  Earning, income, and careers"
                     criterionLead="The curriculum addresses grade-level appropriate topics for earning, income, and careers."
-                    criterionExceedsText="All essential components scored “yes”<br />At least one beneficial component scored “yes”"
-                    criterionMeetsText="All essential components scored “yes”<br />None of the beneficial components scored “yes”"
-                    criterionDoesNotMeetText="One or more essential components scored “no”"
+                    criterionExceedsText="5 or more components were addressed"
+                    criterionMeetsText="4 components were addressed"
+                    criterionDoesNotMeetText="Less than 4 components were addressed"
                     {...this.props} />
 
-                {/* Criterion 2 */}
                 <CriterionScoreBlock
                     showExceeds={true}
                     showBeneficial={true}
-                    dimensionKey={contentDimensionKey}
+                    dimensionKey="content-high-crt-"
                     dimensionPage={C.CONTENT_PAGE}
                     criterionNumber="2"
                     criterionName="Criterion 2: Saving and investing"
                     criterionLead="The curriculum addresses grade-level appropriate topics for saving and investing."
-                    criterionExceedsText="All essential components scored “yes”<br />At least one beneficial component scored “yes”"
-                    criterionMeetsText="All essential components scored “yes”<br />None of the beneficial components scored “yes”"
-                    criterionDoesNotMeetText="One or more essential components scored “no”"
+                    criterionExceedsText="8 or more components were addressed"
+                    criterionMeetsText="6 or 7 components were addressed"
+                    criterionDoesNotMeetText="Less than 6 components were addressed"
                     {...this.props} />
 
-                {/* Criterion 3 */}
                 <CriterionScoreBlock
                     showExceeds={true}
                     showBeneficial={true}
-                    dimensionKey={contentDimensionKey}
+                    dimensionKey="content-high-crt-"
                     dimensionPage={C.CONTENT_PAGE}
                     criterionNumber="3"
                     criterionName="Criterion 3: Spending"
                     criterionLead="The curriculum addresses grade-level appropriate topics for spending."
-                    criterionExceedsText="All essential components scored “yes”<br />At least one beneficial component scored “yes”"
-                    criterionMeetsText="All essential components scored “yes”<br />None of the beneficial components scored “yes”"
-                    criterionDoesNotMeetText="One or more essential components scored “no”"
+                    criterionExceedsText="All 4 components were addressed"
+                    criterionMeetsText="3 components were addressed"
+                    criterionDoesNotMeetText="Less than 3 components were addressed"
                     {...this.props} />
 
-                {/* Criterion 4 */}
                 <CriterionScoreBlock
                     showExceeds={true}
                     showBeneficial={true}
-                    dimensionKey={contentDimensionKey}
+                    dimensionKey="content-high-crt-"
                     dimensionPage={C.CONTENT_PAGE}
                     criterionNumber="4"
                     criterionName="Criterion 4: Borrowing and credit"
                     criterionLead="The curriculum addresses grade-level appropriate topics for borrowing and credit."
-                    criterionExceedsText="All essential components scored “yes”<br />At least one beneficial component scored “yes”"
-                    criterionMeetsText="All essential components scored “yes”<br />None of the beneficial components scored “yes”"
-                    criterionDoesNotMeetText="One or more essential components scored “no”"
+                    criterionExceedsText="9 or more components were addressed"
+                    criterionMeetsText="7 or 8 components were addressed"
+                    criterionDoesNotMeetText="Less than 7 components were addressed"
                     {...this.props} />
 
-                {/* Criterion 5 */}
                 <CriterionScoreBlock
                     showExceeds={true}
                     showBeneficial={true}
-                    dimensionKey={contentDimensionKey}
+                    dimensionKey="content-high-crt-"
                     dimensionPage={C.CONTENT_PAGE}
                     criterionNumber="5"
                     criterionName="Criterion 5: Managing financial risk"
                     criterionLead="The curriculum addresses grade-level appropriate topics for managing potential financial risk, including insurance."
-                    criterionExceedsText="All essential components scored “yes”<br />At least one beneficial component scored “yes”"
-                    criterionMeetsText="All essential components scored “yes”<br />None of the beneficial components scored “yes”"
-                    criterionDoesNotMeetText="One or more essential components scored “no”"
+                    criterionExceedsText="6 or more components were addressed"
+                    criterionMeetsText="5 components were addressed"
+                    criterionDoesNotMeetText="Less than 5 components were addressed"
                     {...this.props} />
 
-                {/* Criterion 6 */}
                 <CriterionScoreBlock
                     showExceeds={true}
                     showBeneficial={true}
-                    dimensionKey={contentDimensionKey}
+                    dimensionKey="content-high-crt-"
                     dimensionPage={C.CONTENT_PAGE}
                     criterionNumber="6"
                     criterionName="Criterion 6: Financial responsibility and money management"
                     criterionLead="The curriculum addresses grade-level appropriate topics for financial responsibility, money management, and financial decisions."
-                    criterionExceedsText="All essential components scored “yes”<br />At least one beneficial component scored “yes”"
-                    criterionMeetsText="All essential components scored “yes”<br />None of the beneficial components scored “yes”"
-                    criterionDoesNotMeetText="One or more essential components scored “no”"
+                    criterionExceedsText="All 3 components were addressed"
+                    criterionMeetsText="2 components were addressed"
+                    criterionDoesNotMeetText="Less than 2 components were addressed"
                     {...this.props} />
 
-                {/* Content Overall Score */}
+
                 <DimensionScoreBlock
                     dimensionPage={C.CONTENT_PAGE}
-                    dimensionKey={contentDimensionKey}
+                    dimensionKey="content-high-crt-"
                     dimensionName="Content"
                     dimensionLead="How does this curriculum meet the criteria for content:"
+                    strongText="All 6 criteria were met, and at least one was exceeded"
+                    moderateText="All 6 criteria were met"
+                    limitedText="At least one of the criteria was not met"
                     {...this.props} />
 
                 {/* Forced Page Break */}

--- a/teachers_digital_platform/crtool/src/js/components/pages/ContentPrintHighPage.js
+++ b/teachers_digital_platform/crtool/src/js/components/pages/ContentPrintHighPage.js
@@ -7,7 +7,7 @@ import DimensionScoreBlock from "./summary/DimensionScoreBlock";
 import DimensionInformation from "../common/DimensionInformation";
 import ContentCriterionBlockSummary from "../../components/pages/summary/ContentCriterionBlockSummary";
 
-export default class ContentPrintPage extends React.Component {
+export default class ContentPrintHighPage extends React.Component {
     componentDidMount() {
         this.props.resetPrintButtonState(C.CONTENT_PAGE);
     }

--- a/teachers_digital_platform/crtool/src/js/components/pages/ContentPrintMiddlePage.js
+++ b/teachers_digital_platform/crtool/src/js/components/pages/ContentPrintMiddlePage.js
@@ -13,12 +13,6 @@ export default class ContentPrintMiddlePage extends React.Component {
     }
 
     render() {
-        let contentDimensionKey = "content-high-crt-";
-        if (this.props.gradeRange === C.GRADE_ELEMENTARY) {
-            contentDimensionKey = "content-elementary-crt-";
-        } else if (this.props.gradeRange === C.GRADE_MIDDLE) {
-            contentDimensionKey = "content-middle-crt-";
-        }
         return (
             <React.Fragment>
                 {this.props.showPrintIntro && <PrintIntroComponent {...this.props} />}

--- a/teachers_digital_platform/crtool/src/js/components/pages/ContentPrintMiddlePage.js
+++ b/teachers_digital_platform/crtool/src/js/components/pages/ContentPrintMiddlePage.js
@@ -29,96 +29,91 @@ export default class ContentPrintMiddlePage extends React.Component {
                     {...this.props}
                     reviewedOnDate={this.props.distinctiveCompletedDate[C.CONTENT_PAGE]} />
 
-                {/* Criterion 1 */}
                 <CriterionScoreBlock
                     showExceeds={true}
                     showBeneficial={true}
-                    dimensionKey={contentDimensionKey}
+                    dimensionKey="content-middle-crt-"
                     dimensionPage={C.CONTENT_PAGE}
                     criterionNumber="1"
                     criterionName="Criterion 1:  Earning, income, and careers"
                     criterionLead="The curriculum addresses grade-level appropriate topics for earning, income, and careers."
-                    criterionExceedsText="All essential components scored “yes”<br />At least one beneficial component scored “yes”"
-                    criterionMeetsText="All essential components scored “yes”<br />None of the beneficial components scored “yes”"
-                    criterionDoesNotMeetText="One or more essential components scored “no”"
+                    criterionExceedsText="All 3 components were addressed"
+                    criterionMeetsText="2 components were addressed"
+                    criterionDoesNotMeetText="Less than 2 components were addressed"
                     {...this.props} />
 
-                {/* Criterion 2 */}
                 <CriterionScoreBlock
                     showExceeds={true}
                     showBeneficial={true}
-                    dimensionKey={contentDimensionKey}
+                    dimensionKey="content-middle-crt-"
                     dimensionPage={C.CONTENT_PAGE}
                     criterionNumber="2"
                     criterionName="Criterion 2: Saving and investing"
                     criterionLead="The curriculum addresses grade-level appropriate topics for saving and investing."
-                    criterionExceedsText="All essential components scored “yes”<br />At least one beneficial component scored “yes”"
-                    criterionMeetsText="All essential components scored “yes”<br />None of the beneficial components scored “yes”"
-                    criterionDoesNotMeetText="One or more essential components scored “no”"
+                    criterionExceedsText="7 or more components were addressed"
+                    criterionMeetsText="5 or 6 components were addressed"
+                    criterionDoesNotMeetText="Less than 5 components were addressed"
                     {...this.props} />
 
-                {/* Criterion 3 */}
                 <CriterionScoreBlock
                     showExceeds={true}
                     showBeneficial={true}
-                    dimensionKey={contentDimensionKey}
+                    dimensionKey="content-middle-crt-"
                     dimensionPage={C.CONTENT_PAGE}
                     criterionNumber="3"
                     criterionName="Criterion 3: Spending"
                     criterionLead="The curriculum addresses grade-level appropriate topics for spending."
-                    criterionExceedsText="All essential components scored “yes”<br />At least one beneficial component scored “yes”"
-                    criterionMeetsText="All essential components scored “yes”<br />None of the beneficial components scored “yes”"
-                    criterionDoesNotMeetText="One or more essential components scored “no”"
+                    criterionExceedsText="All 5 components were addressed"
+                    criterionMeetsText="4 components were addressed"
+                    criterionDoesNotMeetText="Less than 4 components were addressed"
                     {...this.props} />
 
-                {/* Criterion 4 */}
                 <CriterionScoreBlock
                     showExceeds={true}
                     showBeneficial={true}
-                    dimensionKey={contentDimensionKey}
+                    dimensionKey="content-middle-crt-"
                     dimensionPage={C.CONTENT_PAGE}
                     criterionNumber="4"
                     criterionName="Criterion 4: Borrowing and credit"
                     criterionLead="The curriculum addresses grade-level appropriate topics for borrowing and credit."
-                    criterionExceedsText="All essential components scored “yes”<br />At least one beneficial component scored “yes”"
-                    criterionMeetsText="All essential components scored “yes”<br />None of the beneficial components scored “yes”"
-                    criterionDoesNotMeetText="One or more essential components scored “no”"
+                    criterionExceedsText="6 or more components were addressed"
+                    criterionMeetsText="5 components were addressed"
+                    criterionDoesNotMeetText="Less than 5 components were addressed"
                     {...this.props} />
 
-                {/* Criterion 5 */}
                 <CriterionScoreBlock
                     showExceeds={true}
                     showBeneficial={true}
-                    dimensionKey={contentDimensionKey}
+                    dimensionKey="content-middle-crt-"
                     dimensionPage={C.CONTENT_PAGE}
                     criterionNumber="5"
                     criterionName="Criterion 5: Managing financial risk"
                     criterionLead="The curriculum addresses grade-level appropriate topics for managing potential financial risk, including insurance."
-                    criterionExceedsText="All essential components scored “yes”<br />At least one beneficial component scored “yes”"
-                    criterionMeetsText="All essential components scored “yes”<br />None of the beneficial components scored “yes”"
-                    criterionDoesNotMeetText="One or more essential components scored “no”"
+                    criterionExceedsText="All 4 components were addressed"
+                    criterionMeetsText="3 components were addressed"
+                    criterionDoesNotMeetText="Less than 3 components were addressed"
                     {...this.props} />
 
-                {/* Criterion 6 */}
                 <CriterionScoreBlock
                     showExceeds={true}
                     showBeneficial={true}
-                    dimensionKey={contentDimensionKey}
+                    dimensionKey="content-middle-crt-"
                     dimensionPage={C.CONTENT_PAGE}
                     criterionNumber="6"
                     criterionName="Criterion 6: Financial responsibility and money management"
                     criterionLead="The curriculum addresses grade-level appropriate topics for financial responsibility, money management, and financial decisions."
-                    criterionExceedsText="All essential components scored “yes”<br />At least one beneficial component scored “yes”"
-                    criterionMeetsText="All essential components scored “yes”<br />None of the beneficial components scored “yes”"
-                    criterionDoesNotMeetText="One or more essential components scored “no”"
+                    criterionMeetsText="1 component was addressed"
+                    criterionDoesNotMeetText="0 components were addressed"
                     {...this.props} />
 
-                {/* Content Overall Score */}
                 <DimensionScoreBlock
                     dimensionPage={C.CONTENT_PAGE}
-                    dimensionKey={contentDimensionKey}
+                    dimensionKey="content-middle-crt-"
                     dimensionName="Content"
                     dimensionLead="How does this curriculum meet the criteria for content:"
+                    strongText="All 6 criteria were met, and at least one was exceeded"
+                    moderateText="All 6 criteria were met"
+                    limitedText="At least one of the criteria was not met"
                     {...this.props} />
 
                 {/* Forced Page Break */}

--- a/teachers_digital_platform/crtool/src/js/components/pages/ContentPrintMiddlePage.js
+++ b/teachers_digital_platform/crtool/src/js/components/pages/ContentPrintMiddlePage.js
@@ -1,0 +1,133 @@
+import React from "react";
+
+import C from "../../business.logic/constants";
+import PrintIntroComponent from "../pages/partial.pages/PrintIntroComponent";
+import CriterionScoreBlock from "./summary/CriterionScoreBlock";
+import DimensionScoreBlock from "./summary/DimensionScoreBlock";
+import DimensionInformation from "../common/DimensionInformation";
+import ContentCriterionBlockSummary from "../../components/pages/summary/ContentCriterionBlockSummary";
+
+export default class ContentPrintMiddlePage extends React.Component {
+    componentDidMount() {
+        this.props.resetPrintButtonState(C.CONTENT_PAGE);
+    }
+
+    render() {
+        let contentDimensionKey = "content-high-crt-";
+        if (this.props.gradeRange === C.GRADE_ELEMENTARY) {
+            contentDimensionKey = "content-elementary-crt-";
+        } else if (this.props.gradeRange === C.GRADE_MIDDLE) {
+            contentDimensionKey = "content-middle-crt-";
+        }
+        return (
+            <React.Fragment>
+                {this.props.showPrintIntro && <PrintIntroComponent {...this.props} />}
+
+                <DimensionInformation
+                    dimensionName={C.CONTENT_PAGE}
+                    dimensionSummary="The content dimension evaluates the supports for using the curriculum. Such supports include guidance for teachers, materials that facilitate strong and effective instruction, and assessments to measure student mastery of skills and knowledge."
+                    {...this.props}
+                    reviewedOnDate={this.props.distinctiveCompletedDate[C.CONTENT_PAGE]} />
+
+                {/* Criterion 1 */}
+                <CriterionScoreBlock
+                    showExceeds={true}
+                    showBeneficial={true}
+                    dimensionKey={contentDimensionKey}
+                    dimensionPage={C.CONTENT_PAGE}
+                    criterionNumber="1"
+                    criterionName="Criterion 1:  Earning, income, and careers"
+                    criterionLead="The curriculum addresses grade-level appropriate topics for earning, income, and careers."
+                    criterionExceedsText="All essential components scored “yes”<br />At least one beneficial component scored “yes”"
+                    criterionMeetsText="All essential components scored “yes”<br />None of the beneficial components scored “yes”"
+                    criterionDoesNotMeetText="One or more essential components scored “no”"
+                    {...this.props} />
+
+                {/* Criterion 2 */}
+                <CriterionScoreBlock
+                    showExceeds={true}
+                    showBeneficial={true}
+                    dimensionKey={contentDimensionKey}
+                    dimensionPage={C.CONTENT_PAGE}
+                    criterionNumber="2"
+                    criterionName="Criterion 2: Saving and investing"
+                    criterionLead="The curriculum addresses grade-level appropriate topics for saving and investing."
+                    criterionExceedsText="All essential components scored “yes”<br />At least one beneficial component scored “yes”"
+                    criterionMeetsText="All essential components scored “yes”<br />None of the beneficial components scored “yes”"
+                    criterionDoesNotMeetText="One or more essential components scored “no”"
+                    {...this.props} />
+
+                {/* Criterion 3 */}
+                <CriterionScoreBlock
+                    showExceeds={true}
+                    showBeneficial={true}
+                    dimensionKey={contentDimensionKey}
+                    dimensionPage={C.CONTENT_PAGE}
+                    criterionNumber="3"
+                    criterionName="Criterion 3: Spending"
+                    criterionLead="The curriculum addresses grade-level appropriate topics for spending."
+                    criterionExceedsText="All essential components scored “yes”<br />At least one beneficial component scored “yes”"
+                    criterionMeetsText="All essential components scored “yes”<br />None of the beneficial components scored “yes”"
+                    criterionDoesNotMeetText="One or more essential components scored “no”"
+                    {...this.props} />
+
+                {/* Criterion 4 */}
+                <CriterionScoreBlock
+                    showExceeds={true}
+                    showBeneficial={true}
+                    dimensionKey={contentDimensionKey}
+                    dimensionPage={C.CONTENT_PAGE}
+                    criterionNumber="4"
+                    criterionName="Criterion 4: Borrowing and credit"
+                    criterionLead="The curriculum addresses grade-level appropriate topics for borrowing and credit."
+                    criterionExceedsText="All essential components scored “yes”<br />At least one beneficial component scored “yes”"
+                    criterionMeetsText="All essential components scored “yes”<br />None of the beneficial components scored “yes”"
+                    criterionDoesNotMeetText="One or more essential components scored “no”"
+                    {...this.props} />
+
+                {/* Criterion 5 */}
+                <CriterionScoreBlock
+                    showExceeds={true}
+                    showBeneficial={true}
+                    dimensionKey={contentDimensionKey}
+                    dimensionPage={C.CONTENT_PAGE}
+                    criterionNumber="5"
+                    criterionName="Criterion 5: Managing financial risk"
+                    criterionLead="The curriculum addresses grade-level appropriate topics for managing potential financial risk, including insurance."
+                    criterionExceedsText="All essential components scored “yes”<br />At least one beneficial component scored “yes”"
+                    criterionMeetsText="All essential components scored “yes”<br />None of the beneficial components scored “yes”"
+                    criterionDoesNotMeetText="One or more essential components scored “no”"
+                    {...this.props} />
+
+                {/* Criterion 6 */}
+                <CriterionScoreBlock
+                    showExceeds={true}
+                    showBeneficial={true}
+                    dimensionKey={contentDimensionKey}
+                    dimensionPage={C.CONTENT_PAGE}
+                    criterionNumber="6"
+                    criterionName="Criterion 6: Financial responsibility and money management"
+                    criterionLead="The curriculum addresses grade-level appropriate topics for financial responsibility, money management, and financial decisions."
+                    criterionExceedsText="All essential components scored “yes”<br />At least one beneficial component scored “yes”"
+                    criterionMeetsText="All essential components scored “yes”<br />None of the beneficial components scored “yes”"
+                    criterionDoesNotMeetText="One or more essential components scored “no”"
+                    {...this.props} />
+
+                {/* Content Overall Score */}
+                <DimensionScoreBlock
+                    dimensionPage={C.CONTENT_PAGE}
+                    dimensionKey={contentDimensionKey}
+                    dimensionName="Content"
+                    dimensionLead="How does this curriculum meet the criteria for content:"
+                    {...this.props} />
+
+                {/* Forced Page Break */}
+                <div className="u-page-break-before">
+
+                    {/* Content individual Criterion Q&A for all Criterion*/}
+                    <ContentCriterionBlockSummary {...this.props} /> {/* Criterion Information */}
+                </div>
+            </React.Fragment>
+        );
+    }
+}

--- a/teachers_digital_platform/crtool/src/js/components/pages/PrintAndSummaryPages.js
+++ b/teachers_digital_platform/crtool/src/js/components/pages/PrintAndSummaryPages.js
@@ -3,9 +3,13 @@ import React from "react";
 import C from "../../business.logic/constants";
 import QualityPrintPage from "./QualityPrintPage";
 import UtilityPrintPage from "./UtilityPrintPage";
-import ContentPrintPage from "./ContentPrintPage";
 import EfficacyPrintPage from "./EfficacyPrintPage";
 import FinalSummaryPage from "../pages/FinalSummaryPage";
+
+
+import ContentPrintElemenataryPage from "./ContentPrintElementaryPage";
+import ContentPrintMiddlePage from "./ContentPrintMiddlePage";
+import ContentPrintHighPage from "./ContentPrintHighPage";
 
 export default class PrintAndSummaryPages extends React.Component {
 
@@ -14,12 +18,19 @@ export default class PrintAndSummaryPages extends React.Component {
     }
 
     render() {
-        if (this.props.currentPrintButton === C.QUALITY_PAGE) {
+        if (this.props.currentPrintButton === C.CONTENT_PAGE) {
+            // Since each content group has different content for the scoring we need different Print pages for each
+            if (this.props.gradeRange === C.GRADE_ELEMENTARY) {
+                return ( <ContentPrintElemenataryPage showPrintIntro={true} {...this.props} /> );
+            } else if (this.props.gradeRange === C.GRADE_MIDDLE) {
+                return ( <ContentPrintMiddlePage showPrintIntro={true} {...this.props} /> );
+            } else {
+                return ( <ContentPrintHighPage showPrintIntro={true} {...this.props} /> );
+            }
+        } else if (this.props.currentPrintButton === C.QUALITY_PAGE) {
             return ( <QualityPrintPage showPrintIntro={true} {...this.props} /> );
         } else if (this.props.currentPrintButton === C.UTILITY_PAGE) {
             return ( <UtilityPrintPage showPrintIntro={true} {...this.props} /> );
-        } else if (this.props.currentPrintButton === C.CONTENT_PAGE) {
-            return ( <ContentPrintPage showPrintIntro={true} {...this.props} /> );
         } else if (this.props.currentPrintButton === C.EFFICACY_PAGE) {
             return ( <EfficacyPrintPage showPrintIntro={true} {...this.props} /> );
         } else {
@@ -27,3 +38,5 @@ export default class PrintAndSummaryPages extends React.Component {
         }
     }
 }
+
+

--- a/teachers_digital_platform/crtool/src/js/components/pages/PrintAndSummaryPages.js
+++ b/teachers_digital_platform/crtool/src/js/components/pages/PrintAndSummaryPages.js
@@ -38,5 +38,3 @@ export default class PrintAndSummaryPages extends React.Component {
         }
     }
 }
-
-

--- a/teachers_digital_platform/crtool/src/js/components/pages/summary/CriterionScoreBlock.js
+++ b/teachers_digital_platform/crtool/src/js/components/pages/summary/CriterionScoreBlock.js
@@ -8,48 +8,15 @@ export default class CriterionScoreBlock extends React.Component {
         this.props.criterionAnswerChanged(this.props.dimensionPage, key, checkedValue);
     }
 
-    criterionOveralScoreClassName(level, type) {
-        let isLimited = false;
-        if (this.props.criterionScores[this.props.dimensionKey + "1"].doesnotmeet ||
-            this.props.criterionScores[this.props.dimensionKey + "2"].doesnotmeet ||
-            this.props.criterionScores[this.props.dimensionKey + "3"].doesnotmeet ||
-            this.props.criterionScores[this.props.dimensionKey + "4"].doesnotmeet ) {
-
-            isLimited = true;
-        }
-
-        let isModerate = false;
-        if (this.props.criterionScores[this.props.dimensionKey + "1"].meets &&
-            this.props.criterionScores[this.props.dimensionKey + "2"].meets &&
-            this.props.criterionScores[this.props.dimensionKey + "3"].meets &&
-            this.props.criterionScores[this.props.dimensionKey + "4"].meets ) {
-
-            isModerate = true;
-        }
-
-        let className = "m-form-field_radio-icon";
-        if (type === "text") className = "m-form-field_radio-text";
-
-        if (level === "limited" && isLimited) {
-            className = className + " is-active";
-        } else if (level === "moderate" && isModerate) {
-            className = className + " is-active";
-        } else if (level === "strong" && !isLimited && !isModerate) {
-            className = className + " is-active";
-        }
-
-        return className;
-    }
-
     renderTextValue(style, level) {
         let criterionScore = this.props.criterionScores[this.props.dimensionKey + this.props.criterionNumber];
         let isTrue = false;
 
         if (level === "exceeds" && criterionScore !== undefined){
             isTrue = criterionScore.exceeds;
-        } else if (level === "meets") {
+        } else if (level === "meets" && criterionScore !== undefined) {
             isTrue = criterionScore.meets;
-        } else if (level === "doesnotmeet") {
+        } else if (level === "doesnotmeet" && criterionScore !== undefined) {
             isTrue = criterionScore.doesnotmeet;
         }
 


### PR DESCRIPTION
Since the CONTENT for print score is different between the different Content print pages I renamed ContentPrintPage.js to ContentPrintElementaryPage.js and duplicated it for Middle and High.

You will now find the following three files (currently identical)
- ContentPrintElementaryPage.js
- ContentPrintMiddlePage.js
- ContentPrintHighPage.js

If you direct me in the direction where I can find the content for the Content Score, I will update the two new ones.

## Additions
- Created the following new files for Printing content scores
  - ContentPrintElementaryPage.js 
  - ContentPrintMiddlePage.js 
  - ContentPrintHighPage.js
- Removed console.log() statements
- Fixed minor content score calculation error (Didn't affect the score, just threw and exception that got ignored
- Removed dead code in CriterionScoreBlock.js  "criterionOveralScoreClassName()"


## Testing

- Clear all local storage by choosing "Start over with a new review"
- Choose Grade Elementary and verify
  -  [ ] You can fill out the whole "Content" Dimension
   - [ ] You can view the Summary and its scored correctly
   - [ ] You can view the Content Print with score
- Do the above for both Middle and High grades

## Review

- @dcmouyard @rrstoll 

[Preview this PR without the whitespace changes](?w=0)

## Notes

- Still need to update the following two files with the correct content.  Right now they are duplicating ContentPrintElementaryPage.js
  - ContentPrintMiddlePage.js 
  - ContentPrintHighPage.js
