### PR TITLE
GH136: Adding max-width to fix IE11 bug

### DIFF
--- a/teachers_digital_platform/css/organisms/survey.less
+++ b/teachers_digital_platform/css/organisms/survey.less
@@ -116,7 +116,9 @@ li.o-survey {
     }
 }
 
-.o-survey_legend {}
+.o-survey_legend {
+    max-width: 100%;
+}
 
 .o-survey_question-helper {
     color: @gray;


### PR DESCRIPTION
Adding max-width: 100% fixes the issue on the survey and print pages and doesn't affect Chrome.