### PR TITLE
Updated gulp task to run one command, not 3 parallel commands

### DIFF
--- a/gulp/tasks/crtool.js
+++ b/gulp/tasks/crtool.js
@@ -2,24 +2,9 @@
 
 const gulp = require( 'gulp' );
 const run = require( 'gulp-run' );
+const spawn = require( 'child_process' ).spawn;
 
-gulp.task( 'crtool:chdir-down', () => {
-  process.chdir( 'teachers_digital_platform/crtool' );
-} );
-
-gulp.task( 'crtool:build', () => {
-  return run( 'npm run build' ).exec();
-} );
-
-gulp.task( 'crtool:chdir-up', () => {
-  process.chdir( '../..' );
-} );
-
-gulp.task( 'crtool',
-  [
-    'crtool:chdir-down',
-    'crtool:build',
-    'crtool:chdir-up',
-    'test'
-  ]
-);
+gulp.task('crtool', function(done) {
+    spawn('npm', ['run', 'build'], { cwd: 'teachers_digital_platform/crtool/', stdio: 'inherit' })
+      .on('close', done);
+});

--- a/gulp/tasks/test.js
+++ b/gulp/tasks/test.js
@@ -2,23 +2,9 @@
 
 const gulp = require( 'gulp' );
 const run = require( 'gulp-run' );
+const spawn = require( 'child_process' ).spawn;
 
-gulp.task( 'test:chdir-down', () => {
-  process.chdir( 'teachers_digital_platform/crtool');
-} );
-
-gulp.task( 'crtool:test', () => {
-  return run( 'npm run test').exec();
-} );
-
-gulp.task( 'test:chdir-up', () => {
-  process.chdir( '../..' );
-} );
-
-gulp.task( 'test',
-  [
-    'test:chdir-down',
-    'crtool:test',
-    'test:chdir-up'
-  ]
-);
+gulp.task('test', function(done) {
+    spawn('npm', ['run', 'test'], { cwd: 'teachers_digital_platform/crtool/', stdio: 'inherit' })
+      .on('close', done);
+});


### PR DESCRIPTION
Updated the gulp build and gulp test tasks for crtool, to use one command to execute them for the crtool.

Previously I had a task to cd down into the crtool folder and then one to cd back out.  The new code executes it in the subfolder with out having to cd.

This is much cleaner and removes any parallel execution issues.