### PR TITLE
Remove Wagtail from install_requires

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -9,7 +9,6 @@ except (IOError, ImportError):
 
 install_requires = [
     'Django>=1.8,<1.12',
-    'wagtail>=1.8,<1.11',
 ]
 
 


### PR DESCRIPTION
Closes #167.

This PR removes the wagtail requirement from `install_requires` in setup.py. This will resolve the version conflict with cfgov-refresh and allow tests that include optional apps in cfgov-refresh (like `tox -e validate-assets`) to run without erring.

## Removals

- wagtail from `install_requires`

