### PR TITLE
Set version_format to what we want

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -26,7 +26,7 @@ setup(
     description='Teachers digital platform',
     long_description=long_description,
     license='CC0',
-    version_format='{tag}.dev{commitcount}+{gitsha}',
+    version_format='{tag}',
     include_package_data=True,
     packages=find_packages(),
     package_data={


### PR DESCRIPTION
Something has changed and `bdist_wheel` apparently is now honoring this value, which is giving us a value we actually _don't_ want.