### PR TITLE
Added google analytics to the CR-Tool

### DIFF
--- a/teachers_digital_platform/crtool/src/__tests__/__snapshots__/ContentElementaryCriterionPage.test.js.snap
+++ b/teachers_digital_platform/crtool/src/__tests__/__snapshots__/ContentElementaryCriterionPage.test.js.snap
@@ -319,10 +319,10 @@ Array [
       </label>
       <textarea
         className="a-text-input a-text-input__full"
+        defaultValue={undefined}
         id="content-elementary-crt-notes-optional-1"
-        onChange={[Function]}
+        onBlur={[Function]}
         rows="6"
-        value={undefined}
       />
     </div>
   </div>,
@@ -685,10 +685,10 @@ Array [
       </label>
       <textarea
         className="a-text-input a-text-input__full"
+        defaultValue={undefined}
         id="content-elementary-crt-notes-optional-1"
-        onChange={[Function]}
+        onBlur={[Function]}
         rows="6"
-        value={undefined}
       />
     </div>
   </div>,
@@ -1077,10 +1077,10 @@ Array [
       </label>
       <textarea
         className="a-text-input a-text-input__full"
+        defaultValue={undefined}
         id="content-elementary-crt-notes-optional-2"
-        onChange={[Function]}
+        onBlur={[Function]}
         rows="6"
-        value={undefined}
       />
     </div>
   </div>,
@@ -1557,10 +1557,10 @@ Array [
       </label>
       <textarea
         className="a-text-input a-text-input__full"
+        defaultValue={undefined}
         id="content-elementary-crt-notes-optional-3"
-        onChange={[Function]}
+        onBlur={[Function]}
         rows="6"
-        value={undefined}
       />
     </div>
   </div>,
@@ -1759,10 +1759,10 @@ Array [
       </label>
       <textarea
         className="a-text-input a-text-input__full"
+        defaultValue={undefined}
         id="content-elementary-crt-notes-optional-4"
-        onChange={[Function]}
+        onBlur={[Function]}
         rows="6"
-        value={undefined}
       />
     </div>
   </div>,
@@ -1961,10 +1961,10 @@ Array [
       </label>
       <textarea
         className="a-text-input a-text-input__full"
+        defaultValue={undefined}
         id="content-elementary-crt-notes-optional-5"
-        onChange={[Function]}
+        onBlur={[Function]}
         rows="6"
-        value={undefined}
       />
     </div>
   </div>,
@@ -2327,10 +2327,10 @@ Array [
       </label>
       <textarea
         className="a-text-input a-text-input__full"
+        defaultValue={undefined}
         id="content-elementary-crt-notes-optional-1"
-        onChange={[Function]}
+        onBlur={[Function]}
         rows="6"
-        value={undefined}
       />
     </div>
   </div>,
@@ -2719,10 +2719,10 @@ Array [
       </label>
       <textarea
         className="a-text-input a-text-input__full"
+        defaultValue={undefined}
         id="content-elementary-crt-notes-optional-2"
-        onChange={[Function]}
+        onBlur={[Function]}
         rows="6"
-        value={undefined}
       />
     </div>
   </div>,
@@ -3085,10 +3085,10 @@ Array [
       </label>
       <textarea
         className="a-text-input a-text-input__full"
+        defaultValue={undefined}
         id="content-elementary-crt-notes-optional-1"
-        onChange={[Function]}
+        onBlur={[Function]}
         rows="6"
-        value={undefined}
       />
     </div>
   </div>,
@@ -3464,10 +3464,10 @@ Array [
       </label>
       <textarea
         className="a-text-input a-text-input__full"
+        defaultValue={undefined}
         id="content-elementary-crt-notes-optional-1"
-        onChange={[Function]}
+        onBlur={[Function]}
         rows="6"
-        value={undefined}
       />
     </div>
   </div>,

--- a/teachers_digital_platform/crtool/src/__tests__/__snapshots__/ContentElementaryCriterionPage.test.js.snap
+++ b/teachers_digital_platform/crtool/src/__tests__/__snapshots__/ContentElementaryCriterionPage.test.js.snap
@@ -42,6 +42,7 @@ Array [
     This dimension assesses whether the curriculum content helps students develop knowledge, skills, and behaviors that are important for financial capability. Evaluation criteria are based on research and major national and state education standards. 
     <a
       href="https://files.consumerfinance.gov/f/documents/cfpb_youth-financialeducation-curriculum-review.pdf"
+      onClick={[Function]}
       rel="noopener noreferrer"
       target="_blank"
     >
@@ -408,6 +409,7 @@ Array [
     This dimension assesses whether the curriculum content helps students develop knowledge, skills, and behaviors that are important for financial capability. Evaluation criteria are based on research and major national and state education standards. 
     <a
       href="https://files.consumerfinance.gov/f/documents/cfpb_youth-financialeducation-curriculum-review.pdf"
+      onClick={[Function]}
       rel="noopener noreferrer"
       target="_blank"
     >
@@ -2050,6 +2052,7 @@ Array [
     This dimension assesses whether the curriculum content helps students develop knowledge, skills, and behaviors that are important for financial capability. Evaluation criteria are based on research and major national and state education standards. 
     <a
       href="https://files.consumerfinance.gov/f/documents/cfpb_youth-financialeducation-curriculum-review.pdf"
+      onClick={[Function]}
       rel="noopener noreferrer"
       target="_blank"
     >
@@ -2808,6 +2811,7 @@ Array [
     This dimension assesses whether the curriculum content helps students develop knowledge, skills, and behaviors that are important for financial capability. Evaluation criteria are based on research and major national and state education standards. 
     <a
       href="https://files.consumerfinance.gov/f/documents/cfpb_youth-financialeducation-curriculum-review.pdf"
+      onClick={[Function]}
       rel="noopener noreferrer"
       target="_blank"
     >
@@ -3174,6 +3178,7 @@ Array [
     This dimension assesses whether the curriculum content helps students develop knowledge, skills, and behaviors that are important for financial capability. Evaluation criteria are based on research and major national and state education standards. 
     <a
       href="https://files.consumerfinance.gov/f/documents/cfpb_youth-financialeducation-curriculum-review.pdf"
+      onClick={[Function]}
       rel="noopener noreferrer"
       target="_blank"
     >

--- a/teachers_digital_platform/crtool/src/__tests__/__snapshots__/ContentElementaryCriterionPage.test.js.snap
+++ b/teachers_digital_platform/crtool/src/__tests__/__snapshots__/ContentElementaryCriterionPage.test.js.snap
@@ -74,6 +74,7 @@ Array [
   <p>
     <button
       className="a-btn a-btn__link"
+      data-gtm_ignore="true"
       onClick={[Function]}
     >
       How can I save my work?
@@ -439,6 +440,7 @@ Array [
   <p>
     <button
       className="a-btn a-btn__link"
+      data-gtm_ignore="true"
       onClick={[Function]}
     >
       How can I save my work?
@@ -2080,6 +2082,7 @@ Array [
   <p>
     <button
       className="a-btn a-btn__link"
+      data-gtm_ignore="true"
       onClick={[Function]}
     >
       How can I save my work?
@@ -2837,6 +2840,7 @@ Array [
   <p>
     <button
       className="a-btn a-btn__link"
+      data-gtm_ignore="true"
       onClick={[Function]}
     >
       How can I save my work?
@@ -3202,6 +3206,7 @@ Array [
   <p>
     <button
       className="a-btn a-btn__link"
+      data-gtm_ignore="true"
       onClick={[Function]}
     >
       How can I save my work?

--- a/teachers_digital_platform/crtool/src/__tests__/__snapshots__/EfficacyCriterionPage.test.js.snap
+++ b/teachers_digital_platform/crtool/src/__tests__/__snapshots__/EfficacyCriterionPage.test.js.snap
@@ -1214,6 +1214,7 @@ Array [
     >
       <button
         className="a-btn a-btn__link a-btn__no-line"
+        data-gtm_ignore="true"
         onClick={[Function]}
       >
         Review another study
@@ -2500,6 +2501,7 @@ Array [
     >
       <button
         className="a-btn a-btn__link a-btn__no-line"
+        data-gtm_ignore="true"
         onClick={[Function]}
       >
         Review another study
@@ -4063,6 +4065,7 @@ Array [
     >
       <button
         className="a-btn a-btn__link a-btn__no-line"
+        data-gtm_ignore="true"
         onClick={[Function]}
       >
         Review another study
@@ -5877,6 +5880,7 @@ Array [
     >
       <button
         className="a-btn a-btn__link a-btn__no-line"
+        data-gtm_ignore="true"
         onClick={[Function]}
       >
         Review another study

--- a/teachers_digital_platform/crtool/src/__tests__/__snapshots__/EfficacyCriterionPage.test.js.snap
+++ b/teachers_digital_platform/crtool/src/__tests__/__snapshots__/EfficacyCriterionPage.test.js.snap
@@ -149,10 +149,10 @@ Array [
         </label>
         <input
           className="a-text-input a-text-input__full"
+          defaultValue={undefined}
           id="efficacy-crt-question-#0#study"
-          onChange={[Function]}
+          onBlur={[Function]}
           type="text"
-          value={undefined}
         />
       </div>
     </div>
@@ -1203,10 +1203,10 @@ Array [
       </label>
       <textarea
         className="a-text-input a-text-input__full u-mb30"
+        defaultValue={undefined}
         id="efficacy-crt-question-1#0#_notes_optional"
-        onChange={[Function]}
+        onBlur={[Function]}
         rows="6"
-        value={undefined}
       />
     </div>
     <div
@@ -1408,10 +1408,10 @@ Array [
         </label>
         <input
           className="a-text-input a-text-input__full"
+          defaultValue={undefined}
           id="efficacy-crt-question-#0#study"
-          onChange={[Function]}
+          onBlur={[Function]}
           type="text"
-          value={undefined}
         />
       </div>
     </div>
@@ -2462,10 +2462,10 @@ Array [
       </label>
       <textarea
         className="a-text-input a-text-input__full u-mb30"
+        defaultValue={undefined}
         id="efficacy-crt-question-1#0#_notes_optional"
-        onChange={[Function]}
+        onBlur={[Function]}
         rows="6"
-        value={undefined}
       />
     </div>
     <div
@@ -2770,10 +2770,10 @@ Array [
       </label>
       <textarea
         className="a-text-input a-text-input__full"
+        defaultValue={undefined}
         id="efficacy-crt-notes-optional-2"
-        onChange={[Function]}
+        onBlur={[Function]}
         rows="6"
-        value={undefined}
       />
     </div>
   </div>,
@@ -2972,10 +2972,10 @@ Array [
         </label>
         <input
           className="a-text-input a-text-input__full"
+          defaultValue={undefined}
           id="efficacy-crt-question-#0#study"
-          onChange={[Function]}
+          onBlur={[Function]}
           type="text"
-          value={undefined}
         />
       </div>
     </div>
@@ -4026,10 +4026,10 @@ Array [
       </label>
       <textarea
         className="a-text-input a-text-input__full u-mb30"
+        defaultValue={undefined}
         id="efficacy-crt-question-1#0#_notes_optional"
-        onChange={[Function]}
+        onBlur={[Function]}
         rows="6"
-        value={undefined}
       />
     </div>
     <div
@@ -4334,10 +4334,10 @@ Array [
       </label>
       <textarea
         className="a-text-input a-text-input__full"
+        defaultValue={undefined}
         id="efficacy-crt-notes-optional-2"
-        onChange={[Function]}
+        onBlur={[Function]}
         rows="6"
-        value={undefined}
       />
     </div>
   </div>,
@@ -4640,10 +4640,10 @@ Array [
       </label>
       <textarea
         className="a-text-input a-text-input__full"
+        defaultValue={undefined}
         id="efficacy-crt-notes-optional-3"
-        onChange={[Function]}
+        onBlur={[Function]}
         rows="6"
-        value={undefined}
       />
     </div>
   </div>,
@@ -4815,10 +4815,10 @@ Array [
         </label>
         <input
           className="a-text-input a-text-input__full"
+          defaultValue={undefined}
           id="efficacy-crt-question-#0#study"
-          onChange={[Function]}
+          onBlur={[Function]}
           type="text"
-          value={undefined}
         />
       </div>
     </div>
@@ -5869,10 +5869,10 @@ Array [
       </label>
       <textarea
         className="a-text-input a-text-input__full u-mb30"
+        defaultValue={undefined}
         id="efficacy-crt-question-1#0#_notes_optional"
-        onChange={[Function]}
+        onBlur={[Function]}
         rows="6"
-        value={undefined}
       />
     </div>
     <div

--- a/teachers_digital_platform/crtool/src/__tests__/__snapshots__/EfficacyCriterionPage.test.js.snap
+++ b/teachers_digital_platform/crtool/src/__tests__/__snapshots__/EfficacyCriterionPage.test.js.snap
@@ -81,6 +81,7 @@ Array [
   <p>
     <button
       className="a-btn a-btn__link"
+      data-gtm_ignore="true"
       onClick={[Function]}
     >
       How can I save my work?
@@ -1325,6 +1326,7 @@ Array [
   <p>
     <button
       className="a-btn a-btn__link"
+      data-gtm_ignore="true"
       onClick={[Function]}
     >
       How can I save my work?
@@ -2887,6 +2889,7 @@ Array [
   <p>
     <button
       className="a-btn a-btn__link"
+      data-gtm_ignore="true"
       onClick={[Function]}
     >
       How can I save my work?
@@ -4728,6 +4731,7 @@ Array [
   <p>
     <button
       className="a-btn a-btn__link"
+      data-gtm_ignore="true"
       onClick={[Function]}
     >
       How can I save my work?

--- a/teachers_digital_platform/crtool/src/__tests__/__snapshots__/EfficacyCriterionPage.test.js.snap
+++ b/teachers_digital_platform/crtool/src/__tests__/__snapshots__/EfficacyCriterionPage.test.js.snap
@@ -34,6 +34,7 @@ Array [
     The efficacy dimension assesses the measurable impact the curriculum has had on students by looking at high-quality studies that have been done about its effectiveness. Evaluation criteria are based on research and major national and state education standards. 
     <a
       href="https://files.consumerfinance.gov/f/documents/cfpb_youth-financialeducation-curriculum-review.pdf"
+      onClick={[Function]}
       rel="noopener noreferrer"
       target="_blank"
     >
@@ -1280,6 +1281,7 @@ Array [
     The efficacy dimension assesses the measurable impact the curriculum has had on students by looking at high-quality studies that have been done about its effectiveness. Evaluation criteria are based on research and major national and state education standards. 
     <a
       href="https://files.consumerfinance.gov/f/documents/cfpb_youth-financialeducation-curriculum-review.pdf"
+      onClick={[Function]}
       rel="noopener noreferrer"
       target="_blank"
     >
@@ -2844,6 +2846,7 @@ Array [
     The efficacy dimension assesses the measurable impact the curriculum has had on students by looking at high-quality studies that have been done about its effectiveness. Evaluation criteria are based on research and major national and state education standards. 
     <a
       href="https://files.consumerfinance.gov/f/documents/cfpb_youth-financialeducation-curriculum-review.pdf"
+      onClick={[Function]}
       rel="noopener noreferrer"
       target="_blank"
     >
@@ -4687,6 +4690,7 @@ Array [
     The efficacy dimension assesses the measurable impact the curriculum has had on students by looking at high-quality studies that have been done about its effectiveness. Evaluation criteria are based on research and major national and state education standards. 
     <a
       href="https://files.consumerfinance.gov/f/documents/cfpb_youth-financialeducation-curriculum-review.pdf"
+      onClick={[Function]}
       rel="noopener noreferrer"
       target="_blank"
     >

--- a/teachers_digital_platform/crtool/src/__tests__/__snapshots__/QualityCriterionPage.test.js.snap
+++ b/teachers_digital_platform/crtool/src/__tests__/__snapshots__/QualityCriterionPage.test.js.snap
@@ -57,6 +57,7 @@ Array [
   <p>
     <button
       className="a-btn a-btn__link"
+      data-gtm_ignore="true"
       onClick={[Function]}
     >
       How can I save my work?
@@ -1042,6 +1043,7 @@ Array [
   <p>
     <button
       className="a-btn a-btn__link"
+      data-gtm_ignore="true"
       onClick={[Function]}
     >
       How can I save my work?
@@ -3622,6 +3624,7 @@ Array [
   <p>
     <button
       className="a-btn a-btn__link"
+      data-gtm_ignore="true"
       onClick={[Function]}
     >
       How can I save my work?
@@ -5003,6 +5006,7 @@ Array [
   <p>
     <button
       className="a-btn a-btn__link"
+      data-gtm_ignore="true"
       onClick={[Function]}
     >
       How can I save my work?
@@ -5988,6 +5992,7 @@ Array [
   <p>
     <button
       className="a-btn a-btn__link"
+      data-gtm_ignore="true"
       onClick={[Function]}
     >
       How can I save my work?

--- a/teachers_digital_platform/crtool/src/__tests__/__snapshots__/QualityCriterionPage.test.js.snap
+++ b/teachers_digital_platform/crtool/src/__tests__/__snapshots__/QualityCriterionPage.test.js.snap
@@ -174,11 +174,11 @@ Array [
                   </label>
                   <input
                     className="a-text-input a-text-input__full"
+                    defaultValue={undefined}
                     id="quality-crt-text-optional-1.1.1"
-                    onChange={[Function]}
+                    onBlur={[Function]}
                     placeholder="$"
                     type="text"
-                    value={undefined}
                   />
                 </div>
               </div>
@@ -939,10 +939,10 @@ Array [
       </label>
       <textarea
         className="a-text-input a-text-input__full"
+        defaultValue={undefined}
         id="quality-crt-notes-optional-1"
-        onChange={[Function]}
+        onBlur={[Function]}
         rows="6"
-        value={undefined}
       />
     </div>
   </div>,
@@ -1160,11 +1160,11 @@ Array [
                   </label>
                   <input
                     className="a-text-input a-text-input__full"
+                    defaultValue={undefined}
                     id="quality-crt-text-optional-1.1.1"
-                    onChange={[Function]}
+                    onBlur={[Function]}
                     placeholder="$"
                     type="text"
-                    value={undefined}
                   />
                 </div>
               </div>
@@ -1925,10 +1925,10 @@ Array [
       </label>
       <textarea
         className="a-text-input a-text-input__full"
+        defaultValue={undefined}
         id="quality-crt-notes-optional-1"
-        onChange={[Function]}
+        onBlur={[Function]}
         rows="6"
-        value={undefined}
       />
     </div>
   </div>,
@@ -2321,10 +2321,10 @@ Array [
       </label>
       <textarea
         className="a-text-input a-text-input__full"
+        defaultValue={undefined}
         id="quality-crt-notes-optional-2"
-        onChange={[Function]}
+        onBlur={[Function]}
         rows="6"
-        value={undefined}
       />
     </div>
   </div>,
@@ -2901,10 +2901,10 @@ Array [
       </label>
       <textarea
         className="a-text-input a-text-input__full"
+        defaultValue={undefined}
         id="quality-crt-notes-optional-3"
-        onChange={[Function]}
+        onBlur={[Function]}
         rows="6"
-        value={undefined}
       />
     </div>
   </div>,
@@ -3547,10 +3547,10 @@ Array [
       </label>
       <textarea
         className="a-text-input a-text-input__full"
+        defaultValue={undefined}
         id="quality-crt-notes-optional-4"
-        onChange={[Function]}
+        onBlur={[Function]}
         rows="6"
-        value={undefined}
       />
     </div>
   </div>,
@@ -3741,11 +3741,11 @@ Array [
                   </label>
                   <input
                     className="a-text-input a-text-input__full"
+                    defaultValue={undefined}
                     id="quality-crt-text-optional-1.1.1"
-                    onChange={[Function]}
+                    onBlur={[Function]}
                     placeholder="$"
                     type="text"
-                    value={undefined}
                   />
                 </div>
               </div>
@@ -4506,10 +4506,10 @@ Array [
       </label>
       <textarea
         className="a-text-input a-text-input__full"
+        defaultValue={undefined}
         id="quality-crt-notes-optional-1"
-        onChange={[Function]}
+        onBlur={[Function]}
         rows="6"
-        value={undefined}
       />
     </div>
   </div>,
@@ -4902,10 +4902,10 @@ Array [
       </label>
       <textarea
         className="a-text-input a-text-input__full"
+        defaultValue={undefined}
         id="quality-crt-notes-optional-2"
-        onChange={[Function]}
+        onBlur={[Function]}
         rows="6"
-        value={undefined}
       />
     </div>
   </div>,
@@ -5123,11 +5123,11 @@ Array [
                   </label>
                   <input
                     className="a-text-input a-text-input__full"
+                    defaultValue={undefined}
                     id="quality-crt-text-optional-1.1.1"
-                    onChange={[Function]}
+                    onBlur={[Function]}
                     placeholder="$"
                     type="text"
-                    value={undefined}
                   />
                 </div>
               </div>
@@ -5888,10 +5888,10 @@ Array [
       </label>
       <textarea
         className="a-text-input a-text-input__full"
+        defaultValue={undefined}
         id="quality-crt-notes-optional-1"
-        onChange={[Function]}
+        onBlur={[Function]}
         rows="6"
-        value={undefined}
       />
     </div>
   </div>,
@@ -6122,11 +6122,11 @@ Array [
                   </label>
                   <input
                     className="a-text-input a-text-input__full"
+                    defaultValue={undefined}
                     id="quality-crt-text-optional-1.1.1"
-                    onChange={[Function]}
+                    onBlur={[Function]}
                     placeholder="$"
                     type="text"
-                    value={undefined}
                   />
                 </div>
               </div>
@@ -6887,10 +6887,10 @@ Array [
       </label>
       <textarea
         className="a-text-input a-text-input__full"
+        defaultValue={undefined}
         id="quality-crt-notes-optional-1"
-        onChange={[Function]}
+        onBlur={[Function]}
         rows="6"
-        value={undefined}
       />
     </div>
   </div>,

--- a/teachers_digital_platform/crtool/src/__tests__/__snapshots__/QualityCriterionPage.test.js.snap
+++ b/teachers_digital_platform/crtool/src/__tests__/__snapshots__/QualityCriterionPage.test.js.snap
@@ -31,6 +31,7 @@ Array [
     The quality dimension assesses whether curriculum materials are clear, accurate, and objective and how easy the materials are for teachers and students to access. Evaluation criteria are based on research and major national and state education standards. 
     <a
       href="https://files.consumerfinance.gov/f/documents/cfpb_youth-financialeducation-curriculum-review.pdf"
+      onClick={[Function]}
       rel="noopener noreferrer"
       target="_blank"
     >
@@ -1017,6 +1018,7 @@ Array [
     The quality dimension assesses whether curriculum materials are clear, accurate, and objective and how easy the materials are for teachers and students to access. Evaluation criteria are based on research and major national and state education standards. 
     <a
       href="https://files.consumerfinance.gov/f/documents/cfpb_youth-financialeducation-curriculum-review.pdf"
+      onClick={[Function]}
       rel="noopener noreferrer"
       target="_blank"
     >
@@ -3598,6 +3600,7 @@ Array [
     The quality dimension assesses whether curriculum materials are clear, accurate, and objective and how easy the materials are for teachers and students to access. Evaluation criteria are based on research and major national and state education standards. 
     <a
       href="https://files.consumerfinance.gov/f/documents/cfpb_youth-financialeducation-curriculum-review.pdf"
+      onClick={[Function]}
       rel="noopener noreferrer"
       target="_blank"
     >
@@ -4980,6 +4983,7 @@ Array [
     The quality dimension assesses whether curriculum materials are clear, accurate, and objective and how easy the materials are for teachers and students to access. Evaluation criteria are based on research and major national and state education standards. 
     <a
       href="https://files.consumerfinance.gov/f/documents/cfpb_youth-financialeducation-curriculum-review.pdf"
+      onClick={[Function]}
       rel="noopener noreferrer"
       target="_blank"
     >
@@ -5966,6 +5970,7 @@ Array [
     The quality dimension assesses whether curriculum materials are clear, accurate, and objective and how easy the materials are for teachers and students to access. Evaluation criteria are based on research and major national and state education standards. 
     <a
       href="https://files.consumerfinance.gov/f/documents/cfpb_youth-financialeducation-curriculum-review.pdf"
+      onClick={[Function]}
       rel="noopener noreferrer"
       target="_blank"
     >

--- a/teachers_digital_platform/crtool/src/__tests__/__snapshots__/UtilityCriterionPage.test.js.snap
+++ b/teachers_digital_platform/crtool/src/__tests__/__snapshots__/UtilityCriterionPage.test.js.snap
@@ -36,6 +36,7 @@ Array [
     The utility dimension evaluates the supports for using the curriculum. Such supports include guidance for teachers, materials that facilitate strong and effective instruction, and assessments to measure student mastery of skills and knowledge. Evaluation criteria are based on research and major national and state education standards. 
     <a
       href="https://files.consumerfinance.gov/f/documents/cfpb_youth-financialeducation-curriculum-review.pdf"
+      onClick={[Function]}
       rel="noopener noreferrer"
       target="_blank"
     >
@@ -1000,6 +1001,7 @@ Array [
     The utility dimension evaluates the supports for using the curriculum. Such supports include guidance for teachers, materials that facilitate strong and effective instruction, and assessments to measure student mastery of skills and knowledge. Evaluation criteria are based on research and major national and state education standards. 
     <a
       href="https://files.consumerfinance.gov/f/documents/cfpb_youth-financialeducation-curriculum-review.pdf"
+      onClick={[Function]}
       rel="noopener noreferrer"
       target="_blank"
     >
@@ -6238,6 +6240,7 @@ Array [
     The utility dimension evaluates the supports for using the curriculum. Such supports include guidance for teachers, materials that facilitate strong and effective instruction, and assessments to measure student mastery of skills and knowledge. Evaluation criteria are based on research and major national and state education standards. 
     <a
       href="https://files.consumerfinance.gov/f/documents/cfpb_youth-financialeducation-curriculum-review.pdf"
+      onClick={[Function]}
       rel="noopener noreferrer"
       target="_blank"
     >
@@ -8846,6 +8849,7 @@ Array [
     The utility dimension evaluates the supports for using the curriculum. Such supports include guidance for teachers, materials that facilitate strong and effective instruction, and assessments to measure student mastery of skills and knowledge. Evaluation criteria are based on research and major national and state education standards. 
     <a
       href="https://files.consumerfinance.gov/f/documents/cfpb_youth-financialeducation-curriculum-review.pdf"
+      onClick={[Function]}
       rel="noopener noreferrer"
       target="_blank"
     >
@@ -9810,6 +9814,7 @@ Array [
     The utility dimension evaluates the supports for using the curriculum. Such supports include guidance for teachers, materials that facilitate strong and effective instruction, and assessments to measure student mastery of skills and knowledge. Evaluation criteria are based on research and major national and state education standards. 
     <a
       href="https://files.consumerfinance.gov/f/documents/cfpb_youth-financialeducation-curriculum-review.pdf"
+      onClick={[Function]}
       rel="noopener noreferrer"
       target="_blank"
     >

--- a/teachers_digital_platform/crtool/src/__tests__/__snapshots__/UtilityCriterionPage.test.js.snap
+++ b/teachers_digital_platform/crtool/src/__tests__/__snapshots__/UtilityCriterionPage.test.js.snap
@@ -917,10 +917,10 @@ Array [
       </label>
       <textarea
         className="a-text-input a-text-input__full"
+        defaultValue={undefined}
         id="utility-crt-notes-optional-1"
-        onChange={[Function]}
+        onBlur={[Function]}
         rows="6"
-        value={undefined}
       />
     </div>
   </div>,
@@ -1881,10 +1881,10 @@ Array [
       </label>
       <textarea
         className="a-text-input a-text-input__full"
+        defaultValue={undefined}
         id="utility-crt-notes-optional-1"
-        onChange={[Function]}
+        onBlur={[Function]}
         rows="6"
-        value={undefined}
       />
     </div>
   </div>,
@@ -3525,10 +3525,10 @@ Array [
       </label>
       <textarea
         className="a-text-input a-text-input__full"
+        defaultValue={undefined}
         id="utility-crt-notes-optional-2"
-        onChange={[Function]}
+        onBlur={[Function]}
         rows="6"
-        value={undefined}
       />
     </div>
   </div>,
@@ -4664,10 +4664,10 @@ Array [
       </label>
       <textarea
         className="a-text-input a-text-input__full"
+        defaultValue={undefined}
         id="utility-crt-notes-optional-3"
-        onChange={[Function]}
+        onBlur={[Function]}
         rows="6"
-        value={undefined}
       />
     </div>
   </div>,
@@ -5702,10 +5702,10 @@ Array [
       </label>
       <textarea
         className="a-text-input a-text-input__full"
+        defaultValue={undefined}
         id="utility-crt-notes-optional-4"
-        onChange={[Function]}
+        onBlur={[Function]}
         rows="6"
-        value={undefined}
       />
     </div>
   </div>,
@@ -6182,10 +6182,10 @@ Array [
       </label>
       <textarea
         className="a-text-input a-text-input__full"
+        defaultValue={undefined}
         id="utility-crt-notes-optional-5"
-        onChange={[Function]}
+        onBlur={[Function]}
         rows="6"
-        value={undefined}
       />
     </div>
   </div>,
@@ -7119,10 +7119,10 @@ Array [
       </label>
       <textarea
         className="a-text-input a-text-input__full"
+        defaultValue={undefined}
         id="utility-crt-notes-optional-1"
-        onChange={[Function]}
+        onBlur={[Function]}
         rows="6"
-        value={undefined}
       />
     </div>
   </div>,
@@ -8763,10 +8763,10 @@ Array [
       </label>
       <textarea
         className="a-text-input a-text-input__full"
+        defaultValue={undefined}
         id="utility-crt-notes-optional-2"
-        onChange={[Function]}
+        onBlur={[Function]}
         rows="6"
-        value={undefined}
       />
     </div>
   </div>,
@@ -9727,10 +9727,10 @@ Array [
       </label>
       <textarea
         className="a-text-input a-text-input__full"
+        defaultValue={undefined}
         id="utility-crt-notes-optional-1"
-        onChange={[Function]}
+        onBlur={[Function]}
         rows="6"
-        value={undefined}
       />
     </div>
   </div>,
@@ -10704,10 +10704,10 @@ Array [
       </label>
       <textarea
         className="a-text-input a-text-input__full"
+        defaultValue={undefined}
         id="utility-crt-notes-optional-1"
-        onChange={[Function]}
+        onBlur={[Function]}
         rows="6"
-        value={undefined}
       />
     </div>
   </div>,

--- a/teachers_digital_platform/crtool/src/__tests__/__snapshots__/UtilityCriterionPage.test.js.snap
+++ b/teachers_digital_platform/crtool/src/__tests__/__snapshots__/UtilityCriterionPage.test.js.snap
@@ -62,6 +62,7 @@ Array [
   <p>
     <button
       className="a-btn a-btn__link"
+      data-gtm_ignore="true"
       onClick={[Function]}
     >
       How can I save my work?
@@ -1025,6 +1026,7 @@ Array [
   <p>
     <button
       className="a-btn a-btn__link"
+      data-gtm_ignore="true"
       onClick={[Function]}
     >
       How can I save my work?
@@ -6262,6 +6264,7 @@ Array [
   <p>
     <button
       className="a-btn a-btn__link"
+      data-gtm_ignore="true"
       onClick={[Function]}
     >
       How can I save my work?
@@ -8869,6 +8872,7 @@ Array [
   <p>
     <button
       className="a-btn a-btn__link"
+      data-gtm_ignore="true"
       onClick={[Function]}
     >
       How can I save my work?
@@ -9832,6 +9836,7 @@ Array [
   <p>
     <button
       className="a-btn a-btn__link"
+      data-gtm_ignore="true"
       onClick={[Function]}
     >
       How can I save my work?

--- a/teachers_digital_platform/crtool/src/__tests__/__snapshots__/app_test.js.snap
+++ b/teachers_digital_platform/crtool/src/__tests__/__snapshots__/app_test.js.snap
@@ -9,6 +9,7 @@ exports[`renders without crashing 1`] = `
   >
     <button
       className="a-btn a-btn__link a-btn__no-line"
+      data-gtm_ignore="true"
       onClick={[Function]}
     >
       <span

--- a/teachers_digital_platform/crtool/src/js/business.logic/analytics.js
+++ b/teachers_digital_platform/crtool/src/js/business.logic/analytics.js
@@ -1,0 +1,84 @@
+/*
+ * Other uses of Analytics in public CFPB repositories.
+ * https://github.com/cfpb/ccdb5-ui/blob/77dcb86ecb8471d326e6c18d7f9bb1a809c922bf/src/actions/analytics.jsx#L1
+ * https://github.com/cfpb/college-costs/blob/969043ee4f879999cf91bbb481e64be620021d26/src/disclosures/js/utils/Analytics.js#L3
+ */
+import C from "./constants";
+
+const Analytics = {
+
+    tagManagerIsLoaded: false,
+  
+    EVENT_CATEGORY: 'Consumer Review Tool',
+  
+    /**
+     * Get data layer object.
+     * @param {string} action Name of event.
+     * @param {string} label DOM element label.
+     * @param {string} category Type of event.
+     * @param {Function} callback Function to call on GTM submission.
+     * @param {number} timeout Callback invocation fallback time.
+     * @returns {object} Data layer object.
+     */
+    getDataLayerOptions: function( action, label, category, callback, timeout ) {
+      return {
+        event:         category || Analytics.EVENT_CATEGORY,
+        action:        action,
+        label:         label || '',
+        eventCallback: callback,
+        eventTimeout:  timeout || 500
+      }
+    },
+  
+    /**
+     * Initialize the Analytics module.
+     */
+    init: function() {
+      // detect if Google tag manager is loaded
+      if ( window.hasOwnProperty( 'google_tag_manager' ) ) {
+        Analytics.tagManagerIsLoaded = true;
+      } else {
+        var _tagManager;
+        Object.defineProperty( window, 'google_tag_manager', {
+          enumerable: true,
+          configurable: true,
+          get: function() {
+            return _tagManager
+          },
+          set: function( value ) {
+            _tagManager = value;
+            Analytics.tagManagerIsLoaded = true;
+          }
+        } )
+      }
+    },
+  
+    /**
+     * @name sendEvent
+     * @kind function
+     *
+     * @description
+     * Pushes an event to the GTM dataLayer.
+     * @param {object} dataLayerOptions Type of event.
+     */
+    sendEvent: function( dataLayerOptions ) {
+        if (C.ANALYTICS_DEBUG_ON) {
+            console.log(dataLayerOptions);
+        } else {   
+            var callback = dataLayerOptions.eventCallback;
+            if ( Analytics.tagManagerIsLoaded ) {
+                window.dataLayer.push( dataLayerOptions );
+            } else if ( callback && typeof callback === 'function' ) {
+                callback(); // eslint-disable-line callback-return, inline-comments, max-len
+            }
+        }
+    }
+  
+    // sendEvents(array) for multiple events is here is required in future:
+    // https://github.com/cfpb/college-costs/blob/master/src/disclosures/js/utils/Analytics.js#L77
+  
+  }
+  
+  Analytics.init()
+  
+  export default Analytics

--- a/teachers_digital_platform/crtool/src/js/business.logic/analytics.js
+++ b/teachers_digital_platform/crtool/src/js/business.logic/analytics.js
@@ -9,7 +9,7 @@ const Analytics = {
 
     tagManagerIsLoaded: false,
   
-    EVENT_CATEGORY: 'Consumer Review Tool',
+    EVENT_CATEGORY: 'curriculum review tool interaction',
   
     /**
      * Get data layer object.

--- a/teachers_digital_platform/crtool/src/js/business.logic/constants.js
+++ b/teachers_digital_platform/crtool/src/js/business.logic/constants.js
@@ -69,7 +69,7 @@ const C = {
     LEARN_MORE_PDF_LINK: "https://files.consumerfinance.gov/f/documents/cfpb_youth-financialeducation-curriculum-review.pdf",
     LEARN_MORE_LINK_TEXT: "Learn more about how the review was developed",
 
-    ANALYTICS_DEBUG_ON: true,
+    ANALYTICS_DEBUG_ON: false,
 };
 
 export default C;

--- a/teachers_digital_platform/crtool/src/js/business.logic/constants.js
+++ b/teachers_digital_platform/crtool/src/js/business.logic/constants.js
@@ -62,6 +62,8 @@ const C = {
     GRADE_ELEMENTARY: "Elementary school",
     GRADE_MIDDLE: "Middle school",
     GRADE_HIGH: "High school",
+
+    ANALYTICS_DEBUG_ON: true,
 };
 
 export default C;

--- a/teachers_digital_platform/crtool/src/js/business.logic/constants.js
+++ b/teachers_digital_platform/crtool/src/js/business.logic/constants.js
@@ -16,6 +16,9 @@ const C = {
     FINAL_PRINT_EVERYTHING: "FINAL_PRINT_EVERYTHING",
     START_PAGE: "START",
 
+    FINAL_PRINT_ENTIRE_BUTTON_TEXT: "Print or save entire review",
+    FINAL_PRINT_BUTTON_TEXT: "Print or save this page",
+
     CONTENT_STATUS: "content_status",
     UTILITY_STATUS: "utility_status",
     QUALITY_STATUS: "quality_status",

--- a/teachers_digital_platform/crtool/src/js/business.logic/constants.js
+++ b/teachers_digital_platform/crtool/src/js/business.logic/constants.js
@@ -66,6 +66,9 @@ const C = {
     GRADE_MIDDLE: "Middle school",
     GRADE_HIGH: "High school",
 
+    LEARN_MORE_PDF_LINK: "https://files.consumerfinance.gov/f/documents/cfpb_youth-financialeducation-curriculum-review.pdf",
+    LEARN_MORE_LINK_TEXT: "Learn more about how the review was developed",
+
     ANALYTICS_DEBUG_ON: true,
 };
 

--- a/teachers_digital_platform/crtool/src/js/business.logic/criterionService.js
+++ b/teachers_digital_platform/crtool/src/js/business.logic/criterionService.js
@@ -1,4 +1,5 @@
 import C from "./constants";
+import Analytics from "./analytics";
 import Repository from "./repository";
 import UtilityService from "./utilityService";
 import CriterionCalculationService from "./summary/criterionCalculationService";
@@ -58,9 +59,45 @@ const CriterionService = {
     calculateDistinctiveCompletion(component, alteredCriterionObjects, changedDistinctive) {
         if (this.isDistinctiveComplete(component, alteredCriterionObjects, changedDistinctive)) {
             Repository.setDistinctiveStatus(component, changedDistinctive, C.STATUS_COMPLETE);
+
+            //Analytics dimension is done (all radio buttons in dimension have been clicked)
+            this.sendAnalyticsDimensionStatusHasChanged(component, changedDistinctive, C.STATUS_COMPLETE);
         }
         else {
             Repository.setDistinctiveStatus(component, changedDistinctive, C.STATUS_IN_PROGRESS);
+
+            //Analytics dimension is in progress 
+            this.sendAnalyticsDimensionStatusHasChanged(component, changedDistinctive, C.STATUS_IN_PROGRESS);
+        }
+    },
+
+    sendAnalyticsDimensionStatusHasChanged(component, changedDistinctive, newStatus) {
+        let actionText = "dimension in progress";
+        if (newStatus === C.STATUS_COMPLETE) { actionText = "dimension complete"; }
+
+        switch(changedDistinctive) {
+            case C.CONTENT_PAGE:
+                if (component.state.contentInProgress !== newStatus) {
+                    Analytics.sendEvent(Analytics.getDataLayerOptions(actionText, component.state.currentPage));
+                }
+                break;
+            case C.UTILITY_PAGE:
+                if (component.state.utilityInProgress !== newStatus) {
+                    Analytics.sendEvent(Analytics.getDataLayerOptions(actionText, component.state.currentPage));
+                }
+                break;
+            case C.QUALITY_PAGE:
+                if (component.state.qualityInProgress !== newStatus) {
+                    Analytics.sendEvent(Analytics.getDataLayerOptions(actionText, component.state.currentPage));
+                }
+                break;
+            case C.EFFICACY_PAGE:
+                if (component.state.efficacyInProgress !== newStatus) {
+                    Analytics.sendEvent(Analytics.getDataLayerOptions(actionText, component.state.currentPage));
+                }
+                break;
+            default:
+                break;
         }
     },
 
@@ -71,7 +108,7 @@ const CriterionService = {
     setCriterionGroupCompletionStatuses(component, criterion, status) {
         // Do not change if the current criterion group is already complete
         if (component.state.criterionCompletionStatuses[criterion] !== C.ICON_CHECK_ROUND) {
-            CriterionCalculationService.setCriterionGroupCompletionStatuses(component, criterion, status);
+            CriterionCalculationService.setCriterionGroupCompletionStatuses(component, criterion, status);          
         }
     },
 

--- a/teachers_digital_platform/crtool/src/js/business.logic/repository.js
+++ b/teachers_digital_platform/crtool/src/js/business.logic/repository.js
@@ -13,29 +13,7 @@ const Repository = {
      */
     resetApplicationData() {
         this.clearAllData();
-        this.saveCurrentPage(this, C.START_PAGE);
-        this.savePrintButtonPage(this, C.START_PAGE);
-        this.saveFinishAddingEfficacyStudies(this, false);
-
-        this.setDistinctiveStatus(this, C.CONTENT_PAGE, C.STATUS_IN_START);
-        this.setDistinctiveStatus(this, C.UTILITY_PAGE, C.STATUS_IN_START);
-        this.setDistinctiveStatus(this, C.QUALITY_PAGE, C.STATUS_IN_START);
-        this.setDistinctiveStatus(this, C.EFFICACY_PAGE, C.STATUS_IN_START);
-
-        this.setDistinctiveView(this, C.CONTENT_PAGE, false);
-        this.setDistinctiveView(this, C.UTILITY_PAGE, false);
-        this.setDistinctiveView(this, C.QUALITY_PAGE, false);
-        this.setDistinctiveView(this, C.EFFICACY_PAGE, false);
-
-        this.saveStudyAnsers(this, {});
-        this.saveCriterionScores(this, {});
-        this.saveCriterionAnswers(this, {});
-        this.setCriterionTitleLinkClicked(this, {});
-        this.saveCriterionEfficacyStudies(this, [0]);
-        this.savedimensionOverallScores(this, {});
-        this.saveDistinctiveCompletionDates(this, {});
-        this.saveFinalSummaryShowEntireReview(this, "");
-        this.saveCriterionGroupCompletionStatuses(this, {});
+        localStorage.setItem(C.START_PAGE, C.START_PAGE);
     },
 
     /*
@@ -117,6 +95,10 @@ const Repository = {
         return JSON.parse(localStorage.getItem("studyAnswers")) || {};
     },
 
+    getNumberFinalSummaryViews() {
+        return localStorage.getItem("numberFinalSummaryViews") || 0;
+    },
+
     getCriterionAnswers() {
         return JSON.parse(localStorage.getItem("criterionAnswers")) || {};
     },
@@ -173,6 +155,11 @@ const Repository = {
     saveStudyAnsers(component, alteredStudies) {
         localStorage.setItem("studyAnswers", JSON.stringify(alteredStudies));
         component.setState({studyAnswers: alteredStudies});
+    },
+
+    saveNumberFinalSummaryViews(component, count) {
+        localStorage.setItem("numberFinalSummaryViews", count);
+        component.setState({numberFinalSummaryViews: count});
     },
 
     /*

--- a/teachers_digital_platform/crtool/src/js/business.logic/summary/criterionCalculationService.js
+++ b/teachers_digital_platform/crtool/src/js/business.logic/summary/criterionCalculationService.js
@@ -1,4 +1,5 @@
 import C from "../constants";
+import Analytics from "../analytics";
 import Repository from "../repository";
 import UtilityService from "../utilityService";
 import QualityCalculationService from "../summary/qualityCalculationService";
@@ -53,6 +54,12 @@ const CriterionCalculationService = {
             // down and now have to add logic later
             this.setCriterionGroupCompletionStatuses(component, criterionKey, C.ICON_CHECK_ROUND);
             this.setDimensionOverallScore(component, criterionKey);
+
+            //Analytics all radio buttons in a criterion have been clicked
+            if (component.state.criterionCompletionStatuses[criterionKey] !== C.ICON_CHECK_ROUND) {
+                let label = changedDistinctive + " " + criterionKey.replace("-question", "").replace("-optional", "").replace("-crt", "");;
+                Analytics.sendEvent(Analytics.getDataLayerOptions("completed criterion", label));  
+            }
         }
         else {
             this.setCriterionGroupCompletionStatuses(component, criterionKey, C.STATUS_IN_PROGRESS);

--- a/teachers_digital_platform/crtool/src/js/business.logic/summary/efficacyCalculationService.js
+++ b/teachers_digital_platform/crtool/src/js/business.logic/summary/efficacyCalculationService.js
@@ -257,6 +257,27 @@ const EfficacyCalculationService = {
         return criterionScore;
     },
 
+    getAllEfficacyStudyScoresForAnalytics(component) {
+        let studyScores = "";
+        let count = 0;
+        for (var score in component.state.criterionScores) {
+            if (score.indexOf("efficacy-crt-1") >= 0)
+            {
+                if (count > 0) { studyScores += ", "; }
+
+                let currentScore = "Not reviewed";
+                if (component.state.criterionScores[score]) {
+                    currentScore = component.state.criterionScores[score].all_essential_yes ? "Strong" : "Not Strong";
+                }
+
+                studyScores += "Study " + count + " = " + currentScore;
+                count += 1;
+            }
+        }
+
+        return studyScores;
+    },
+
 }
 
 export default EfficacyCalculationService;

--- a/teachers_digital_platform/crtool/src/js/components/CustomerReviewToolComponent.js
+++ b/teachers_digital_platform/crtool/src/js/components/CustomerReviewToolComponent.js
@@ -47,6 +47,7 @@ export default class CustomerReviewToolComponent extends React.Component {
             currentPrintButton: Repository.getPrintButtonPage(),
             dimensionOverallScores: Repository.getDimensionOverallScores(),
             criterionClickedTitles: Repository.getCriterionClickedTitles(),
+            numberFinalSummaryViews: Repository.getNumberFinalSummaryViews(),
             criterionEfficacyStudies: Repository.getCriterionEfficacyStudies(),
             distinctiveCompletedDate: Repository.getDistinctiveCompletedDate(),
             criterionCompletionStatuses: Repository.getCriterionCompletionSatuses(),
@@ -173,6 +174,12 @@ export default class CustomerReviewToolComponent extends React.Component {
         this.setDistinctiveCompletionDateNow(C.FINAL_SUMMARY_PAGE);
         Repository.saveCurrentPage(this, C.FINAL_SUMMARY_PAGE);
 
+        let finalSummaryViews = Number(this.state.numberFinalSummaryViews) + 1;
+        Repository.saveNumberFinalSummaryViews(this, finalSummaryViews);
+
+        //Analytics number of times they clicked final summary button
+        Analytics.sendEvent(Analytics.getDataLayerOptions("button clicked", "Final summary: clicked " + finalSummaryViews + " times"));
+
         //Analytics final summary button clicked
         Analytics.sendEvent(Analytics.getDataLayerOptions("button clicked", "Final summary"));
 
@@ -266,9 +273,11 @@ export default class CustomerReviewToolComponent extends React.Component {
     setCriterionTitleLinkClicked(criterionKey) {
         CriterionService.setCriterionTitleLinkClicked(this, criterionKey);
 
-        //Analytics criterion expandable clicked
-        let label = this.state.currentPage + " " + criterionKey.replace("-question", "").replace("-optional", "").replace("-crt", "");
-        Analytics.sendEvent(Analytics.getDataLayerOptions("expandable opened", label));
+        if (criterionKey !== "efficacy-crt-question-2") {
+            //Analytics criterion expandable clicked
+            let label = this.state.currentPage + " " + criterionKey.replace("-question", "").replace("-optional", "").replace("-crt", "");
+            Analytics.sendEvent(Analytics.getDataLayerOptions("expandable opened", label));
+        }
     }
 
     /* 
@@ -312,6 +321,7 @@ export default class CustomerReviewToolComponent extends React.Component {
             criterionAnswers:this.state.criterionAnswers,
             currentPrintButton:this.state.currentPrintButton,
             criterionClickedTitles:this.state.criterionClickedTitles,
+            numberFinalSummaryViews:this.state.numberFinalSummaryViews,
             criterionEfficacyStudies:this.state.criterionEfficacyStudies,
             criterionScores:this.state.criterionScores,
             criterionCompletionStatuses:this.state.criterionCompletionStatuses,

--- a/teachers_digital_platform/crtool/src/js/components/CustomerReviewToolComponent.js
+++ b/teachers_digital_platform/crtool/src/js/components/CustomerReviewToolComponent.js
@@ -271,6 +271,14 @@ export default class CustomerReviewToolComponent extends React.Component {
         Analytics.sendEvent(Analytics.getDataLayerOptions("expandable opened", label));
     }
 
+    /* 
+     * Save Insturctions link clicked 
+     */
+    sendAnalyticsForLinkClick(link_text, link_url) {
+        //Analytics opened how to save your work
+        Analytics.sendEvent(Analytics.getDataLayerOptions(link_text, link_url, "Download"));
+    }
+
     setCriterionStatusToInStart(criterionKey) {
         CriterionService.setCriterionGroupCompletionStatuses(this, criterionKey, C.STATUS_IN_START);
     }
@@ -309,6 +317,7 @@ export default class CustomerReviewToolComponent extends React.Component {
             criterionCompletionStatuses:this.state.criterionCompletionStatuses,
             finalSummaryShowEntireReview:this.state.finalSummaryShowEntireReview,
 
+            sendAnalyticsForLinkClick:this.sendAnalyticsForLinkClick.bind(this),
             handleSummaryButtonClick:this.handleSummaryButtonClick.bind(this),
             handleFinalSummaryButtonClick:this.handleFinalSummaryButtonClick.bind(this),
             resetPrintButtonState:this.resetPrintButtonState.bind(this),
@@ -343,7 +352,8 @@ export default class CustomerReviewToolComponent extends React.Component {
                     <div className="l-survey-top">
                         <SaveWorkModal
                             buttonText="Can I save my work?"
-                            hasIcon="true" />
+                            hasIcon="true" 
+                            {...applicationProps}/>
                     </div>
                     {
                         this.state.currentPage === C.START_PAGE &&

--- a/teachers_digital_platform/crtool/src/js/components/CustomerReviewToolComponent.js
+++ b/teachers_digital_platform/crtool/src/js/components/CustomerReviewToolComponent.js
@@ -77,6 +77,10 @@ export default class CustomerReviewToolComponent extends React.Component {
      */
     clearLocalStorage() {
         Repository.resetApplicationData();
+
+        //Analytics clicked start over with new review
+        Analytics.sendEvent(Analytics.getDataLayerOptions("Starting over modal", "Yes"));
+
         this.navigateBackToStartPage();
     }
 

--- a/teachers_digital_platform/crtool/src/js/components/CustomerReviewToolComponent.js
+++ b/teachers_digital_platform/crtool/src/js/components/CustomerReviewToolComponent.js
@@ -56,7 +56,6 @@ export default class CustomerReviewToolComponent extends React.Component {
     }
 
     componentDidMount() {
-
         //If we are on a print page we need to configure after print for data analytics
         if (this.state.currentPrintButton === C.FINAL_PRINT_EVERYTHING) {
             this.afterPrint(C.FINAL_PRINT_ENTIRE_BUTTON_TEXT);
@@ -129,7 +128,7 @@ export default class CustomerReviewToolComponent extends React.Component {
         Repository.saveFinalSummaryShowEntireReview(this, newValue);
         this.setState({finalSummaryShowEntireReview: newValue});
 
-        //Analytics print finaly summary clicked
+        //Analytics print final summary button clicked
         if (newValue === "true" && showEverything === "true") {
             this.printButtonClicked(C.FINAL_PRINT_EVERYTHING, false);
             Analytics.sendEvent(Analytics.getDataLayerOptions("button clicked", C.FINAL_PRINT_ENTIRE_BUTTON_TEXT));
@@ -146,7 +145,7 @@ export default class CustomerReviewToolComponent extends React.Component {
         Repository.savePrintButtonPage(this, distinctiveName);
         Repository.saveCurrentPage(this, distinctiveName);
 
-        if (sendAnalytics !== undefined && sendAnalytics !== false) {
+        if (sendAnalytics !== undefined && sendAnalytics === true) {
             let label = distinctiveName + " Print or save summary";
             Analytics.sendEvent(Analytics.getDataLayerOptions("button clicked", label));
         } 
@@ -174,6 +173,7 @@ export default class CustomerReviewToolComponent extends React.Component {
         this.setDistinctiveCompletionDateNow(C.FINAL_SUMMARY_PAGE);
         Repository.saveCurrentPage(this, C.FINAL_SUMMARY_PAGE);
 
+        //Count number of times user clicked Final Summary
         let finalSummaryViews = Number(this.state.numberFinalSummaryViews) + 1;
         Repository.saveNumberFinalSummaryViews(this, finalSummaryViews);
 
@@ -239,6 +239,8 @@ export default class CustomerReviewToolComponent extends React.Component {
 
     removeEfficacyStudy(efficacyStudyNumber) {
         CriterionService.removeEfficacyStudy(this, efficacyStudyNumber);
+
+        //Analytics use clicked remove efficacy study
         Analytics.sendEvent(Analytics.getDataLayerOptions("button clicked", "Remove"));
     }
 
@@ -259,6 +261,7 @@ export default class CustomerReviewToolComponent extends React.Component {
     sendAnalyticsForCriterionChanged(distinctiveName, changedQuestion) {
         let criterionNumber = changedQuestion.replace("-question", "").replace("-optional", "").replace("-crt", "");
 
+        //Analytics we need to treat the notes fields different than the radio buttons
         if (changedQuestion.indexOf("notes") > 0) {
             Analytics.sendEvent(Analytics.getDataLayerOptions("text box completed", distinctiveName + " : " + criterionNumber));
         } else {
@@ -273,6 +276,8 @@ export default class CustomerReviewToolComponent extends React.Component {
     setCriterionTitleLinkClicked(criterionKey) {
         CriterionService.setCriterionTitleLinkClicked(this, criterionKey);
 
+        // Since the efficacy page invokes this method for the efficacy-crt-question-2 
+        // for the user automatically if/when user completes studies and 2 are strong
         if (criterionKey !== "efficacy-crt-question-2") {
             //Analytics criterion expandable clicked
             let label = this.state.currentPage + " " + criterionKey.replace("-question", "").replace("-optional", "").replace("-crt", "");

--- a/teachers_digital_platform/crtool/src/js/components/CustomerReviewToolComponent.js
+++ b/teachers_digital_platform/crtool/src/js/components/CustomerReviewToolComponent.js
@@ -2,6 +2,7 @@ import React from "react";
 import resolveUrl from "resolve-url";
 
 import C from "../business.logic/constants";
+import Analytics from "../business.logic/analytics";
 import SaveWorkModal from "./dialogs/SaveWorkModal";
 import DistinctiveMenuBar from "./distinctives/DistinctiveMenuBar";
 import FooterButtonAreaComponent from "./pages/partial.pages/FooterButtonAreaComponent";
@@ -117,6 +118,9 @@ export default class CustomerReviewToolComponent extends React.Component {
         Repository.saveCurrentPage(this, distinctiveName);
 
         if (distinctiveName !== C.START_PAGE) {
+            
+            Analytics.sendEvent(Analytics.getDataLayerOptions( "Print", "User Chose to print " + distinctiveName ));
+
             this.openPrintPage();
 
             if (distinctiveName === C.FINAL_PRINT_PAGE || distinctiveName === C.FINAL_PRINT_EVERYTHING) {

--- a/teachers_digital_platform/crtool/src/js/components/CustomerReviewToolComponent.js
+++ b/teachers_digital_platform/crtool/src/js/components/CustomerReviewToolComponent.js
@@ -53,6 +53,23 @@ export default class CustomerReviewToolComponent extends React.Component {
         };
     }
 
+    componentDidMount() {
+
+        //If we are on a print page we need to configure after print for data analytics
+        if (this.state.currentPrintButton === C.FINAL_PRINT_EVERYTHING) {
+            this.afterPrint(C.FINAL_PRINT_ENTIRE_BUTTON_TEXT);
+        } else if (this.state.currentPrintButton === C.FINAL_PRINT_PAGE) {
+            this.afterPrint(C.FINAL_PRINT_BUTTON_TEXT);
+        }
+    }
+
+    afterPrint(printButtonText) {
+        // Not positive the below method is 100% cross browser supported
+        window.onafterprint = function(evt) { 
+            Analytics.sendEvent(Analytics.getDataLayerOptions("print or save", printButtonText));
+        };
+    }
+
     /*
      * Remove all values frmo localStorage.
      * Used for starting a new review
@@ -105,8 +122,10 @@ export default class CustomerReviewToolComponent extends React.Component {
 
         if (newValue === "true" && showEverything === "true") {
             this.printButtonClicked(C.FINAL_PRINT_EVERYTHING);
+            Analytics.sendEvent(Analytics.getDataLayerOptions("button clicked", C.FINAL_PRINT_ENTIRE_BUTTON_TEXT));
         } else if (newValue === "true"){
             this.printButtonClicked(C.FINAL_PRINT_PAGE);
+            Analytics.sendEvent(Analytics.getDataLayerOptions("button clicked", C.FINAL_PRINT_BUTTON_TEXT));
         } else {
             this.resetPrintButtonState(C.START_PAGE);
         }
@@ -118,9 +137,6 @@ export default class CustomerReviewToolComponent extends React.Component {
         Repository.saveCurrentPage(this, distinctiveName);
 
         if (distinctiveName !== C.START_PAGE) {
-            
-            Analytics.sendEvent(Analytics.getDataLayerOptions( "Print", "User Chose to print " + distinctiveName ));
-
             this.openPrintPage();
 
             if (distinctiveName === C.FINAL_PRINT_PAGE || distinctiveName === C.FINAL_PRINT_EVERYTHING) {
@@ -177,6 +193,7 @@ export default class CustomerReviewToolComponent extends React.Component {
 
     criterionAnswerChanged(distinctiveName, changedQuestion, newValue) {
         CriterionService.criterionAnswerChanged(this, distinctiveName, changedQuestion, newValue);
+        Analytics.sendEvent(Analytics.getDataLayerOptions("text box completed", distinctiveName + " : " + changedQuestion));
     }
 
     setCriterionStatusToInProgress(criterionKey) {

--- a/teachers_digital_platform/crtool/src/js/components/buttons/SummaryButton.js
+++ b/teachers_digital_platform/crtool/src/js/components/buttons/SummaryButton.js
@@ -25,7 +25,7 @@ export default class SummaryButton extends React.Component {
                     (this.props.currentPage === C.UTILITY_PAGE && this.props.utilityIsSummaryView === true) ||
                     (this.props.currentPage === C.EFFICACY_PAGE && this.props.efficacyIsSummaryView === true) ) {
            return (
-               <button className="a-btn" data-gtm_ignore="true" onClick={(e) => {this.props.printButtonClicked(this.props.currentPage); e.preventDefault();}}>
+               <button className="a-btn" data-gtm_ignore="true" onClick={(e) => {this.props.printButtonClicked(this.props.currentPage, true); e.preventDefault();}}>
                    Print or save summary
                </button>
            );

--- a/teachers_digital_platform/crtool/src/js/components/buttons/SummaryButton.js
+++ b/teachers_digital_platform/crtool/src/js/components/buttons/SummaryButton.js
@@ -25,7 +25,7 @@ export default class SummaryButton extends React.Component {
                     (this.props.currentPage === C.UTILITY_PAGE && this.props.utilityIsSummaryView === true) ||
                     (this.props.currentPage === C.EFFICACY_PAGE && this.props.efficacyIsSummaryView === true) ) {
            return (
-               <button className="a-btn" onClick={(e) => {this.props.printButtonClicked(this.props.currentPage); e.preventDefault();}}>
+               <button className="a-btn" data-gtm_ignore="true" onClick={(e) => {this.props.printButtonClicked(this.props.currentPage); e.preventDefault();}}>
                    Print or save summary
                </button>
            );

--- a/teachers_digital_platform/crtool/src/js/components/common/FinalCurriculumInformation.js
+++ b/teachers_digital_platform/crtool/src/js/components/common/FinalCurriculumInformation.js
@@ -34,7 +34,7 @@ export default class FinalCurriculumInformation extends React.Component {
                     {
                         this.props.finalSummaryShowEntireReview !== "true" &&
                         <React.Fragment>
-                            <SaveWorkInformation />
+                            <SaveWorkInformation {...this.props} />
                             <PrintOrSaveFinalSummary {...this.props} />
                         </React.Fragment>
                     }

--- a/teachers_digital_platform/crtool/src/js/components/common/KeyTakeawaysComponent.js
+++ b/teachers_digital_platform/crtool/src/js/components/common/KeyTakeawaysComponent.js
@@ -23,8 +23,8 @@ export default class KeyTakeawaysComponent extends React.Component {
                 rows="6"
                 id="crt-key-takeaways"
                 ref="crt-key-takeaways"
-                value={this.props.criterionAnswers["crt-key-takeaways"]}
-                onChange={e=>this.props.criterionAnswerChanged("final", "crt-key-takeaways", e.target.value)} >
+                defaultValue={this.props.criterionAnswers["crt-key-takeaways"]}
+                onBlur={e=>this.props.criterionAnswerChanged("final", "crt-key-takeaways", e.target.value)} >
             </textarea>
         );
     }

--- a/teachers_digital_platform/crtool/src/js/components/common/PrintOrSaveFinalSummary.js
+++ b/teachers_digital_platform/crtool/src/js/components/common/PrintOrSaveFinalSummary.js
@@ -6,10 +6,11 @@ export default class PrintOrSaveFinalSummary extends React.Component {
             <div className="m-btn-group
                             m-btn-group__wide
                             u-mb15">
-                <button className="a-btn a-btn__super" onClick={(e) => {this.props.setPrintFinalSummaryShowEntireReview("true", "false"); e.preventDefault();}}>
+                <button className="a-btn a-btn__super" data-gtm_ignore="true" onClick={(e) => {this.props.setPrintFinalSummaryShowEntireReview("true", "false"); e.preventDefault();}}>
+
                     Print or save this page
                 </button>
-                <button className="a-btn a-btn__super" onClick={(e) => {this.props.setPrintFinalSummaryShowEntireReview("true", "true"); e.preventDefault();}}>
+                <button className="a-btn a-btn__super" data-gtm_ignore="true" onClick={(e) => {this.props.setPrintFinalSummaryShowEntireReview("true", "true"); e.preventDefault();}}>
                     Print or save entire review
                 </button>
             </div>

--- a/teachers_digital_platform/crtool/src/js/components/common/SaveWorkInformation.js
+++ b/teachers_digital_platform/crtool/src/js/components/common/SaveWorkInformation.js
@@ -24,7 +24,7 @@ export default class SaveWorkInformation extends React.Component {
                             <SaveWorkModal
                                 buttonText="Learn more about how to save your work."
                                 hasIcon="false"
-                                hasUnderline="true" />
+                                hasUnderline="true" {...this.props} />
                         </p>
                     </div>
                 </div>

--- a/teachers_digital_platform/crtool/src/js/components/dialogs/SaveWorkModal.js
+++ b/teachers_digital_platform/crtool/src/js/components/dialogs/SaveWorkModal.js
@@ -64,7 +64,7 @@ export default class SaveWorkModal extends React.Component {
 
         return (
             <React.Fragment>
-                <button className={buttonClasses} onClick={(e) => {this.openSaveWorkModalDialog()}}>
+                <button className={buttonClasses} data-gtm_ignore="true" onClick={(e) => {this.openSaveWorkModalDialog()}}>
                     <SvgIcon
                         icon={currentIcon}
                         isLarge="true"

--- a/teachers_digital_platform/crtool/src/js/components/dialogs/SaveWorkModal.js
+++ b/teachers_digital_platform/crtool/src/js/components/dialogs/SaveWorkModal.js
@@ -54,12 +54,6 @@ export default class SaveWorkModal extends React.Component {
         this.setState({modalIsOpen: false});
     }
 
-    /* Save Insturctions link clicked */
-    saveInstructionsClicked() {
-        //Analytics opened how to save your work
-        Analytics.sendEvent(Analytics.getDataLayerOptions("", "", "Download"));
-    }
-
     render() {
         let currentIcon = "";
         let buttonClasses = "a-btn a-btn__link";
@@ -108,7 +102,7 @@ export default class SaveWorkModal extends React.Component {
                                     <h1 id="modal-save-work_title" className="h3">Saving your work</h1>
                                     <div id="modal-save-work_desc">
                                         <p>This tool uses cookies to <strong>temporarily</strong> save your work. To see answers you’ve already completed, you need to use the same computer and browser, and don’t clear your cookies.</p>
-                                        <p>To save a permanent copy of your work, please print the summary or save it as a PDF for every dimension as you complete it. You can also print or save a summary of the entire review. Learn how to <a href="https://www.consumerfinance.gov/consumer-tools/save-as-pdf-instructions/" target="_blank" rel="noopener noreferrer" onClick={(e) => {this.saveInstructionsClicked();}}>save the summary as a PDF</a>.</p>
+                                        <p>To save a permanent copy of your work, please print the summary or save it as a PDF for every dimension as you complete it. You can also print or save a summary of the entire review. Learn how to <a href="https://www.consumerfinance.gov/consumer-tools/save-as-pdf-instructions/" target="_blank" rel="noopener noreferrer" onClick={(e) => {this.props.sendAnalyticsForLinkClick("save the summary as a PDF", "https://www.consumerfinance.gov/consumer-tools/save-as-pdf-instructions/");}}>save the summary as a PDF</a>.</p>
                                         <p>You can only work on a single curriculum at a time</p>
                                     </div>
                                 </div>

--- a/teachers_digital_platform/crtool/src/js/components/dialogs/SaveWorkModal.js
+++ b/teachers_digital_platform/crtool/src/js/components/dialogs/SaveWorkModal.js
@@ -2,6 +2,7 @@ import React from "react";
 import Modal from "react-modal";
 
 import C from "../../business.logic/constants";
+import Analytics from "../../business.logic/analytics";
 import SvgIcon from "../svgs/SvgIcon";
 
 export default class SaveWorkModal extends React.Component {
@@ -43,11 +44,20 @@ export default class SaveWorkModal extends React.Component {
     /* Modal specific open dialog */
     openSaveWorkModalDialog() {
         this.setState({modalIsOpen: true});
+
+        //Analytics opened how to save your work
+        Analytics.sendEvent(Analytics.getDataLayerOptions("link clicked: " + this.props.buttonText, "Saving your work"));
     }
 
     /* Modal specific close dialog */
     closeSaveWorkModalDialog() {
         this.setState({modalIsOpen: false});
+    }
+
+    /* Save Insturctions link clicked */
+    saveInstructionsClicked() {
+        //Analytics opened how to save your work
+        Analytics.sendEvent(Analytics.getDataLayerOptions("", "", "Download"));
     }
 
     render() {
@@ -98,7 +108,7 @@ export default class SaveWorkModal extends React.Component {
                                     <h1 id="modal-save-work_title" className="h3">Saving your work</h1>
                                     <div id="modal-save-work_desc">
                                         <p>This tool uses cookies to <strong>temporarily</strong> save your work. To see answers you’ve already completed, you need to use the same computer and browser, and don’t clear your cookies.</p>
-                                        <p>To save a permanent copy of your work, please print the summary or save it as a PDF for every dimension as you complete it. You can also print or save a summary of the entire review. Learn how to <a href="https://www.consumerfinance.gov/consumer-tools/save-as-pdf-instructions/" target="_blank" rel="noopener noreferrer">save the summary as a PDF</a>.</p>
+                                        <p>To save a permanent copy of your work, please print the summary or save it as a PDF for every dimension as you complete it. You can also print or save a summary of the entire review. Learn how to <a href="https://www.consumerfinance.gov/consumer-tools/save-as-pdf-instructions/" target="_blank" rel="noopener noreferrer" onClick={(e) => {this.saveInstructionsClicked();}}>save the summary as a PDF</a>.</p>
                                         <p>You can only work on a single curriculum at a time</p>
                                     </div>
                                 </div>

--- a/teachers_digital_platform/crtool/src/js/components/dialogs/StartOverModal.js
+++ b/teachers_digital_platform/crtool/src/js/components/dialogs/StartOverModal.js
@@ -2,6 +2,7 @@ import React from "react";
 import Modal from "react-modal";
 
 import C from "../../business.logic/constants";
+import Analytics from "../../business.logic/analytics";
 import SvgIcon from "../svgs/SvgIcon";
 
 export default class StartOverModal extends React.Component {
@@ -43,6 +44,9 @@ export default class StartOverModal extends React.Component {
     /* Modal specific open dialog */
     openStartOverModalDialog() {
         this.setState({modalIsOpen: true});
+
+        //Analytics opened start over with a new review
+        Analytics.sendEvent(Analytics.getDataLayerOptions("link clicked: Start over with a new review", "Starting over"));
     }
 
     /* Modal specific close dialog */

--- a/teachers_digital_platform/crtool/src/js/components/dialogs/StartOverModal.js
+++ b/teachers_digital_platform/crtool/src/js/components/dialogs/StartOverModal.js
@@ -53,7 +53,7 @@ export default class StartOverModal extends React.Component {
     render() {
         return (
         <React.Fragment>
-            <button className="a-btn a-btn__link" onClick={(e) => {this.openStartOverModalDialog();}}>
+            <button className="a-btn a-btn__link" data-gtm_ignore="true" onClick={(e) => {this.openStartOverModalDialog();}}>
                 Start over with a new review
             </button>
             <Modal

--- a/teachers_digital_platform/crtool/src/js/components/pages/EfficacyCriterionPage.js
+++ b/teachers_digital_platform/crtool/src/js/components/pages/EfficacyCriterionPage.js
@@ -250,8 +250,8 @@ export default class EfficacyCriterionPage extends React.Component {
                             rows="6"
                             id="efficacy-crt-notes-optional-2"
                             ref="efficacy-crt-notes-optional-2"
-                            value={this.props.criterionAnswers['efficacy-crt-notes-optional-2']}
-                            onChange={e=>this.criterionAnswerChanged('efficacy-crt-notes-optional-2', e.target.value)} >
+                            defaultValue={this.props.criterionAnswers['efficacy-crt-notes-optional-2']}
+                            onBlur={e=>this.criterionAnswerChanged('efficacy-crt-notes-optional-2', e.target.value)} >
                         </textarea>
                     </div>
                 </div>
@@ -324,8 +324,8 @@ export default class EfficacyCriterionPage extends React.Component {
                             rows="6"
                             id="efficacy-crt-notes-optional-3"
                             ref="efficacy-crt-notes-optional-3"
-                            value={this.props.criterionAnswers['efficacy-crt-notes-optional-3']}
-                            onChange={e=>this.criterionAnswerChanged('efficacy-crt-notes-optional-3', e.target.value)} >
+                            defaultValue={this.props.criterionAnswers['efficacy-crt-notes-optional-3']}
+                            onBlur={e=>this.criterionAnswerChanged('efficacy-crt-notes-optional-3', e.target.value)} >
                         </textarea>
                     </div>
                 </div>

--- a/teachers_digital_platform/crtool/src/js/components/pages/EfficacyCriterionPage.js
+++ b/teachers_digital_platform/crtool/src/js/components/pages/EfficacyCriterionPage.js
@@ -122,7 +122,7 @@ export default class EfficacyCriterionPage extends React.Component {
                     Efficacy
                 </h2>
                 <p className="lead-paragraph">
-                    The efficacy dimension assesses the measurable impact the curriculum has had on students by looking at high-quality studies that have been done about its effectiveness. Evaluation criteria are based on research and major national and state education standards. <a target="_blank" rel="noopener noreferrer" href="https://files.consumerfinance.gov/f/documents/cfpb_youth-financialeducation-curriculum-review.pdf">Learn more about how the review was developed</a>.
+                    The efficacy dimension assesses the measurable impact the curriculum has had on students by looking at high-quality studies that have been done about its effectiveness. Evaluation criteria are based on research and major national and state education standards. <a target="_blank" rel="noopener noreferrer" href={C.LEARN_MORE_PDF_LINK} onClick={(e) => {this.props.sendAnalyticsForLinkClick(C.LEARN_MORE_LINK_TEXT, C.LEARN_MORE_PDF_LINK);}}>{C.LEARN_MORE_LINK_TEXT}</a>.
                 </p>
                 <h3 className="h2">Instructions</h3>
                 <ul>
@@ -142,7 +142,7 @@ export default class EfficacyCriterionPage extends React.Component {
                     <SaveWorkModal
                         buttonText="How can I save my work?"
                         hasIcon="false"
-                        hasUnderline="true" />
+                        hasUnderline="true" {...this.props} />
                 </p>
                 <div className="o-well
                                 u-mb30

--- a/teachers_digital_platform/crtool/src/js/components/pages/EfficacyCriterionPage.js
+++ b/teachers_digital_platform/crtool/src/js/components/pages/EfficacyCriterionPage.js
@@ -179,6 +179,7 @@ export default class EfficacyCriterionPage extends React.Component {
 
                     <div className="u-mt15 u-mb30">
                         <button className="a-btn a-btn__link a-btn__no-line"
+                            data-gtm_ignore="true"
                             onClick={() => this.AddEfficacyStudy()}>
                             Review another study
                             <SvgIcon

--- a/teachers_digital_platform/crtool/src/js/components/pages/EfficacySummaryPage.js
+++ b/teachers_digital_platform/crtool/src/js/components/pages/EfficacySummaryPage.js
@@ -30,7 +30,7 @@ export default class EfficacySummaryPage extends React.Component {
                     Then, review the overall score for the efficacy criteria and enter your thoughts about its strengths and weaknesses.
                 </p>
                 <SaveWorkInformation />
-                <button className="a-btn" data-gtm_ignore="true" onClick={(e) => {this.props.printButtonClicked(C.EFFICACY_PAGE); e.preventDefault();}}>
+                <button className="a-btn" data-gtm_ignore="true" onClick={(e) => {this.props.printButtonClicked(C.EFFICACY_PAGE, true); e.preventDefault();}}>
                     Print or save summary
                 </button>
 

--- a/teachers_digital_platform/crtool/src/js/components/pages/EfficacySummaryPage.js
+++ b/teachers_digital_platform/crtool/src/js/components/pages/EfficacySummaryPage.js
@@ -30,7 +30,7 @@ export default class EfficacySummaryPage extends React.Component {
                     Then, review the overall score for the efficacy criteria and enter your thoughts about its strengths and weaknesses.
                 </p>
                 <SaveWorkInformation />
-                <button className="a-btn" onClick={(e) => {this.props.printButtonClicked(C.EFFICACY_PAGE); e.preventDefault();}}>
+                <button className="a-btn" data-gtm_ignore="true" onClick={(e) => {this.props.printButtonClicked(C.EFFICACY_PAGE); e.preventDefault();}}>
                     Print or save summary
                 </button>
 

--- a/teachers_digital_platform/crtool/src/js/components/pages/EfficacySummaryPage.js
+++ b/teachers_digital_platform/crtool/src/js/components/pages/EfficacySummaryPage.js
@@ -29,7 +29,7 @@ export default class EfficacySummaryPage extends React.Component {
                 <p>
                     Then, review the overall score for the efficacy criteria and enter your thoughts about its strengths and weaknesses.
                 </p>
-                <SaveWorkInformation />
+                <SaveWorkInformation {...this.props} />
                 <button className="a-btn" data-gtm_ignore="true" onClick={(e) => {this.props.printButtonClicked(C.EFFICACY_PAGE, true); e.preventDefault();}}>
                     Print or save summary
                 </button>

--- a/teachers_digital_platform/crtool/src/js/components/pages/FinalSummaryPage.js
+++ b/teachers_digital_platform/crtool/src/js/components/pages/FinalSummaryPage.js
@@ -32,7 +32,7 @@ export default class FinalSummaryPage extends React.Component {
                 <div className="l-survey-top">
                     <SaveWorkModal
                         buttonText="Can I save my work?"
-                        hasIcon="true" />
+                        hasIcon="true" {...this.props} />
                 </div>
                 {
                     this.props.currentPage === C.START_PAGE &&

--- a/teachers_digital_platform/crtool/src/js/components/pages/QualityCriterionPage.js
+++ b/teachers_digital_platform/crtool/src/js/components/pages/QualityCriterionPage.js
@@ -102,8 +102,8 @@ export default class QualityCriterionPage extends React.Component {
                                                 <input className="a-text-input a-text-input__full" type="text"
                                                     id="quality-crt-text-optional-1.1.1"
                                                     ref="quality-crt-text-optional-1.1.1"
-                                                    value={this.props.criterionAnswers['quality-crt-text-optional-1.1.1']}
-                                                    onChange={e=>this.criterionAnswerChanged('quality-crt-text-optional-1.1.1', e.target.value)}
+                                                    defaultValue={this.props.criterionAnswers['quality-crt-text-optional-1.1.1']}
+                                                    onBlur={e=>this.criterionAnswerChanged('quality-crt-text-optional-1.1.1', e.target.value)}
                                                     placeholder="$" />
                                             </div>
                                         </div>
@@ -544,8 +544,8 @@ export default class QualityCriterionPage extends React.Component {
                                     rows="6"
                                     id="quality-crt-notes-optional-1"
                                     ref="quality-crt-notes-optional-1"
-                                    value={this.props.criterionAnswers['quality-crt-notes-optional-1']}
-                                    onChange={e=>this.criterionAnswerChanged('quality-crt-notes-optional-1', e.target.value)} >
+                                    defaultValue={this.props.criterionAnswers['quality-crt-notes-optional-1']}
+                                    onBlur={e=>this.criterionAnswerChanged('quality-crt-notes-optional-1', e.target.value)} >
                         </textarea>
                     </div>
                 </div>
@@ -770,8 +770,8 @@ export default class QualityCriterionPage extends React.Component {
                                     rows="6"
                                     id="quality-crt-notes-optional-2"
                                     ref="quality-crt-notes-optional-2"
-                                    value={this.props.criterionAnswers['quality-crt-notes-optional-2']}
-                                    onChange={e=>this.criterionAnswerChanged('quality-crt-notes-optional-2', e.target.value)} >
+                                    defaultValue={this.props.criterionAnswers['quality-crt-notes-optional-2']}
+                                    onBlur={e=>this.criterionAnswerChanged('quality-crt-notes-optional-2', e.target.value)} >
                         </textarea>
                     </div>
                 </div>
@@ -1114,8 +1114,8 @@ export default class QualityCriterionPage extends React.Component {
                                     rows="6"
                                     id="quality-crt-notes-optional-3"
                                     ref="quality-crt-notes-optional-3"
-                                    value={this.props.criterionAnswers['quality-crt-notes-optional-3']}
-                                    onChange={e=>this.criterionAnswerChanged('quality-crt-notes-optional-3', e.target.value)} >
+                                    defaultValue={this.props.criterionAnswers['quality-crt-notes-optional-3']}
+                                    onBlur={e=>this.criterionAnswerChanged('quality-crt-notes-optional-3', e.target.value)} >
                         </textarea>
                     </div>
                 </div>
@@ -1484,8 +1484,8 @@ export default class QualityCriterionPage extends React.Component {
                                     rows="6"
                                     id="quality-crt-notes-optional-4"
                                     ref="quality-crt-notes-optional-4"
-                                    value={this.props.criterionAnswers['quality-crt-notes-optional-4']}
-                                    onChange={e=>this.criterionAnswerChanged('quality-crt-notes-optional-4', e.target.value)} >
+                                    defaultValue={this.props.criterionAnswers['quality-crt-notes-optional-4']}
+                                    onBlur={e=>this.criterionAnswerChanged('quality-crt-notes-optional-4', e.target.value)} >
                         </textarea>
                     </div>
                 </div>

--- a/teachers_digital_platform/crtool/src/js/components/pages/QualityCriterionPage.js
+++ b/teachers_digital_platform/crtool/src/js/components/pages/QualityCriterionPage.js
@@ -42,7 +42,7 @@ export default class QualityCriterionPage extends React.Component {
                     Quality
                 </h2>
                 <p className="lead-paragraph">
-                    The quality dimension assesses whether curriculum materials are clear, accurate, and objective and how easy the materials are for teachers and students to access. Evaluation criteria are based on research and major national and state education standards. <a target="_blank" rel="noopener noreferrer" href="https://files.consumerfinance.gov/f/documents/cfpb_youth-financialeducation-curriculum-review.pdf">Learn more about how the review was developed</a>.
+                    The quality dimension assesses whether curriculum materials are clear, accurate, and objective and how easy the materials are for teachers and students to access. Evaluation criteria are based on research and major national and state education standards. <a target="_blank" rel="noopener noreferrer" href={C.LEARN_MORE_PDF_LINK} onClick={(e) => {this.props.sendAnalyticsForLinkClick(C.LEARN_MORE_LINK_TEXT, C.LEARN_MORE_PDF_LINK);}}>{C.LEARN_MORE_LINK_TEXT}</a>.
                 </p>
                 <h3 className="h2">Instructions</h3>
                 <ul>
@@ -53,7 +53,7 @@ export default class QualityCriterionPage extends React.Component {
                     <SaveWorkModal
                         buttonText="How can I save my work?"
                         hasIcon="false"
-                        hasUnderline="true" />
+                        hasUnderline="true" {...this.props} />
                 </p>
                 <div className="o-well
                                 u-mb30

--- a/teachers_digital_platform/crtool/src/js/components/pages/QualitySummaryPage.js
+++ b/teachers_digital_platform/crtool/src/js/components/pages/QualitySummaryPage.js
@@ -28,7 +28,7 @@ export default class QualitySummaryPage extends React.Component {
                     Then, review the overall score for the quality criteria and enter your thoughts about its strengths and weaknesses.
                 </p>
                 <SaveWorkInformation />
-                <button className="a-btn" data-gtm_ignore="true" onClick={(e) => {this.props.printButtonClicked(C.QUALITY_PAGE); e.preventDefault();}}>
+                <button className="a-btn" data-gtm_ignore="true" onClick={(e) => {this.props.printButtonClicked(C.QUALITY_PAGE, true); e.preventDefault();}}>
                     Print or save summary
                 </button>
                 <DimensionInformation dimensionName={C.QUALITY_PAGE} {...this.props} reviewedOnDate={this.props.distinctiveCompletedDate[C.QUALITY_PAGE]} />

--- a/teachers_digital_platform/crtool/src/js/components/pages/QualitySummaryPage.js
+++ b/teachers_digital_platform/crtool/src/js/components/pages/QualitySummaryPage.js
@@ -28,7 +28,7 @@ export default class QualitySummaryPage extends React.Component {
                     Then, review the overall score for the quality criteria and enter your thoughts about its strengths and weaknesses.
                 </p>
                 <SaveWorkInformation />
-                <button className="a-btn" onClick={(e) => {this.props.printButtonClicked(C.QUALITY_PAGE); e.preventDefault();}}>
+                <button className="a-btn" data-gtm_ignore="true" onClick={(e) => {this.props.printButtonClicked(C.QUALITY_PAGE); e.preventDefault();}}>
                     Print or save summary
                 </button>
                 <DimensionInformation dimensionName={C.QUALITY_PAGE} {...this.props} reviewedOnDate={this.props.distinctiveCompletedDate[C.QUALITY_PAGE]} />

--- a/teachers_digital_platform/crtool/src/js/components/pages/QualitySummaryPage.js
+++ b/teachers_digital_platform/crtool/src/js/components/pages/QualitySummaryPage.js
@@ -27,7 +27,7 @@ export default class QualitySummaryPage extends React.Component {
                 <p>
                     Then, review the overall score for the quality criteria and enter your thoughts about its strengths and weaknesses.
                 </p>
-                <SaveWorkInformation />
+                <SaveWorkInformation {...this.props} />
                 <button className="a-btn" data-gtm_ignore="true" onClick={(e) => {this.props.printButtonClicked(C.QUALITY_PAGE, true); e.preventDefault();}}>
                     Print or save summary
                 </button>

--- a/teachers_digital_platform/crtool/src/js/components/pages/UtilityCriterionPage.js
+++ b/teachers_digital_platform/crtool/src/js/components/pages/UtilityCriterionPage.js
@@ -528,8 +528,8 @@ export default class UtilityCriterionPage extends React.Component {
                                     rows="6"
                                     id="utility-crt-notes-optional-1"
                                     ref="utility-crt-notes-optional-1"
-                                    value={this.props.criterionAnswers['utility-crt-notes-optional-1']}
-                                    onChange={e=>this.criterionAnswerChanged('utility-crt-notes-optional-1', e.target.value)} >
+                                    defaultValue={this.props.criterionAnswers['utility-crt-notes-optional-1']}
+                                    onBlur={e=>this.criterionAnswerChanged('utility-crt-notes-optional-1', e.target.value)} >
                         </textarea>
                     </div>
                 </div>
@@ -1478,8 +1478,8 @@ export default class UtilityCriterionPage extends React.Component {
                                     rows="6"
                                     id="utility-crt-notes-optional-2"
                                     ref="utility-crt-notes-optional-2"
-                                    value={this.props.criterionAnswers['utility-crt-notes-optional-2']}
-                                    onChange={e=>this.criterionAnswerChanged('utility-crt-notes-optional-2', e.target.value)} >
+                                    defaultValue={this.props.criterionAnswers['utility-crt-notes-optional-2']}
+                                    onBlur={e=>this.criterionAnswerChanged('utility-crt-notes-optional-2', e.target.value)} >
                         </textarea>
                     </div>
                 </div>
@@ -2122,8 +2122,8 @@ export default class UtilityCriterionPage extends React.Component {
                                     rows="6"
                                     id="utility-crt-notes-optional-3"
                                     ref="utility-crt-notes-optional-3"
-                                    value={this.props.criterionAnswers['utility-crt-notes-optional-3']}
-                                    onChange={e=>this.criterionAnswerChanged('utility-crt-notes-optional-3', e.target.value)} >
+                                    defaultValue={this.props.criterionAnswers['utility-crt-notes-optional-3']}
+                                    onBlur={e=>this.criterionAnswerChanged('utility-crt-notes-optional-3', e.target.value)} >
                         </textarea>
                     </div>
                 </div>
@@ -2700,8 +2700,8 @@ export default class UtilityCriterionPage extends React.Component {
                                     rows="6"
                                     id="utility-crt-notes-optional-4"
                                     ref="utility-crt-notes-optional-4"
-                                    value={this.props.criterionAnswers['utility-crt-notes-optional-4']}
-                                    onChange={e=>this.criterionAnswerChanged('utility-crt-notes-optional-4', e.target.value)} >
+                                    defaultValue={this.props.criterionAnswers['utility-crt-notes-optional-4']}
+                                    onBlur={e=>this.criterionAnswerChanged('utility-crt-notes-optional-4', e.target.value)} >
                         </textarea>
                     </div>
                 </div>
@@ -2984,8 +2984,8 @@ export default class UtilityCriterionPage extends React.Component {
                                     rows="6"
                                     id="utility-crt-notes-optional-5"
                                     ref="utility-crt-notes-optional-5"
-                                    value={this.props.criterionAnswers['utility-crt-notes-optional-5']}
-                                    onChange={e=>this.criterionAnswerChanged('utility-crt-notes-optional-5', e.target.value)} >
+                                    defaultValue={this.props.criterionAnswers['utility-crt-notes-optional-5']}
+                                    onBlur={e=>this.criterionAnswerChanged('utility-crt-notes-optional-5', e.target.value)} >
                         </textarea>
                     </div>
                 </div>

--- a/teachers_digital_platform/crtool/src/js/components/pages/UtilityCriterionPage.js
+++ b/teachers_digital_platform/crtool/src/js/components/pages/UtilityCriterionPage.js
@@ -42,7 +42,7 @@ export default class UtilityCriterionPage extends React.Component {
                     Utility
                 </h2>
                 <p className="lead-paragraph">
-                    The utility dimension evaluates the supports for using the curriculum. Such supports include guidance for teachers, materials that facilitate strong and effective instruction, and assessments to measure student mastery of skills and knowledge. Evaluation criteria are based on research and major national and state education standards. <a target="_blank" rel="noopener noreferrer" href="https://files.consumerfinance.gov/f/documents/cfpb_youth-financialeducation-curriculum-review.pdf">Learn more about how the review was developed</a>.
+                    The utility dimension evaluates the supports for using the curriculum. Such supports include guidance for teachers, materials that facilitate strong and effective instruction, and assessments to measure student mastery of skills and knowledge. Evaluation criteria are based on research and major national and state education standards. <a target="_blank" rel="noopener noreferrer" href={C.LEARN_MORE_PDF_LINK} onClick={(e) => {this.props.sendAnalyticsForLinkClick(C.LEARN_MORE_LINK_TEXT, C.LEARN_MORE_PDF_LINK);}}>{C.LEARN_MORE_LINK_TEXT}</a>.
                 </p>
                 <h3 className="h2">Instructions</h3>
                 <ul>
@@ -53,7 +53,7 @@ export default class UtilityCriterionPage extends React.Component {
                     <SaveWorkModal
                         buttonText="How can I save my work?"
                         hasIcon="false"
-                        hasUnderline="true" />
+                        hasUnderline="true" {...this.props} />
                 </p>
                 <div className="o-well
                                 u-mb30

--- a/teachers_digital_platform/crtool/src/js/components/pages/UtilitySummaryPage.js
+++ b/teachers_digital_platform/crtool/src/js/components/pages/UtilitySummaryPage.js
@@ -28,7 +28,7 @@ export default class UtilitySummaryPage extends React.Component {
                     Then, review the overall score for the utility criteria and enter your thoughts about its strengths and weaknesses.
                 </p>
                 <SaveWorkInformation />
-                <button className="a-btn" onClick={(e) => {this.props.printButtonClicked(C.UTILITY_PAGE); e.preventDefault();}}>
+                <button className="a-btn" data-gtm_ignore="true" onClick={(e) => {this.props.printButtonClicked(C.UTILITY_PAGE); e.preventDefault();}}>
                     Print or save summary
                 </button>
                 <DimensionInformation dimensionName={C.UTILITY_PAGE} {...this.props} reviewedOnDate={this.props.distinctiveCompletedDate[C.UTILITY_PAGE]} />

--- a/teachers_digital_platform/crtool/src/js/components/pages/UtilitySummaryPage.js
+++ b/teachers_digital_platform/crtool/src/js/components/pages/UtilitySummaryPage.js
@@ -28,7 +28,7 @@ export default class UtilitySummaryPage extends React.Component {
                     Then, review the overall score for the utility criteria and enter your thoughts about its strengths and weaknesses.
                 </p>
                 <SaveWorkInformation />
-                <button className="a-btn" data-gtm_ignore="true" onClick={(e) => {this.props.printButtonClicked(C.UTILITY_PAGE); e.preventDefault();}}>
+                <button className="a-btn" data-gtm_ignore="true" onClick={(e) => {this.props.printButtonClicked(C.UTILITY_PAGE, true); e.preventDefault();}}>
                     Print or save summary
                 </button>
                 <DimensionInformation dimensionName={C.UTILITY_PAGE} {...this.props} reviewedOnDate={this.props.distinctiveCompletedDate[C.UTILITY_PAGE]} />

--- a/teachers_digital_platform/crtool/src/js/components/pages/UtilitySummaryPage.js
+++ b/teachers_digital_platform/crtool/src/js/components/pages/UtilitySummaryPage.js
@@ -27,7 +27,7 @@ export default class UtilitySummaryPage extends React.Component {
                 <p>
                     Then, review the overall score for the utility criteria and enter your thoughts about its strengths and weaknesses.
                 </p>
-                <SaveWorkInformation />
+                <SaveWorkInformation {...this.props} />
                 <button className="a-btn" data-gtm_ignore="true" onClick={(e) => {this.props.printButtonClicked(C.UTILITY_PAGE, true); e.preventDefault();}}>
                     Print or save summary
                 </button>

--- a/teachers_digital_platform/crtool/src/js/components/pages/content/ContentElementaryCriterionPage.js
+++ b/teachers_digital_platform/crtool/src/js/components/pages/content/ContentElementaryCriterionPage.js
@@ -42,7 +42,7 @@ export default class ContentElementaryCriterionPage extends React.Component {
                     Content
                 </h2>
                 <p className="lead-paragraph">
-                    This dimension assesses whether the curriculum content helps students develop knowledge, skills, and behaviors that are important for financial capability. Evaluation criteria are based on research and major national and state education standards. <a target="_blank" rel="noopener noreferrer" href="https://files.consumerfinance.gov/f/documents/cfpb_youth-financialeducation-curriculum-review.pdf">Learn more about how the review was developed</a>.
+                    This dimension assesses whether the curriculum content helps students develop knowledge, skills, and behaviors that are important for financial capability. Evaluation criteria are based on research and major national and state education standards. <a target="_blank" rel="noopener noreferrer" href={C.LEARN_MORE_PDF_LINK} onClick={(e) => {this.props.sendAnalyticsForLinkClick(C.LEARN_MORE_LINK_TEXT, C.LEARN_MORE_PDF_LINK);}}>{C.LEARN_MORE_LINK_TEXT}</a>.
                 </p>
                 <h3 className="h2">Instructions</h3>
                 <ul>
@@ -55,7 +55,7 @@ export default class ContentElementaryCriterionPage extends React.Component {
                     <SaveWorkModal
                         buttonText="How can I save my work?"
                         hasIcon="false"
-                        hasUnderline="true" />
+                        hasUnderline="true" {...this.props} />
                 </p>
                 <hr className="hr
                                 u-mb30

--- a/teachers_digital_platform/crtool/src/js/components/pages/content/ContentElementaryCriterionPage.js
+++ b/teachers_digital_platform/crtool/src/js/components/pages/content/ContentElementaryCriterionPage.js
@@ -188,8 +188,8 @@ export default class ContentElementaryCriterionPage extends React.Component {
                                     rows="6"
                                     id="content-elementary-crt-notes-optional-1"
                                     ref="content-elementary-crt-notes-optional-1"
-                                    value={this.props.criterionAnswers['content-elementary-crt-notes-optional-1']}
-                                    onChange={e=>this.criterionAnswerChanged('content-elementary-crt-notes-optional-1', e.target.value)} >
+                                    defaultValue={this.props.criterionAnswers['content-elementary-crt-notes-optional-1']}
+                                    onBlur={e=>this.criterionAnswerChanged('content-elementary-crt-notes-optional-1', e.target.value)} >
                         </textarea>
                     </div>
                 </div>
@@ -414,8 +414,8 @@ export default class ContentElementaryCriterionPage extends React.Component {
                                     rows="6"
                                     id="content-elementary-crt-notes-optional-2"
                                     ref="content-elementary-crt-notes-optional-2"
-                                    value={this.props.criterionAnswers['content-elementary-crt-notes-optional-2']}
-                                    onChange={e=>this.criterionAnswerChanged('content-elementary-crt-notes-optional-2', e.target.value)} >
+                                    defaultValue={this.props.criterionAnswers['content-elementary-crt-notes-optional-2']}
+                                    onBlur={e=>this.criterionAnswerChanged('content-elementary-crt-notes-optional-2', e.target.value)} >
                         </textarea>
                     </div>
                 </div>
@@ -706,8 +706,8 @@ export default class ContentElementaryCriterionPage extends React.Component {
                                     rows="6"
                                     id="content-elementary-crt-notes-optional-3"
                                     ref="content-elementary-crt-notes-optional-3"
-                                    value={this.props.criterionAnswers['content-elementary-crt-notes-optional-3']}
-                                    onChange={e=>this.criterionAnswerChanged('content-elementary-crt-notes-optional-3', e.target.value)} >
+                                    defaultValue={this.props.criterionAnswers['content-elementary-crt-notes-optional-3']}
+                                    onBlur={e=>this.criterionAnswerChanged('content-elementary-crt-notes-optional-3', e.target.value)} >
                         </textarea>
                     </div>
                 </div>
@@ -830,8 +830,8 @@ export default class ContentElementaryCriterionPage extends React.Component {
                                     rows="6"
                                     id="content-elementary-crt-notes-optional-4"
                                     ref="content-elementary-crt-notes-optional-4"
-                                    value={this.props.criterionAnswers['content-elementary-crt-notes-optional-4']}
-                                    onChange={e=>this.criterionAnswerChanged('content-elementary-crt-notes-optional-4', e.target.value)} >
+                                    defaultValue={this.props.criterionAnswers['content-elementary-crt-notes-optional-4']}
+                                    onBlur={e=>this.criterionAnswerChanged('content-elementary-crt-notes-optional-4', e.target.value)} >
                         </textarea>
                     </div>
                 </div>
@@ -954,8 +954,8 @@ export default class ContentElementaryCriterionPage extends React.Component {
                                     rows="6"
                                     id="content-elementary-crt-notes-optional-5"
                                     ref="content-elementary-crt-notes-optional-5"
-                                    value={this.props.criterionAnswers['content-elementary-crt-notes-optional-5']}
-                                    onChange={e=>this.criterionAnswerChanged('content-elementary-crt-notes-optional-5', e.target.value)} >
+                                    defaultValue={this.props.criterionAnswers['content-elementary-crt-notes-optional-5']}
+                                    onBlur={e=>this.criterionAnswerChanged('content-elementary-crt-notes-optional-5', e.target.value)} >
                         </textarea>
                     </div>
                 </div>
@@ -1039,8 +1039,8 @@ export default class ContentElementaryCriterionPage extends React.Component {
                                     rows="6"
                                     id="content-elementary-crt-notes-optional-6"
                                     ref="content-elementary-crt-notes-optional-6"
-                                    value={this.props.criterionAnswers['content-elementary-crt-notes-optional-6']}
-                                    onChange={e=>this.criterionAnswerChanged('content-elementary-crt-notes-optional-6', e.target.value)} >
+                                    defaultValue={this.props.criterionAnswers['content-elementary-crt-notes-optional-6']}
+                                    onBlur={e=>this.criterionAnswerChanged('content-elementary-crt-notes-optional-6', e.target.value)} >
                         </textarea>
                     </div>
                 </div>

--- a/teachers_digital_platform/crtool/src/js/components/pages/content/ContentElementarySummaryPage.js
+++ b/teachers_digital_platform/crtool/src/js/components/pages/content/ContentElementarySummaryPage.js
@@ -28,7 +28,7 @@ export default class ContentElementarySummaryPage extends React.Component {
                     Then, review the overall score for the content criteria and enter your thoughts about its strengths and weaknesses.
                 </p>
                 <SaveWorkInformation />
-                <button className="a-btn" onClick={(e) => {this.props.printButtonClicked(C.CONTENT_PAGE); e.preventDefault();}}>
+                <button className="a-btn" data-gtm_ignore="true" onClick={(e) => {this.props.printButtonClicked(C.CONTENT_PAGE); e.preventDefault();}}>
                     Print or save summary
                 </button>
                 <DimensionInformation dimensionName={C.CONTENT_PAGE} {...this.props} reviewedOnDate={this.props.distinctiveCompletedDate[C.CONTENT_PAGE]} />

--- a/teachers_digital_platform/crtool/src/js/components/pages/content/ContentElementarySummaryPage.js
+++ b/teachers_digital_platform/crtool/src/js/components/pages/content/ContentElementarySummaryPage.js
@@ -27,7 +27,7 @@ export default class ContentElementarySummaryPage extends React.Component {
                 <p>
                     Then, review the overall score for the content criteria and enter your thoughts about its strengths and weaknesses.
                 </p>
-                <SaveWorkInformation />
+                <SaveWorkInformation {...this.props} />
                 <button className="a-btn" data-gtm_ignore="true" onClick={(e) => {this.props.printButtonClicked(C.CONTENT_PAGE, true); e.preventDefault();}}>
                     Print or save summary
                 </button>

--- a/teachers_digital_platform/crtool/src/js/components/pages/content/ContentElementarySummaryPage.js
+++ b/teachers_digital_platform/crtool/src/js/components/pages/content/ContentElementarySummaryPage.js
@@ -28,7 +28,7 @@ export default class ContentElementarySummaryPage extends React.Component {
                     Then, review the overall score for the content criteria and enter your thoughts about its strengths and weaknesses.
                 </p>
                 <SaveWorkInformation />
-                <button className="a-btn" data-gtm_ignore="true" onClick={(e) => {this.props.printButtonClicked(C.CONTENT_PAGE); e.preventDefault();}}>
+                <button className="a-btn" data-gtm_ignore="true" onClick={(e) => {this.props.printButtonClicked(C.CONTENT_PAGE, true); e.preventDefault();}}>
                     Print or save summary
                 </button>
                 <DimensionInformation dimensionName={C.CONTENT_PAGE} {...this.props} reviewedOnDate={this.props.distinctiveCompletedDate[C.CONTENT_PAGE]} />

--- a/teachers_digital_platform/crtool/src/js/components/pages/content/ContentHighCriterionPage.js
+++ b/teachers_digital_platform/crtool/src/js/components/pages/content/ContentHighCriterionPage.js
@@ -344,8 +344,8 @@ export default class ContentHighCriterionPage extends React.Component {
                                     rows="6"
                                     id="content-high-crt-notes-optional-1"
                                     ref="content-high-crt-notes-optional-1"
-                                    value={this.props.criterionAnswers['content-high-crt-notes-optional-1']}
-                                    onChange={e=>this.criterionAnswerChanged('content-high-crt-notes-optional-1', e.target.value)} >
+                                    defaultValue={this.props.criterionAnswers['content-high-crt-notes-optional-1']}
+                                    onBlur={e=>this.criterionAnswerChanged('content-high-crt-notes-optional-1', e.target.value)} >
                         </textarea>
                     </div>
                 </div>
@@ -777,8 +777,8 @@ export default class ContentHighCriterionPage extends React.Component {
                                     rows="6"
                                     id="content-high-crt-notes-optional-2"
                                     ref="content-high-crt-notes-optional-2"
-                                    value={this.props.criterionAnswers['content-high-crt-notes-optional-2']}
-                                    onChange={e=>this.criterionAnswerChanged('content-high-crt-notes-optional-2', e.target.value)} >
+                                    defaultValue={this.props.criterionAnswers['content-high-crt-notes-optional-2']}
+                                    onBlur={e=>this.criterionAnswerChanged('content-high-crt-notes-optional-2', e.target.value)} >
                         </textarea>
                     </div>
                 </div>
@@ -991,8 +991,8 @@ export default class ContentHighCriterionPage extends React.Component {
                                     rows="6"
                                     id="content-high-crt-notes-optional-3"
                                     ref="content-high-crt-notes-optional-3"
-                                    value={this.props.criterionAnswers['content-high-crt-notes-optional-3']}
-                                    onChange={e=>this.criterionAnswerChanged('content-high-crt-notes-optional-3', e.target.value)} >
+                                    defaultValue={this.props.criterionAnswers['content-high-crt-notes-optional-3']}
+                                    onBlur={e=>this.criterionAnswerChanged('content-high-crt-notes-optional-3', e.target.value)} >
                         </textarea>
                     </div>
                 </div>
@@ -1451,8 +1451,8 @@ export default class ContentHighCriterionPage extends React.Component {
                                     rows="6"
                                     id="content-high-crt-notes-optional-4"
                                     ref="content-high-crt-notes-optional-4"
-                                    value={this.props.criterionAnswers['content-high-crt-notes-optional-4']}
-                                    onChange={e=>this.criterionAnswerChanged('content-high-crt-notes-optional-4', e.target.value)} >
+                                    defaultValue={this.props.criterionAnswers['content-high-crt-notes-optional-4']}
+                                    onBlur={e=>this.criterionAnswerChanged('content-high-crt-notes-optional-4', e.target.value)} >
                         </textarea>
                     </div>
                 </div>
@@ -1794,8 +1794,8 @@ export default class ContentHighCriterionPage extends React.Component {
                                     rows="6"
                                     id="content-high-crt-notes-optional-5"
                                     ref="content-high-crt-notes-optional-5"
-                                    value={this.props.criterionAnswers['content-high-crt-notes-optional-5']}
-                                    onChange={e=>this.criterionAnswerChanged('content-high-crt-notes-optional-5', e.target.value)} >
+                                    defaultValue={this.props.criterionAnswers['content-high-crt-notes-optional-5']}
+                                    onBlur={e=>this.criterionAnswerChanged('content-high-crt-notes-optional-5', e.target.value)} >
                         </textarea>
                     </div>
                 </div>
@@ -1969,8 +1969,8 @@ export default class ContentHighCriterionPage extends React.Component {
                                     rows="6"
                                     id="content-high-crt-notes-optional-6"
                                     ref="content-high-crt-notes-optional-6"
-                                    value={this.props.criterionAnswers['content-high-crt-notes-optional-6']}
-                                    onChange={e=>this.criterionAnswerChanged('content-high-crt-notes-optional-6', e.target.value)} >
+                                    defaultValue={this.props.criterionAnswers['content-high-crt-notes-optional-6']}
+                                    onBlur={e=>this.criterionAnswerChanged('content-high-crt-notes-optional-6', e.target.value)} >
                         </textarea>
                     </div>
                 </div>

--- a/teachers_digital_platform/crtool/src/js/components/pages/content/ContentHighCriterionPage.js
+++ b/teachers_digital_platform/crtool/src/js/components/pages/content/ContentHighCriterionPage.js
@@ -42,7 +42,7 @@ export default class ContentHighCriterionPage extends React.Component {
                     Content
                 </h2>
                 <p className="lead-paragraph">
-                    This dimension assesses whether the curriculum content helps students develop knowledge, skills, and behaviors that are important for financial capability. Evaluation criteria are based on research and major national and state education standards. <a target="_blank" rel="noopener noreferrer" href="https://files.consumerfinance.gov/f/documents/cfpb_youth-financialeducation-curriculum-review.pdf">Learn more about how the review was developed</a>.
+                    This dimension assesses whether the curriculum content helps students develop knowledge, skills, and behaviors that are important for financial capability. Evaluation criteria are based on research and major national and state education standards. <a target="_blank" rel="noopener noreferrer" href={C.LEARN_MORE_PDF_LINK} onClick={(e) => {this.props.sendAnalyticsForLinkClick(C.LEARN_MORE_LINK_TEXT, C.LEARN_MORE_PDF_LINK);}}>{C.LEARN_MORE_LINK_TEXT}</a>.
                 </p>
                 <h3 className="h2">Instructions</h3>
                 <ul>
@@ -55,7 +55,7 @@ export default class ContentHighCriterionPage extends React.Component {
                     <SaveWorkModal
                         buttonText="How can I save my work?"
                         hasIcon="false"
-                        hasUnderline="true" />
+                        hasUnderline="true" {...this.props} />
                 </p>
                 <hr className="hr
                                 u-mb30

--- a/teachers_digital_platform/crtool/src/js/components/pages/content/ContentHighSummaryPage.js
+++ b/teachers_digital_platform/crtool/src/js/components/pages/content/ContentHighSummaryPage.js
@@ -28,7 +28,7 @@ export default class ContentHighSummaryPage extends React.Component {
                     Then, review the overall score for the content criteria and enter your thoughts about its strengths and weaknesses.
                 </p>
                 <SaveWorkInformation />
-                <button className="a-btn" onClick={(e) => {this.props.printButtonClicked(C.CONTENT_PAGE); e.preventDefault();}}>
+                <button className="a-btn" data-gtm_ignore="true" onClick={(e) => {this.props.printButtonClicked(C.CONTENT_PAGE); e.preventDefault();}}>
                     Print or save summary
                 </button>
                 <DimensionInformation dimensionName={C.CONTENT_PAGE} {...this.props} reviewedOnDate={this.props.distinctiveCompletedDate[C.CONTENT_PAGE]} />

--- a/teachers_digital_platform/crtool/src/js/components/pages/content/ContentHighSummaryPage.js
+++ b/teachers_digital_platform/crtool/src/js/components/pages/content/ContentHighSummaryPage.js
@@ -28,7 +28,7 @@ export default class ContentHighSummaryPage extends React.Component {
                     Then, review the overall score for the content criteria and enter your thoughts about its strengths and weaknesses.
                 </p>
                 <SaveWorkInformation />
-                <button className="a-btn" data-gtm_ignore="true" onClick={(e) => {this.props.printButtonClicked(C.CONTENT_PAGE); e.preventDefault();}}>
+                <button className="a-btn" data-gtm_ignore="true" onClick={(e) => {this.props.printButtonClicked(C.CONTENT_PAGE, true); e.preventDefault();}}>
                     Print or save summary
                 </button>
                 <DimensionInformation dimensionName={C.CONTENT_PAGE} {...this.props} reviewedOnDate={this.props.distinctiveCompletedDate[C.CONTENT_PAGE]} />

--- a/teachers_digital_platform/crtool/src/js/components/pages/content/ContentHighSummaryPage.js
+++ b/teachers_digital_platform/crtool/src/js/components/pages/content/ContentHighSummaryPage.js
@@ -27,7 +27,7 @@ export default class ContentHighSummaryPage extends React.Component {
                 <p>
                     Then, review the overall score for the content criteria and enter your thoughts about its strengths and weaknesses.
                 </p>
-                <SaveWorkInformation />
+                <SaveWorkInformation {...this.props} />
                 <button className="a-btn" data-gtm_ignore="true" onClick={(e) => {this.props.printButtonClicked(C.CONTENT_PAGE, true); e.preventDefault();}}>
                     Print or save summary
                 </button>

--- a/teachers_digital_platform/crtool/src/js/components/pages/content/ContentMiddleCriterionPage.js
+++ b/teachers_digital_platform/crtool/src/js/components/pages/content/ContentMiddleCriterionPage.js
@@ -42,7 +42,7 @@ export default class ContentMiddleCriterionPage extends React.Component {
                     Content
                 </h2>
                 <p className="lead-paragraph">
-                    This dimension assesses whether the curriculum content helps students develop knowledge, skills, and behaviors that are important for financial capability. Evaluation criteria are based on research and major national and state education standards. <a target="_blank" rel="noopener noreferrer" href="https://files.consumerfinance.gov/f/documents/cfpb_youth-financialeducation-curriculum-review.pdf">Learn more about how the review was developed</a>.
+                    This dimension assesses whether the curriculum content helps students develop knowledge, skills, and behaviors that are important for financial capability. Evaluation criteria are based on research and major national and state education standards. <a target="_blank" rel="noopener noreferrer" href={C.LEARN_MORE_PDF_LINK} onClick={(e) => {this.props.sendAnalyticsForLinkClick(C.LEARN_MORE_LINK_TEXT, C.LEARN_MORE_PDF_LINK);}}>{C.LEARN_MORE_LINK_TEXT}</a>.
                 </p>
                 <h3 className="h2">Instructions</h3>
                 <ul>
@@ -55,7 +55,7 @@ export default class ContentMiddleCriterionPage extends React.Component {
                     <SaveWorkModal
                         buttonText="How can I save my work?"
                         hasIcon="false"
-                        hasUnderline="true" />
+                        hasUnderline="true" {...this.props} />
                 </p>
                 <hr className="hr
                                 u-mb30

--- a/teachers_digital_platform/crtool/src/js/components/pages/content/ContentMiddleCriterionPage.js
+++ b/teachers_digital_platform/crtool/src/js/components/pages/content/ContentMiddleCriterionPage.js
@@ -227,8 +227,8 @@ export default class ContentMiddleCriterionPage extends React.Component {
                                     rows="6"
                                     id="content-middle-crt-notes-optional-1"
                                     ref="content-middle-crt-notes-optional-1"
-                                    value={this.props.criterionAnswers['content-middle-crt-notes-optional-1']}
-                                    onChange={e=>this.criterionAnswerChanged('content-middle-crt-notes-optional-1', e.target.value)} >
+                                    defaultValue={this.props.criterionAnswers['content-middle-crt-notes-optional-1']}
+                                    onBlur={e=>this.criterionAnswerChanged('content-middle-crt-notes-optional-1', e.target.value)} >
                         </textarea>
                     </div>
                 </div>
@@ -621,8 +621,8 @@ export default class ContentMiddleCriterionPage extends React.Component {
                                     rows="6"
                                     id="content-middle-crt-notes-optional-2"
                                     ref="content-middle-crt-notes-optional-2"
-                                    value={this.props.criterionAnswers['content-middle-crt-notes-optional-2']}
-                                    onChange={e=>this.criterionAnswerChanged('content-middle-crt-notes-optional-2', e.target.value)} >
+                                    defaultValue={this.props.criterionAnswers['content-middle-crt-notes-optional-2']}
+                                    onBlur={e=>this.criterionAnswerChanged('content-middle-crt-notes-optional-2', e.target.value)} >
                         </textarea>
                     </div>
                 </div>
@@ -874,8 +874,8 @@ export default class ContentMiddleCriterionPage extends React.Component {
                                     rows="6"
                                     id="content-middle-crt-notes-optional-3"
                                     ref="content-middle-crt-notes-optional-3"
-                                    value={this.props.criterionAnswers['content-middle-crt-notes-optional-3']}
-                                    onChange={e=>this.criterionAnswerChanged('content-middle-crt-notes-optional-3', e.target.value)} >
+                                    defaultValue={this.props.criterionAnswers['content-middle-crt-notes-optional-3']}
+                                    onBlur={e=>this.criterionAnswerChanged('content-middle-crt-notes-optional-3', e.target.value)} >
                         </textarea>
                     </div>
                 </div>
@@ -1217,8 +1217,8 @@ export default class ContentMiddleCriterionPage extends React.Component {
                                     rows="6"
                                     id="content-middle-crt-notes-optional-4"
                                     ref="content-middle-crt-notes-optional-4"
-                                    value={this.props.criterionAnswers['content-middle-crt-notes-optional-4']}
-                                    onChange={e=>this.criterionAnswerChanged('content-middle-crt-notes-optional-4', e.target.value)} >
+                                    defaultValue={this.props.criterionAnswers['content-middle-crt-notes-optional-4']}
+                                    onBlur={e=>this.criterionAnswerChanged('content-middle-crt-notes-optional-4', e.target.value)} >
                         </textarea>
                     </div>
                 </div>
@@ -1443,8 +1443,8 @@ export default class ContentMiddleCriterionPage extends React.Component {
                                     rows="6"
                                     id="content-middle-crt-notes-optional-5"
                                     ref="content-middle-crt-notes-optional-5"
-                                    value={this.props.criterionAnswers['content-middle-crt-notes-optional-5']}
-                                    onChange={e=>this.criterionAnswerChanged('content-middle-crt-notes-optional-5', e.target.value)} >
+                                    defaultValue={this.props.criterionAnswers['content-middle-crt-notes-optional-5']}
+                                    onBlur={e=>this.criterionAnswerChanged('content-middle-crt-notes-optional-5', e.target.value)} >
                         </textarea>
                     </div>
                 </div>
@@ -1567,8 +1567,8 @@ export default class ContentMiddleCriterionPage extends React.Component {
                                     rows="6"
                                     id="content-middle-crt-notes-optional-6"
                                     ref="content-middle-crt-notes-optional-6"
-                                    value={this.props.criterionAnswers['content-middle-crt-notes-optional-6']}
-                                    onChange={e=>this.criterionAnswerChanged('content-middle-crt-notes-optional-6', e.target.value)} >
+                                    defaultValue={this.props.criterionAnswers['content-middle-crt-notes-optional-6']}
+                                    onBlur={e=>this.criterionAnswerChanged('content-middle-crt-notes-optional-6', e.target.value)} >
                         </textarea>
                     </div>
                 </div>

--- a/teachers_digital_platform/crtool/src/js/components/pages/content/ContentMiddleSummaryPage.js
+++ b/teachers_digital_platform/crtool/src/js/components/pages/content/ContentMiddleSummaryPage.js
@@ -27,7 +27,7 @@ export default class ContentMiddleSummaryPage extends React.Component {
                 <p>
                     Then, review the overall score for the content criteria and enter your thoughts about its strengths and weaknesses.
                 </p>
-                <SaveWorkInformation />
+                <SaveWorkInformation {...this.props} />
                 <button className="a-btn" data-gtm_ignore="true" onClick={(e) => {this.props.printButtonClicked(C.CONTENT_PAGE, true); e.preventDefault();}}>
                     Print or save summary
                 </button>

--- a/teachers_digital_platform/crtool/src/js/components/pages/content/ContentMiddleSummaryPage.js
+++ b/teachers_digital_platform/crtool/src/js/components/pages/content/ContentMiddleSummaryPage.js
@@ -28,7 +28,7 @@ export default class ContentMiddleSummaryPage extends React.Component {
                     Then, review the overall score for the content criteria and enter your thoughts about its strengths and weaknesses.
                 </p>
                 <SaveWorkInformation />
-                <button className="a-btn" onClick={(e) => {this.props.printButtonClicked(C.CONTENT_PAGE); e.preventDefault();}}>
+                <button className="a-btn" data-gtm_ignore="true" onClick={(e) => {this.props.printButtonClicked(C.CONTENT_PAGE); e.preventDefault();}}>
                     Print or save summary
                 </button>
                 <DimensionInformation dimensionName={C.CONTENT_PAGE} {...this.props} reviewedOnDate={this.props.distinctiveCompletedDate[C.CONTENT_PAGE]} />

--- a/teachers_digital_platform/crtool/src/js/components/pages/content/ContentMiddleSummaryPage.js
+++ b/teachers_digital_platform/crtool/src/js/components/pages/content/ContentMiddleSummaryPage.js
@@ -28,7 +28,7 @@ export default class ContentMiddleSummaryPage extends React.Component {
                     Then, review the overall score for the content criteria and enter your thoughts about its strengths and weaknesses.
                 </p>
                 <SaveWorkInformation />
-                <button className="a-btn" data-gtm_ignore="true" onClick={(e) => {this.props.printButtonClicked(C.CONTENT_PAGE); e.preventDefault();}}>
+                <button className="a-btn" data-gtm_ignore="true" onClick={(e) => {this.props.printButtonClicked(C.CONTENT_PAGE, true); e.preventDefault();}}>
                     Print or save summary
                 </button>
                 <DimensionInformation dimensionName={C.CONTENT_PAGE} {...this.props} reviewedOnDate={this.props.distinctiveCompletedDate[C.CONTENT_PAGE]} />

--- a/teachers_digital_platform/crtool/src/js/components/pages/partial.pages/EfficacyOveralScoreComponent.js
+++ b/teachers_digital_platform/crtool/src/js/components/pages/partial.pages/EfficacyOveralScoreComponent.js
@@ -262,8 +262,8 @@ export default class EfficacyOveralScoreComponent extends React.Component {
                                 rows="6"
                                 id={this.props.dimensionKey + "assets-optional"}
                                 ref={this.props.dimensionKey + "assets-optional"}
-                                value={this.props.criterionAnswers[this.props.dimensionKey + "assets-optional"]}
-                                onChange={e=>this.criterionAnswerChanged(this.props.dimensionKey + "assets-optional", e.target.value)} >
+                                defaultValue={this.props.criterionAnswers[this.props.dimensionKey + "assets-optional"]}
+                                onBlur={e=>this.criterionAnswerChanged(this.props.dimensionKey + "assets-optional", e.target.value)} >
                             </textarea>
                         }
                         {this.isEditMode() === false &&
@@ -290,8 +290,8 @@ export default class EfficacyOveralScoreComponent extends React.Component {
                                 rows="6"
                                 id={this.props.dimensionKey + "gaps-optional"}
                                 ref={this.props.dimensionKey + "gaps-optional"}
-                                value={this.props.criterionAnswers[this.props.dimensionKey + "gaps-optional"]}
-                                onChange={e=>this.criterionAnswerChanged(this.props.dimensionKey + "gaps-optional", e.target.value)} >
+                                defaultValue={this.props.criterionAnswers[this.props.dimensionKey + "gaps-optional"]}
+                                onBlur={e=>this.criterionAnswerChanged(this.props.dimensionKey + "gaps-optional", e.target.value)} >
                             </textarea>
                         }
                         {this.isEditMode() === false &&
@@ -317,8 +317,8 @@ export default class EfficacyOveralScoreComponent extends React.Component {
                                 rows="6"
                                 id={this.props.dimensionKey + "overall-notes-optional"}
                                 ref={this.props.dimensionKey + "overall-notes-optional"}
-                                value={this.props.criterionAnswers[this.props.dimensionKey + "overall-notes-optional"]}
-                                onChange={e=>this.criterionAnswerChanged(this.props.dimensionKey + "overall-notes-optional", e.target.value)} >
+                                defaultValue={this.props.criterionAnswers[this.props.dimensionKey + "overall-notes-optional"]}
+                                onBlur={e=>this.criterionAnswerChanged(this.props.dimensionKey + "overall-notes-optional", e.target.value)} >
                             </textarea>
                         }
                         {this.isEditMode() === false &&
@@ -435,8 +435,8 @@ export default class EfficacyOveralScoreComponent extends React.Component {
                                     rows="6"
                                     id={this.props.dimensionKey + "assets-optional"}
                                     ref={this.props.dimensionKey + "assets-optional"}
-                                    value={this.props.criterionAnswers[this.props.dimensionKey + "assets-optional"]}
-                                    onChange={e=>this.criterionAnswerChanged(this.props.dimensionKey + "assets-optional", e.target.value)} >
+                                    defaultValue={this.props.criterionAnswers[this.props.dimensionKey + "assets-optional"]}
+                                    onBlur={e=>this.criterionAnswerChanged(this.props.dimensionKey + "assets-optional", e.target.value)} >
                                 </textarea>
                             }
                             {this.isEditMode() === false &&
@@ -463,8 +463,8 @@ export default class EfficacyOveralScoreComponent extends React.Component {
                                     rows="6"
                                     id={this.props.dimensionKey + "gaps-optional"}
                                     ref={this.props.dimensionKey + "gaps-optional"}
-                                    value={this.props.criterionAnswers[this.props.dimensionKey + "gaps-optional"]}
-                                    onChange={e=>this.criterionAnswerChanged(this.props.dimensionKey + "gaps-optional", e.target.value)} >
+                                    defaultValue={this.props.criterionAnswers[this.props.dimensionKey + "gaps-optional"]}
+                                    onBlur={e=>this.criterionAnswerChanged(this.props.dimensionKey + "gaps-optional", e.target.value)} >
                                 </textarea>
                             }
                             {this.isEditMode() === false &&
@@ -490,8 +490,8 @@ export default class EfficacyOveralScoreComponent extends React.Component {
                                     rows="6"
                                     id={this.props.dimensionKey + "overall-notes-optional"}
                                     ref={this.props.dimensionKey + "overall-notes-optional"}
-                                    value={this.props.criterionAnswers[this.props.dimensionKey + "overall-notes-optional"]}
-                                    onChange={e=>this.criterionAnswerChanged(this.props.dimensionKey + "overall-notes-optional", e.target.value)} >
+                                    defaultValue={this.props.criterionAnswers[this.props.dimensionKey + "overall-notes-optional"]}
+                                    onBlur={e=>this.criterionAnswerChanged(this.props.dimensionKey + "overall-notes-optional", e.target.value)} >
                                 </textarea>
                             }
                             {this.isEditMode() === false &&

--- a/teachers_digital_platform/crtool/src/js/components/pages/partial.pages/EfficacyStudyComponent.js
+++ b/teachers_digital_platform/crtool/src/js/components/pages/partial.pages/EfficacyStudyComponent.js
@@ -79,8 +79,8 @@ export default class EfficacyStudyComponent extends React.Component {
                         <input className="a-text-input a-text-input__full" type="text"
                             id={this.generateStudyRefId("", "study")}
                             ref={this.generateStudyRefId("", "study")}
-                            value={this.props.studyAnswers[this.props.studyCount][this.generateStudyRefId("", "study")]}
-                            onChange={e=>this.criterionStudyAnswerChanged(this.generateStudyRefId("", "study"), e.target.value)} />
+                            defaultValue={this.props.studyAnswers[this.props.studyCount][this.generateStudyRefId("", "study")]}
+                            onBlur={e=>this.criterionStudyAnswerChanged(this.generateStudyRefId("", "study"), e.target.value)} />
                     </div>
                 </div>
                 <ol className="m-list__unstyled">
@@ -287,8 +287,8 @@ export default class EfficacyStudyComponent extends React.Component {
                                 rows="6"
                                 id={this.generateStudyRefId("1", "_notes_optional")}
                                 ref={this.generateStudyRefId("1", "_notes_optional")}
-                                value={this.props.studyAnswers[this.props.studyCount][this.generateStudyRefId("1", "_notes_optional")]}
-                                onChange={e=>this.criterionStudyAnswerChanged(this.generateStudyRefId("1", "_notes_optional"), e.target.value)} >
+                                defaultValue={this.props.studyAnswers[this.props.studyCount][this.generateStudyRefId("1", "_notes_optional")]}
+                                onBlur={e=>this.criterionStudyAnswerChanged(this.generateStudyRefId("1", "_notes_optional"), e.target.value)} >
                     </textarea>
                 </div>
                 <EfficacyStudyScoreComponent

--- a/teachers_digital_platform/crtool/src/js/components/pages/partial.pages/EfficacyStudyComponent.js
+++ b/teachers_digital_platform/crtool/src/js/components/pages/partial.pages/EfficacyStudyComponent.js
@@ -11,6 +11,7 @@ export default class EfficacyStudyComponent extends React.Component {
             return (
                 <div className="l-survey-top">
                     <button className="a-btn a-btn__link a-btn__no-line"
+                        data-gtm_ignore="true"
                         onClick={() => this.removeEfficacyStudy(this.props.studyCount)} >
                         Remove
                         <SvgIcon

--- a/teachers_digital_platform/crtool/src/js/components/pages/summary/CriterionScoreBlock.js
+++ b/teachers_digital_platform/crtool/src/js/components/pages/summary/CriterionScoreBlock.js
@@ -165,8 +165,8 @@ export default class CriterionScoreBlock extends React.Component {
                         rows="6"
                         id={this.props.dimensionKey + "notes-optional-" + this.props.criterionNumber}
                         ref={this.props.dimensionKey + "notes-optional-" + this.props.criterionNumber}
-                        value={this.props.criterionAnswers[this.props.dimensionKey + "notes-optional-" + this.props.criterionNumber]}
-                        onChange={e=>this.criterionAnswerChanged(this.props.dimensionKey + "notes-optional-" + this.props.criterionNumber, e.target.value)} >
+                        defaultValue={this.props.criterionAnswers[this.props.dimensionKey + "notes-optional-" + this.props.criterionNumber]}
+                        onBlur={e=>this.criterionAnswerChanged(this.props.dimensionKey + "notes-optional-" + this.props.criterionNumber, e.target.value)} >
                     </textarea>
                 </div>
             );

--- a/teachers_digital_platform/crtool/src/js/components/pages/summary/DimensionScoreBlock.js
+++ b/teachers_digital_platform/crtool/src/js/components/pages/summary/DimensionScoreBlock.js
@@ -240,8 +240,8 @@ export default class DimensionScoreBlock extends React.Component {
                             rows="6"
                             id={this.props.dimensionKey + "assets-optional"}
                             ref={this.props.dimensionKey + "assets-optional"}
-                            value={this.props.criterionAnswers[this.props.dimensionKey + "assets-optional"]}
-                            onChange={e=>this.criterionAnswerChanged(this.props.dimensionKey + "assets-optional", e.target.value)} >
+                            defaultValue={this.props.criterionAnswers[this.props.dimensionKey + "assets-optional"]}
+                            onBlur={e=>this.criterionAnswerChanged(this.props.dimensionKey + "assets-optional", e.target.value)} >
                         </textarea>
                     </div>
                     <div className="m-form-field
@@ -258,8 +258,8 @@ export default class DimensionScoreBlock extends React.Component {
                             rows="6"
                             id={this.props.dimensionKey + "gaps-optional"}
                             ref={this.props.dimensionKey + "gaps-optional"}
-                            value={this.props.criterionAnswers[this.props.dimensionKey + "gaps-optional"]}
-                            onChange={e=>this.criterionAnswerChanged(this.props.dimensionKey + "gaps-optional", e.target.value)} >
+                            defaultValue={this.props.criterionAnswers[this.props.dimensionKey + "gaps-optional"]}
+                            onBlur={e=>this.criterionAnswerChanged(this.props.dimensionKey + "gaps-optional", e.target.value)} >
                         </textarea>
                     </div>
                     <div className="m-form-field
@@ -275,8 +275,8 @@ export default class DimensionScoreBlock extends React.Component {
                             rows="6"
                             id={this.props.dimensionKey + "overall-notes-optional"}
                             ref={this.props.dimensionKey + "overall-notes-optional"}
-                            value={this.props.criterionAnswers[this.props.dimensionKey + "overall-notes-optional"]}
-                            onChange={e=>this.criterionAnswerChanged(this.props.dimensionKey + "overall-notes-optional", e.target.value)} >
+                            defaultValue={this.props.criterionAnswers[this.props.dimensionKey + "overall-notes-optional"]}
+                            onBlur={e=>this.criterionAnswerChanged(this.props.dimensionKey + "overall-notes-optional", e.target.value)} >
                         </textarea>
                     </div>
                 </div>
@@ -370,8 +370,8 @@ export default class DimensionScoreBlock extends React.Component {
                             rows="6"
                             id={this.props.dimensionKey + "assets-optional"}
                             ref={this.props.dimensionKey + "assets-optional"}
-                            value={this.props.criterionAnswers[this.props.dimensionKey + "assets-optional"]}
-                            onChange={e=>this.criterionAnswerChanged(this.props.dimensionKey + "assets-optional", e.target.value)} >
+                            defaultValue={this.props.criterionAnswers[this.props.dimensionKey + "assets-optional"]}
+                            onBlur={e=>this.criterionAnswerChanged(this.props.dimensionKey + "assets-optional", e.target.value)} >
                         </textarea>
                     </div>
                     <div className="m-form-field
@@ -388,8 +388,8 @@ export default class DimensionScoreBlock extends React.Component {
                             rows="6"
                             id={this.props.dimensionKey + "gaps-optional"}
                             ref={this.props.dimensionKey + "gaps-optional"}
-                            value={this.props.criterionAnswers[this.props.dimensionKey + "gaps-optional"]}
-                            onChange={e=>this.criterionAnswerChanged(this.props.dimensionKey + "gaps-optional", e.target.value)} >
+                            defaultValue={this.props.criterionAnswers[this.props.dimensionKey + "gaps-optional"]}
+                            onBlur={e=>this.criterionAnswerChanged(this.props.dimensionKey + "gaps-optional", e.target.value)} >
                         </textarea>
                     </div>
                     <div className="m-form-field
@@ -405,8 +405,8 @@ export default class DimensionScoreBlock extends React.Component {
                             rows="6"
                             id={this.props.dimensionKey + "overall-notes-optional"}
                             ref={this.props.dimensionKey + "overall-notes-optional"}
-                            value={this.props.criterionAnswers[this.props.dimensionKey + "overall-notes-optional"]}
-                            onChange={e=>this.criterionAnswerChanged(this.props.dimensionKey + "overall-notes-optional", e.target.value)} >
+                            defaultValue={this.props.criterionAnswers[this.props.dimensionKey + "overall-notes-optional"]}
+                            onBlur={e=>this.criterionAnswerChanged(this.props.dimensionKey + "overall-notes-optional", e.target.value)} >
                         </textarea>
                     </div>
                 </div>

--- a/teachers_digital_platform/jinja2/teachers_digital_platform/crt-start.html
+++ b/teachers_digital_platform/jinja2/teachers_digital_platform/crt-start.html
@@ -176,7 +176,7 @@
                 <button id="tdp-crt-begin-review-btn" class="a-btn" type="submit" onclick="beginReviewButtonClick();return true;" formaction="../tool">
                     Start review
                 </button>
-                <button id="new-review-modal-dialog-btn" class="a-btn a-btn__link" onclick="openNewReviewModalWindow();return false;">Start over with a new review</button>
+                <button id="new-review-modal-dialog-btn" class="a-btn a-btn__link" data-gtm_ignore="true" onclick="openNewReviewModalWindow();return false;">Start over with a new review</button>
             </div>
         </form>
     </div>

--- a/teachers_digital_platform/jinja2/teachers_digital_platform/crt-start.html
+++ b/teachers_digital_platform/jinja2/teachers_digital_platform/crt-start.html
@@ -3,6 +3,7 @@
 
 {# HEAD items #}
 
+
 {% block title -%}
     Curriculum Review Tool | Consumer Financial Protection Bureau
 {%- endblock title %}
@@ -164,19 +165,17 @@
                             <h3 class="h4">Limitations around saving your work</h3>
                             <p>
                                 After you finish each dimension, we recommend you print the summary or save it as a PDF. Learn more about
-                                <button class="a-btn a-btn__link" onclick="openSaveWorkModalWindow();return false;">how to save your work.
-
-                                </button>
+                                <button class="a-btn a-btn__link push-analytics" onclick="openSaveWorkModalWindow();return false;">how to save your work</button>
                             </p>
                         </div>
                     </div>
                 </div>
             </div>
             <div class="m-btn-group m-btn-group__wide">
-                <button id="tdp-crt-begin-review-btn" class="a-btn" type="submit" onclick="beginReviewButtonClick();return true;" formaction="../tool">
+                <button id="tdp-crt-begin-review-btn" class="a-btn push-analytics" type="submit" onclick="beginReviewButtonClick();return true;" formaction="../tool">
                     Start review
                 </button>
-                <button id="new-review-modal-dialog-btn" class="a-btn a-btn__link" data-gtm_ignore="true" onclick="openNewReviewModalWindow();return false;">Start over with a new review</button>
+                <button id="new-review-modal-dialog-btn" class="a-btn a-btn__link push-analytics" data-gtm_ignore="true" onclick="openNewReviewModalWindow();return false;">Start over with a new review</button>
             </div>
         </form>
     </div>
@@ -250,7 +249,7 @@
                 </div>
                 <div class="o-modal_footer">
                     <div class="m-btn-group m-btn-group__wide">
-                        <button class="a-btn" onclick="clearLocalStorage(); return false;">Yes</button>
+                        <button class="a-btn push-analytics" onclick="clearLocalStorage(); return false;">Yes</button>
                         <button class="a-btn a-btn__link" onclick="closeNewReviewModalWindow(); return false;">No, return to current review</button>
                     </div>
                 </div>
@@ -275,7 +274,7 @@
                     <h1 id="modal-save-work_title" class="h3">Saving your work</h1>
                     <div id="modal-save-work_desc">
                         <p>This tool uses cookies to <strong>temporarily</strong> save your work. To see answers you’ve already completed, you need to use the same computer and browser, and don’t clear your cookies.</p>
-                        <p>To save a permanent copy of your work, please print the summary or save it as a PDF for every dimension as you complete it. You can also print or save a summary of the entire review. Learn how to <a href="https://www.consumerfinance.gov/consumer-tools/save-as-pdf-instructions/" target="_blank" rel="noopener noreferrer">save the summary as a PDF</a>.</p>
+                        <p>To save a permanent copy of your work, please print the summary or save it as a PDF for every dimension as you complete it. You can also print or save a summary of the entire review. Learn how to <a href="https://www.consumerfinance.gov/consumer-tools/save-as-pdf-instructions/" class="push-download-analytics" target="_blank" rel="noopener noreferrer">save the summary as a PDF</a>.</p>
                         <p>You can only work on a single curriculum at a time</p>
                     </div>
                 </div>
@@ -286,6 +285,43 @@
         </div>
     </div>
 
+
+    <script src="//ajax.googleapis.com/ajax/libs/jquery/1.11.3/jquery.min.js"></script>
+    <!-- this is where we put our custom analytics -->
+    <!-- H5BP's Asynchronous Google Analytics snippet. -->
+    <script type="text/javascript">
+      var _gaq=[['_setAccount','UA-20466645-3'],['_setDomainName', '.consumerfinance.gov']];
+      (function(d,t){var g=d.createElement(t),s=d.getElementsByTagName(t)[0];
+      g.src=('https:'==location.protocol?'//ssl':'//www')+'.google-analytics.com/ga.js';
+      s.parentNode.insertBefore(g,s)}(document,'script'));
+      $(function(){
+            var prev_hash_val = location.hash;
+            _gaq.push(["_trackPageview", location.pathname + location.search + location.hash]);
+            $(window).bind("hashchange", function (e) {
+                if(prev_hash_val != location.hash){
+                    prev_hash_val = location.hash;
+                    _gaq.push(["_trackPageview", location.pathname + location.search + location.hash]);
+                }
+            });
+        });
+    </script>
+    <script type="text/javascript">
+        // Tracks analytics for links on page clicked
+        $('button.push-analytics').click(function() {
+            var link_text = $(this).text();
+            category="curriculum review tool interaction";
+            action="link clicked: " + link_text;
+            label=link_text;
+            _gaq.push(['_trackEvent', category, action, label]);
+        });
+
+        // Tracks file downloads for the whole page
+        $('a[href$="zip"],a[href$="pdf"],a[href$="doc"],a[href$="docx"],a[href$="xls"],a[href$="xlsx"],a[href$="ppt"],a[href$="pptx"],a[href$="txt"],a[href$="csv"],a.push-download-analytics').click(function() {
+            var link_text = $(this).text();
+            var link_url = $(this).attr('href')
+            _gaq.push(['_trackEvent','Downloads', link_text, link_url]);
+        });
+    </script>
     <script>
         /**
          * The below code manages the enabling/disabling of the submit button
@@ -353,6 +389,22 @@
 
             var gradeRange = document.getElementById('tdp-crt_grade').value;
             localStorage.setItem('gradeRange', gradeRange);
+
+            recordAnalyticsForPage(curriculumTitle, publicationDate, gradeRange);
+        }
+
+        /*
+         * When user starts a new reveiw we need to send analytics for 
+         * Curriculum Title, Publication Date, & Grade Range
+         */
+        function recordAnalyticsForPage(curriculumTitle, publicationDate, gradeRange) {
+            var category="curriculum review tool interaction";
+            // Analytics curriculum title
+            _gaq.push(['_trackEvent', category, "curriculum title", curriculumTitle]);
+            // Analytics date of publication
+            _gaq.push(['_trackEvent', category, "date of publication", publicationDate]);
+            // Analytics grade range
+            _gaq.push(['_trackEvent', category, "grade range", gradeRange]);
         }
 
         /*

--- a/teachers_digital_platform/jinja2/teachers_digital_platform/prototypes/crt-start.html
+++ b/teachers_digital_platform/jinja2/teachers_digital_platform/prototypes/crt-start.html
@@ -159,7 +159,7 @@
                     <div class="m-notification_content">
                         <div class="m-notification_message">
                             <h3 class="h4">Limitations around saving your work</h3>
-                            <p>If you plan to complete this review over multiple sessions, we recommend downloading a summary after each completed section. Learn more about <a href="#modal-dialog">how to save your work.</a></p>
+                            <p>If you plan to complete this review over multiple sessions, we recommend downloading a summary after each completed section. Learn more about <a href="#modal-dialog" data-gtm_ignore="true">how to save your work.</a></p>
                         </div>
                     </div>
                 </div>


### PR DESCRIPTION
Short description explaining the high-level reason for the pull request

## Additions

- Analytics.js (for the tool page)
- Added analytics javascript code to the crt-start page
- for print I used "window.onafterprint()"


## Removals

- Removed code from Repository.resetApplicationData() that was failing to run. After investigating this it was failing to set state so after the first method call a javascript error would be thrown and the reset of the reset would never execute.  Since the whole app was tested this way it is best to remove the error and leave the code executing as it was tested.

## Notable Changes

- Notes fields were trigging on each keypress that did not work well for sending analytics.  The fix is:
   - Changed the Textarea onChange to onBlur
   - This resulted in changing the value to defaultValue

## Review

- @dcmouyard 

[Preview this PR without the whitespace changes](?w=0)
