### PR TITLE
Fix typo on efficacy, quality, and utility survey pages

### DIFF
--- a/teachers_digital_platform/crtool/src/__tests__/__snapshots__/EfficacyCriterionPage.test.js.snap
+++ b/teachers_digital_platform/crtool/src/__tests__/__snapshots__/EfficacyCriterionPage.test.js.snap
@@ -179,7 +179,7 @@ Array [
       <strong>
         beneficial components
       </strong>
-       hold promise for positive impact on student learning, but may only be relevant and useful for some reviewers. Some of the scoring treat essential and beneficial components differently, but you’re still required to answer all beneficial components.
+       hold promise for positive impact on student learning, but may only be relevant and useful for some reviewers. Some of the scoring treats essential and beneficial components differently, but you’re still required to answer all beneficial components.
     </p>
   </div>,
   <hr
@@ -1401,7 +1401,7 @@ Array [
       <strong>
         beneficial components
       </strong>
-       hold promise for positive impact on student learning, but may only be relevant and useful for some reviewers. Some of the scoring treat essential and beneficial components differently, but you’re still required to answer all beneficial components.
+       hold promise for positive impact on student learning, but may only be relevant and useful for some reviewers. Some of the scoring treats essential and beneficial components differently, but you’re still required to answer all beneficial components.
     </p>
   </div>,
   <hr
@@ -2925,7 +2925,7 @@ Array [
       <strong>
         beneficial components
       </strong>
-       hold promise for positive impact on student learning, but may only be relevant and useful for some reviewers. Some of the scoring treat essential and beneficial components differently, but you’re still required to answer all beneficial components.
+       hold promise for positive impact on student learning, but may only be relevant and useful for some reviewers. Some of the scoring treats essential and beneficial components differently, but you’re still required to answer all beneficial components.
     </p>
   </div>,
   <hr
@@ -4704,7 +4704,7 @@ Array [
       <strong>
         beneficial components
       </strong>
-       hold promise for positive impact on student learning, but may only be relevant and useful for some reviewers. Some of the scoring treat essential and beneficial components differently, but you’re still required to answer all beneficial components.
+       hold promise for positive impact on student learning, but may only be relevant and useful for some reviewers. Some of the scoring treats essential and beneficial components differently, but you’re still required to answer all beneficial components.
     </p>
   </div>,
   <hr

--- a/teachers_digital_platform/crtool/src/__tests__/__snapshots__/QualityCriterionPage.test.js.snap
+++ b/teachers_digital_platform/crtool/src/__tests__/__snapshots__/QualityCriterionPage.test.js.snap
@@ -155,7 +155,7 @@ Array [
       <strong>
         beneficial components
       </strong>
-       hold promise for positive impact on student learning, but may only be relevant and useful for some reviewers. Some of the scoring treat essential and beneficial components differently, but you’re still required to answer all beneficial components.
+       hold promise for positive impact on student learning, but may only be relevant and useful for some reviewers. Some of the scoring treats essential and beneficial components differently, but you’re still required to answer all beneficial components.
     </p>
   </div>,
   <hr
@@ -1158,7 +1158,7 @@ Array [
       <strong>
         beneficial components
       </strong>
-       hold promise for positive impact on student learning, but may only be relevant and useful for some reviewers. Some of the scoring treat essential and beneficial components differently, but you’re still required to answer all beneficial components.
+       hold promise for positive impact on student learning, but may only be relevant and useful for some reviewers. Some of the scoring treats essential and beneficial components differently, but you’re still required to answer all beneficial components.
     </p>
   </div>,
   <hr
@@ -3604,7 +3604,7 @@ Array [
       <strong>
         beneficial components
       </strong>
-       hold promise for positive impact on student learning, but may only be relevant and useful for some reviewers. Some of the scoring treat essential and beneficial components differently, but you’re still required to answer all beneficial components.
+       hold promise for positive impact on student learning, but may only be relevant and useful for some reviewers. Some of the scoring treats essential and beneficial components differently, but you’re still required to answer all beneficial components.
     </p>
   </div>,
   <hr
@@ -4971,7 +4971,7 @@ Array [
       <strong>
         beneficial components
       </strong>
-       hold promise for positive impact on student learning, but may only be relevant and useful for some reviewers. Some of the scoring treat essential and beneficial components differently, but you’re still required to answer all beneficial components.
+       hold promise for positive impact on student learning, but may only be relevant and useful for some reviewers. Some of the scoring treats essential and beneficial components differently, but you’re still required to answer all beneficial components.
     </p>
   </div>,
   <hr
@@ -5974,7 +5974,7 @@ Array [
       <strong>
         beneficial components
       </strong>
-       hold promise for positive impact on student learning, but may only be relevant and useful for some reviewers. Some of the scoring treat essential and beneficial components differently, but you’re still required to answer all beneficial components.
+       hold promise for positive impact on student learning, but may only be relevant and useful for some reviewers. Some of the scoring treats essential and beneficial components differently, but you’re still required to answer all beneficial components.
     </p>
   </div>,
   <hr

--- a/teachers_digital_platform/crtool/src/__tests__/__snapshots__/UtilityCriterionPage.test.js.snap
+++ b/teachers_digital_platform/crtool/src/__tests__/__snapshots__/UtilityCriterionPage.test.js.snap
@@ -160,7 +160,7 @@ Array [
       <strong>
         beneficial components
       </strong>
-       hold promise for positive impact on student learning, but may only be relevant and useful for some reviewers. Some of the scoring treat essential and beneficial components differently, but you’re still required to answer all beneficial components.
+       hold promise for positive impact on student learning, but may only be relevant and useful for some reviewers. Some of the scoring treats essential and beneficial components differently, but you’re still required to answer all beneficial components.
     </p>
   </div>,
   <hr
@@ -1125,7 +1125,7 @@ Array [
       <strong>
         beneficial components
       </strong>
-       hold promise for positive impact on student learning, but may only be relevant and useful for some reviewers. Some of the scoring treat essential and beneficial components differently, but you’re still required to answer all beneficial components.
+       hold promise for positive impact on student learning, but may only be relevant and useful for some reviewers. Some of the scoring treats essential and beneficial components differently, but you’re still required to answer all beneficial components.
     </p>
   </div>,
   <hr
@@ -5956,7 +5956,7 @@ Array [
       <strong>
         beneficial components
       </strong>
-       hold promise for positive impact on student learning, but may only be relevant and useful for some reviewers. Some of the scoring treat essential and beneficial components differently, but you’re still required to answer all beneficial components.
+       hold promise for positive impact on student learning, but may only be relevant and useful for some reviewers. Some of the scoring treats essential and beneficial components differently, but you’re still required to answer all beneficial components.
     </p>
   </div>,
   <hr
@@ -8397,7 +8397,7 @@ Array [
       <strong>
         beneficial components
       </strong>
-       hold promise for positive impact on student learning, but may only be relevant and useful for some reviewers. Some of the scoring treat essential and beneficial components differently, but you’re still required to answer all beneficial components.
+       hold promise for positive impact on student learning, but may only be relevant and useful for some reviewers. Some of the scoring treats essential and beneficial components differently, but you’re still required to answer all beneficial components.
     </p>
   </div>,
   <hr
@@ -9362,7 +9362,7 @@ Array [
       <strong>
         beneficial components
       </strong>
-       hold promise for positive impact on student learning, but may only be relevant and useful for some reviewers. Some of the scoring treat essential and beneficial components differently, but you’re still required to answer all beneficial components.
+       hold promise for positive impact on student learning, but may only be relevant and useful for some reviewers. Some of the scoring treats essential and beneficial components differently, but you’re still required to answer all beneficial components.
     </p>
   </div>,
   <hr

--- a/teachers_digital_platform/crtool/src/js/components/pages/EfficacyCriterionPage.js
+++ b/teachers_digital_platform/crtool/src/js/components/pages/EfficacyCriterionPage.js
@@ -148,7 +148,7 @@ export default class EfficacyCriterionPage extends React.Component {
                                 u-mb30
                                 u-mt30">
                     <h4>What’s a beneficial component?</h4>
-                    <p>While most components in this dimension are essential to your review (have been shown to positively impact student learning), some are marked as beneficial. These <strong>beneficial components</strong> hold promise for positive impact on student learning, but may only be relevant and useful for some reviewers. Some of the scoring treat essential and beneficial components differently, but you’re still required to answer all beneficial components.</p>
+                    <p>While most components in this dimension are essential to your review (have been shown to positively impact student learning), some are marked as beneficial. These <strong>beneficial components</strong> hold promise for positive impact on student learning, but may only be relevant and useful for some reviewers. Some of the scoring treats essential and beneficial components differently, but you’re still required to answer all beneficial components.</p>
                 </div>
                 <hr className="hr
                                 u-mb30

--- a/teachers_digital_platform/crtool/src/js/components/pages/QualityCriterionPage.js
+++ b/teachers_digital_platform/crtool/src/js/components/pages/QualityCriterionPage.js
@@ -27,7 +27,7 @@ export default class QualityCriterionPage extends React.Component {
                         (this.props.currentPage === C.UTILITY_PAGE && this.props.utilityInProgress === C.STATUS_COMPLETE) ||
                         (this.props.currentPage === C.EFFICACY_PAGE && this.props.efficacyInProgress === C.STATUS_COMPLETE) ));
     }
-    
+
     render() {
         return (
             <React.Fragment>
@@ -59,7 +59,7 @@ export default class QualityCriterionPage extends React.Component {
                                 u-mb30
                                 u-mt30">
                     <h4>What’s a beneficial component?</h4>
-                    <p>While most components in this dimension are essential to your review (have been shown to positively impact student learning), some are marked as beneficial. These <strong>beneficial components</strong> hold promise for positive impact on student learning, but may only be relevant and useful for some reviewers. Some of the scoring treat essential and beneficial components differently, but you’re still required to answer all beneficial components.</p>
+                    <p>While most components in this dimension are essential to your review (have been shown to positively impact student learning), some are marked as beneficial. These <strong>beneficial components</strong> hold promise for positive impact on student learning, but may only be relevant and useful for some reviewers. Some of the scoring treats essential and beneficial components differently, but you’re still required to answer all beneficial components.</p>
                 </div>
                 <hr className="hr
                                 u-mb30

--- a/teachers_digital_platform/crtool/src/js/components/pages/UtilityCriterionPage.js
+++ b/teachers_digital_platform/crtool/src/js/components/pages/UtilityCriterionPage.js
@@ -27,7 +27,7 @@ export default class UtilityCriterionPage extends React.Component {
                         (this.props.currentPage === C.UTILITY_PAGE && this.props.utilityInProgress === C.STATUS_COMPLETE) ||
                         (this.props.currentPage === C.EFFICACY_PAGE && this.props.efficacyInProgress === C.STATUS_COMPLETE) ));
     }
-    
+
     render() {
         return (
             <React.Fragment>
@@ -59,7 +59,7 @@ export default class UtilityCriterionPage extends React.Component {
                                 u-mb30
                                 u-mt30">
                     <h4>What’s a beneficial component?</h4>
-                    <p>While most components in this dimension are essential to your review (have been shown to positively impact student learning), some are marked as beneficial. These <strong>beneficial components</strong> hold promise for positive impact on student learning, but may only be relevant and useful for some reviewers. Some of the scoring treat essential and beneficial components differently, but you’re still required to answer all beneficial components.</p>
+                    <p>While most components in this dimension are essential to your review (have been shown to positively impact student learning), some are marked as beneficial. These <strong>beneficial components</strong> hold promise for positive impact on student learning, but may only be relevant and useful for some reviewers. Some of the scoring treats essential and beneficial components differently, but you’re still required to answer all beneficial components.</p>
                 </div>
                 <hr className="hr
                                 u-mb30


### PR DESCRIPTION
Fix typo on efficacy, quality, and utility survey pages.

## Changes

- Fix typo on efficacy, quality, and utility survey pages

## Review

- @rrstoll 

[Preview this PR without the whitespace changes](?w=0)
