### PR TITLE
Fix dimension selection bar layout

### DIFF
--- a/teachers_digital_platform/css/organisms/dimension-selection-bar.less
+++ b/teachers_digital_platform/css/organisms/dimension-selection-bar.less
@@ -6,6 +6,7 @@
 @bp-dimension-larger-text: 1140px;
 
 .o-dimension-selection-bar {
+    clear: both;
     display: flex;
     flex-wrap: wrap;
     justify-content: space-between;


### PR DESCRIPTION
Fix dimension selection bar layout.

## Changes

- Add `clear: both` to dimension selection bar

- @rrstoll 

[Preview this PR without the whitespace changes](?w=0)
