### PR TITLE
Implemented error messaging for All Dimensions

### DIFF
--- a/teachers_digital_platform/crtool/src/__tests__/ContentElementaryCriterionPage.test.js
+++ b/teachers_digital_platform/crtool/src/__tests__/ContentElementaryCriterionPage.test.js
@@ -15,6 +15,8 @@ const contentProps = {
     initializeAnswerObjects:(() => { }),
     criterionCompletionStatuses:(() => {}),
     setCriterionStatusToInStart:(() => {}),
+    renderFormLevelErrorMessage:(() => {}),
+    showErrorsForCurrentPage:(() => {}),
 }
     
 afterAll(() => {

--- a/teachers_digital_platform/crtool/src/__tests__/ContentHighCriterionPage.test.js
+++ b/teachers_digital_platform/crtool/src/__tests__/ContentHighCriterionPage.test.js
@@ -15,6 +15,8 @@ const contentProps = {
     initializeAnswerObjects:(() => { }),
     criterionCompletionStatuses:(() => {}),
     setCriterionStatusToInStart:(() => {}),
+    renderFormLevelErrorMessage:(() => {}),
+    showErrorsForCurrentPage:(() => {}),
 }
     
 afterAll(() => {

--- a/teachers_digital_platform/crtool/src/__tests__/ContentMiddleCriterionPage.test.js
+++ b/teachers_digital_platform/crtool/src/__tests__/ContentMiddleCriterionPage.test.js
@@ -15,6 +15,8 @@ const contentProps = {
     initializeAnswerObjects:(() => { }),
     criterionCompletionStatuses:(() => {}),
     setCriterionStatusToInStart:(() => {}),
+    renderFormLevelErrorMessage:(() => {}),
+    showErrorsForCurrentPage:(() => {}),
 }
     
 afterAll(() => {

--- a/teachers_digital_platform/crtool/src/__tests__/EfficacyCriterionPage.test.js
+++ b/teachers_digital_platform/crtool/src/__tests__/EfficacyCriterionPage.test.js
@@ -22,6 +22,8 @@ const efficacyProps = {
     setCriterionStatusToInStart:(() => {}),
     setCriterionTitleLinkClicked:(() => {}),
     initializeStudyAnsers:(() => {}),
+    renderFormLevelErrorMessage:(() => {}),
+    showErrorsForCurrentPage:(() => {}),
 }
 
 afterAll(() => {

--- a/teachers_digital_platform/crtool/src/__tests__/QualityCriterionPage.test.js
+++ b/teachers_digital_platform/crtool/src/__tests__/QualityCriterionPage.test.js
@@ -15,6 +15,8 @@ const qualityProps = {
     initializeAnswerObjects:(() => { }),
     criterionCompletionStatuses:(() => {}),
     setCriterionStatusToInStart:(() => {}),
+    renderFormLevelErrorMessage:(() => {}),
+    showErrorsForCurrentPage:(() => {}),
 }
 
 afterAll(() => {

--- a/teachers_digital_platform/crtool/src/__tests__/UtilityCriterionPage.test.js
+++ b/teachers_digital_platform/crtool/src/__tests__/UtilityCriterionPage.test.js
@@ -15,6 +15,8 @@ const utilityProps = {
     initializeAnswerObjects:(() => { }),
     criterionCompletionStatuses:(() => {}),
     setCriterionStatusToInStart:(() => {}),
+    renderFormLevelErrorMessage:(() => {}),
+    showErrorsForCurrentPage:(() => {}),
 }
   
 afterAll(() => {

--- a/teachers_digital_platform/crtool/src/__tests__/__snapshots__/ContentElementaryCriterionPage.test.js.snap
+++ b/teachers_digital_platform/crtool/src/__tests__/__snapshots__/ContentElementaryCriterionPage.test.js.snap
@@ -3118,6 +3118,11 @@ Array [
         </svg>
       </span>
       Criterion 1: Earning, income, and careers
+      <span
+        class="u-fc-gray"
+      >
+         (complete)
+      </span>
     </h2>
     <p
       className="lead-paragraph u-mb45 u-mt15"

--- a/teachers_digital_platform/crtool/src/__tests__/__snapshots__/ContentElementaryCriterionPage.test.js.snap
+++ b/teachers_digital_platform/crtool/src/__tests__/__snapshots__/ContentElementaryCriterionPage.test.js.snap
@@ -81,13 +81,6 @@ Array [
   <hr
     className="hr u-mb30 u-mt30"
   />,
-  <p
-    className="u-mb60"
-  >
-    <strong>
-      All questions are required, unless otherwise noted.
-    </strong>
-  </p>,
   <div
     className="block block__flush-top"
     id="criterion_1"
@@ -320,6 +313,7 @@ Array [
   </div>,
   <div
     className="block block__flush-top"
+    id="content-elementary-crt-question-2"
   >
     <h3
       className="h2"
@@ -348,13 +342,6 @@ Array [
   <hr
     className="hr u-mb30 u-mt45"
   />,
-  <p
-    className="u-mb30"
-  >
-    <strong>
-      Be sure to answer all yes/no questions to continue.
-    </strong>
-  </p>,
 ]
 `;
 
@@ -439,13 +426,6 @@ Array [
   <hr
     className="hr u-mb30 u-mt30"
   />,
-  <p
-    className="u-mb60"
-  >
-    <strong>
-      All questions are required, unless otherwise noted.
-    </strong>
-  </p>,
   <div
     className="block block__flush-top"
     id="criterion_1"
@@ -1932,6 +1912,7 @@ Array [
   </div>,
   <div
     className="block block__flush-top"
+    id="content-elementary-crt-question-6"
   >
     <h3
       className="h2"
@@ -1960,13 +1941,6 @@ Array [
   <hr
     className="hr u-mb30 u-mt45"
   />,
-  <p
-    className="u-mb30"
-  >
-    <strong>
-      Be sure to answer all yes/no questions to continue.
-    </strong>
-  </p>,
 ]
 `;
 
@@ -2051,13 +2025,6 @@ Array [
   <hr
     className="hr u-mb30 u-mt30"
   />,
-  <p
-    className="u-mb60"
-  >
-    <strong>
-      All questions are required, unless otherwise noted.
-    </strong>
-  </p>,
   <div
     className="block block__flush-top"
     id="criterion_1"
@@ -2674,6 +2641,7 @@ Array [
   </div>,
   <div
     className="block block__flush-top"
+    id="content-elementary-crt-question-3"
   >
     <h3
       className="h2"
@@ -2702,13 +2670,6 @@ Array [
   <hr
     className="hr u-mb30 u-mt45"
   />,
-  <p
-    className="u-mb30"
-  >
-    <strong>
-      Be sure to answer all yes/no questions to continue.
-    </strong>
-  </p>,
 ]
 `;
 
@@ -2793,13 +2754,6 @@ Array [
   <hr
     className="hr u-mb30 u-mt30"
   />,
-  <p
-    className="u-mb60"
-  >
-    <strong>
-      All questions are required, unless otherwise noted.
-    </strong>
-  </p>,
   <div
     className="block block__flush-top"
     id="criterion_1"
@@ -3032,6 +2986,7 @@ Array [
   </div>,
   <div
     className="block block__flush-top"
+    id="content-elementary-crt-question-2"
   >
     <h3
       className="h2"
@@ -3060,13 +3015,6 @@ Array [
   <hr
     className="hr u-mb30 u-mt45"
   />,
-  <p
-    className="u-mb30"
-  >
-    <strong>
-      Be sure to answer all yes/no questions to continue.
-    </strong>
-  </p>,
 ]
 `;
 
@@ -3151,13 +3099,6 @@ Array [
   <hr
     className="hr u-mb30 u-mt30"
   />,
-  <p
-    className="u-mb60"
-  >
-    <strong>
-      All questions are required, unless otherwise noted.
-    </strong>
-  </p>,
   <div
     className="block block__flush-top"
     id="criterion_1"
@@ -3403,6 +3344,7 @@ Array [
   </div>,
   <div
     className="block block__flush-top"
+    id="content-elementary-crt-question-2"
   >
     <h3
       className="h2"
@@ -3431,12 +3373,5 @@ Array [
   <hr
     className="hr u-mb30 u-mt45"
   />,
-  <p
-    className="u-mb30"
-  >
-    <strong>
-      Be sure to answer all yes/no questions to continue.
-    </strong>
-  </p>,
 ]
 `;

--- a/teachers_digital_platform/crtool/src/__tests__/__snapshots__/ContentHighCriterionPage.test.js.snap
+++ b/teachers_digital_platform/crtool/src/__tests__/__snapshots__/ContentHighCriterionPage.test.js.snap
@@ -5567,6 +5567,11 @@ Array [
         </svg>
       </span>
       Criterion 1: Earning, income, and careers
+      <span
+        class="u-fc-gray"
+      >
+         (complete)
+      </span>
     </h2>
     <p
       className="lead-paragraph u-mb45 u-mt15"

--- a/teachers_digital_platform/crtool/src/__tests__/__snapshots__/ContentHighCriterionPage.test.js.snap
+++ b/teachers_digital_platform/crtool/src/__tests__/__snapshots__/ContentHighCriterionPage.test.js.snap
@@ -81,13 +81,6 @@ Array [
   <hr
     className="hr u-mb30 u-mt30"
   />,
-  <p
-    className="u-mb60"
-  >
-    <strong>
-      All questions are required, unless otherwise noted.
-    </strong>
-  </p>,
   <div
     className="block block__flush-top"
     id="criterion_1"
@@ -564,6 +557,7 @@ Array [
   </div>,
   <div
     className="block block__flush-top"
+    id="content-high-crt-question-2"
   >
     <h3
       className="h2"
@@ -592,13 +586,6 @@ Array [
   <hr
     className="hr u-mb30 u-mt45"
   />,
-  <p
-    className="u-mb30"
-  >
-    <strong>
-      Be sure to answer all yes/no questions to continue.
-    </strong>
-  </p>,
 ]
 `;
 
@@ -683,13 +670,6 @@ Array [
   <hr
     className="hr u-mb30 u-mt30"
   />,
-  <p
-    className="u-mb60"
-  >
-    <strong>
-      All questions are required, unless otherwise noted.
-    </strong>
-  </p>,
   <div
     className="block block__flush-top"
     id="criterion_1"
@@ -3556,6 +3536,7 @@ Array [
   </div>,
   <div
     className="block block__flush-top"
+    id="content-high-crt-question-6"
   >
     <h3
       className="h2"
@@ -3584,13 +3565,6 @@ Array [
   <hr
     className="hr u-mb30 u-mt45"
   />,
-  <p
-    className="u-mb30"
-  >
-    <strong>
-      Be sure to answer all yes/no questions to continue.
-    </strong>
-  </p>,
 ]
 `;
 
@@ -3675,13 +3649,6 @@ Array [
   <hr
     className="hr u-mb30 u-mt30"
   />,
-  <p
-    className="u-mb60"
-  >
-    <strong>
-      All questions are required, unless otherwise noted.
-    </strong>
-  </p>,
   <div
     className="block block__flush-top"
     id="criterion_1"
@@ -4879,6 +4846,7 @@ Array [
   </div>,
   <div
     className="block block__flush-top"
+    id="content-high-crt-question-3"
   >
     <h3
       className="h2"
@@ -4907,13 +4875,6 @@ Array [
   <hr
     className="hr u-mb30 u-mt45"
   />,
-  <p
-    className="u-mb30"
-  >
-    <strong>
-      Be sure to answer all yes/no questions to continue.
-    </strong>
-  </p>,
 ]
 `;
 
@@ -4998,13 +4959,6 @@ Array [
   <hr
     className="hr u-mb30 u-mt30"
   />,
-  <p
-    className="u-mb60"
-  >
-    <strong>
-      All questions are required, unless otherwise noted.
-    </strong>
-  </p>,
   <div
     className="block block__flush-top"
     id="criterion_1"
@@ -5481,6 +5435,7 @@ Array [
   </div>,
   <div
     className="block block__flush-top"
+    id="content-high-crt-question-2"
   >
     <h3
       className="h2"
@@ -5509,13 +5464,6 @@ Array [
   <hr
     className="hr u-mb30 u-mt45"
   />,
-  <p
-    className="u-mb30"
-  >
-    <strong>
-      Be sure to answer all yes/no questions to continue.
-    </strong>
-  </p>,
 ]
 `;
 
@@ -5600,13 +5548,6 @@ Array [
   <hr
     className="hr u-mb30 u-mt30"
   />,
-  <p
-    className="u-mb60"
-  >
-    <strong>
-      All questions are required, unless otherwise noted.
-    </strong>
-  </p>,
   <div
     className="block block__flush-top"
     id="criterion_1"
@@ -6096,6 +6037,7 @@ Array [
   </div>,
   <div
     className="block block__flush-top"
+    id="content-high-crt-question-2"
   >
     <h3
       className="h2"
@@ -6124,12 +6066,5 @@ Array [
   <hr
     className="hr u-mb30 u-mt45"
   />,
-  <p
-    className="u-mb30"
-  >
-    <strong>
-      Be sure to answer all yes/no questions to continue.
-    </strong>
-  </p>,
 ]
 `;

--- a/teachers_digital_platform/crtool/src/__tests__/__snapshots__/ContentMiddleCriterionPage.test.js.snap
+++ b/teachers_digital_platform/crtool/src/__tests__/__snapshots__/ContentMiddleCriterionPage.test.js.snap
@@ -4408,6 +4408,11 @@ Array [
         </svg>
       </span>
       Criterion 1: Earning, income, and careers
+      <span
+        class="u-fc-gray"
+      >
+         (complete)
+      </span>
     </h2>
     <p
       className="lead-paragraph u-mb45 u-mt15"

--- a/teachers_digital_platform/crtool/src/__tests__/__snapshots__/ContentMiddleCriterionPage.test.js.snap
+++ b/teachers_digital_platform/crtool/src/__tests__/__snapshots__/ContentMiddleCriterionPage.test.js.snap
@@ -81,13 +81,6 @@ Array [
   <hr
     className="hr u-mb30 u-mt30"
   />,
-  <p
-    className="u-mb60"
-  >
-    <strong>
-      All questions are required, unless otherwise noted.
-    </strong>
-  </p>,
   <div
     className="block block__flush-top"
     id="criterion_1"
@@ -381,6 +374,7 @@ Array [
   </div>,
   <div
     className="block block__flush-top"
+    id="content-middle-crt-question-2"
   >
     <h3
       className="h2"
@@ -409,13 +403,6 @@ Array [
   <hr
     className="hr u-mb30 u-mt45"
   />,
-  <p
-    className="u-mb30"
-  >
-    <strong>
-      Be sure to answer all yes/no questions to continue.
-    </strong>
-  </p>,
 ]
 `;
 
@@ -500,13 +487,6 @@ Array [
   <hr
     className="hr u-mb30 u-mt30"
   />,
-  <p
-    className="u-mb60"
-  >
-    <strong>
-      All questions are required, unless otherwise noted.
-    </strong>
-  </p>,
   <div
     className="block block__flush-top"
     id="criterion_1"
@@ -2824,6 +2804,7 @@ Array [
   </div>,
   <div
     className="block block__flush-top"
+    id="content-middle-crt-question-6"
   >
     <h3
       className="h2"
@@ -2852,13 +2833,6 @@ Array [
   <hr
     className="hr u-mb30 u-mt45"
   />,
-  <p
-    className="u-mb30"
-  >
-    <strong>
-      Be sure to answer all yes/no questions to continue.
-    </strong>
-  </p>,
 ]
 `;
 
@@ -2943,13 +2917,6 @@ Array [
   <hr
     className="hr u-mb30 u-mt30"
   />,
-  <p
-    className="u-mb60"
-  >
-    <strong>
-      All questions are required, unless otherwise noted.
-    </strong>
-  </p>,
   <div
     className="block block__flush-top"
     id="criterion_1"
@@ -3903,6 +3870,7 @@ Array [
   </div>,
   <div
     className="block block__flush-top"
+    id="content-middle-crt-question-3"
   >
     <h3
       className="h2"
@@ -3931,13 +3899,6 @@ Array [
   <hr
     className="hr u-mb30 u-mt45"
   />,
-  <p
-    className="u-mb30"
-  >
-    <strong>
-      Be sure to answer all yes/no questions to continue.
-    </strong>
-  </p>,
 ]
 `;
 
@@ -4022,13 +3983,6 @@ Array [
   <hr
     className="hr u-mb30 u-mt30"
   />,
-  <p
-    className="u-mb60"
-  >
-    <strong>
-      All questions are required, unless otherwise noted.
-    </strong>
-  </p>,
   <div
     className="block block__flush-top"
     id="criterion_1"
@@ -4322,6 +4276,7 @@ Array [
   </div>,
   <div
     className="block block__flush-top"
+    id="content-middle-crt-question-2"
   >
     <h3
       className="h2"
@@ -4350,13 +4305,6 @@ Array [
   <hr
     className="hr u-mb30 u-mt45"
   />,
-  <p
-    className="u-mb30"
-  >
-    <strong>
-      Be sure to answer all yes/no questions to continue.
-    </strong>
-  </p>,
 ]
 `;
 
@@ -4441,13 +4389,6 @@ Array [
   <hr
     className="hr u-mb30 u-mt30"
   />,
-  <p
-    className="u-mb60"
-  >
-    <strong>
-      All questions are required, unless otherwise noted.
-    </strong>
-  </p>,
   <div
     className="block block__flush-top"
     id="criterion_1"
@@ -4754,6 +4695,7 @@ Array [
   </div>,
   <div
     className="block block__flush-top"
+    id="content-middle-crt-question-2"
   >
     <h3
       className="h2"
@@ -4782,12 +4724,5 @@ Array [
   <hr
     className="hr u-mb30 u-mt45"
   />,
-  <p
-    className="u-mb30"
-  >
-    <strong>
-      Be sure to answer all yes/no questions to continue.
-    </strong>
-  </p>,
 ]
 `;

--- a/teachers_digital_platform/crtool/src/__tests__/__snapshots__/EfficacyCriterionPage.test.js.snap
+++ b/teachers_digital_platform/crtool/src/__tests__/__snapshots__/EfficacyCriterionPage.test.js.snap
@@ -1347,6 +1347,11 @@ Array [
         </svg>
       </span>
       Criterion 1: Strength of study (inclusion criteria)
+      <span
+        class="u-fc-gray"
+      >
+         (complete)
+      </span>
     </h2>
     <p
       className="lead-paragraph u-mb45 u-mt15"
@@ -2855,6 +2860,11 @@ Array [
         </svg>
       </span>
       Criterion 1: Strength of study (inclusion criteria)
+      <span
+        class="u-fc-gray"
+      >
+         (complete)
+      </span>
     </h2>
     <p
       className="lead-paragraph u-mb45 u-mt15"
@@ -4635,6 +4645,11 @@ Array [
         </svg>
       </span>
       Criterion 1: Strength of study (inclusion criteria)
+      <span
+        class="u-fc-gray"
+      >
+         (complete)
+      </span>
     </h2>
     <p
       className="lead-paragraph u-mb45 u-mt15"

--- a/teachers_digital_platform/crtool/src/__tests__/__snapshots__/EfficacyCriterionPage.test.js.snap
+++ b/teachers_digital_platform/crtool/src/__tests__/__snapshots__/EfficacyCriterionPage.test.js.snap
@@ -102,13 +102,6 @@ Array [
   <hr
     className="hr u-mb30 u-mt30"
   />,
-  <p
-    className="u-mb60"
-  >
-    <strong>
-      All questions are required, unless otherwise noted.
-    </strong>
-  </p>,
   <div
     className="block block__flush-top"
     id="criterion_1"
@@ -211,7 +204,7 @@ Array [
                   <input
                     checked={false}
                     className="a-radio"
-                    id="efficacy-crt-question-1.1.1#0#_a"
+                    id="efficacy-crt-question-1.1.1#0#a"
                     name="efficacy-crt-question-1.1.1#0#"
                     onChange={[Function]}
                     type="radio"
@@ -219,7 +212,7 @@ Array [
                   />
                   <label
                     className="a-label"
-                    htmlFor="efficacy-crt-question-1.1.1#0#_a"
+                    htmlFor="efficacy-crt-question-1.1.1#0#a"
                   >
                     Yes
                   </label>
@@ -230,7 +223,7 @@ Array [
                   <input
                     checked={false}
                     className="a-radio"
-                    id="efficacy-crt-question-1.1.1#0#_b"
+                    id="efficacy-crt-question-1.1.1#0#b"
                     name="efficacy-crt-question-1.1.1#0#"
                     onChange={[Function]}
                     type="radio"
@@ -238,7 +231,7 @@ Array [
                   />
                   <label
                     className="a-label"
-                    htmlFor="efficacy-crt-question-1.1.1#0#_b"
+                    htmlFor="efficacy-crt-question-1.1.1#0#b"
                   >
                     No
                   </label>
@@ -277,7 +270,7 @@ Array [
                   <input
                     checked={false}
                     className="a-radio"
-                    id="efficacy-crt-question-1.1.2#0#_beneficial_a"
+                    id="efficacy-crt-question-1.1.2#0#a"
                     name="efficacy-crt-question-1.1.2#0#_beneficial"
                     onChange={[Function]}
                     type="radio"
@@ -285,7 +278,7 @@ Array [
                   />
                   <label
                     className="a-label"
-                    htmlFor="efficacy-crt-question-1.1.2#0#_beneficial_a"
+                    htmlFor="efficacy-crt-question-1.1.2#0#a"
                   >
                     Yes
                   </label>
@@ -296,7 +289,7 @@ Array [
                   <input
                     checked={false}
                     className="a-radio"
-                    id="efficacy-crt-question-1.1.2#0#_beneficial_b"
+                    id="efficacy-crt-question-1.1.2#0#b"
                     name="efficacy-crt-question-1.1.2#0#_beneficial"
                     onChange={[Function]}
                     type="radio"
@@ -304,7 +297,7 @@ Array [
                   />
                   <label
                     className="a-label"
-                    htmlFor="efficacy-crt-question-1.1.2#0#_beneficial_b"
+                    htmlFor="efficacy-crt-question-1.1.2#0#b"
                   >
                     No
                   </label>
@@ -370,7 +363,7 @@ Array [
                   <input
                     checked={false}
                     className="a-radio"
-                    id="efficacy-crt-question-1.2#0#_a"
+                    id="efficacy-crt-question-1.2#0#a"
                     name="efficacy-crt-question-1.2#0#"
                     onChange={[Function]}
                     type="radio"
@@ -378,7 +371,7 @@ Array [
                   />
                   <label
                     className="a-label"
-                    htmlFor="efficacy-crt-question-1.2#0#_a"
+                    htmlFor="efficacy-crt-question-1.2#0#a"
                   >
                     Yes
                   </label>
@@ -389,7 +382,7 @@ Array [
                   <input
                     checked={false}
                     className="a-radio"
-                    id="efficacy-crt-question-1.2#0#_b"
+                    id="efficacy-crt-question-1.2#0#b"
                     name="efficacy-crt-question-1.2#0#"
                     onChange={[Function]}
                     type="radio"
@@ -397,7 +390,7 @@ Array [
                   />
                   <label
                     className="a-label"
-                    htmlFor="efficacy-crt-question-1.2#0#_b"
+                    htmlFor="efficacy-crt-question-1.2#0#b"
                   >
                     No
                   </label>
@@ -468,7 +461,7 @@ Array [
                   <input
                     checked={false}
                     className="a-radio"
-                    id="efficacy-crt-question-1.3.1#0#_beneficial_a"
+                    id="efficacy-crt-question-1.3.1#0#a"
                     name="efficacy-crt-question-1.3.1#0#_beneficial"
                     onChange={[Function]}
                     type="radio"
@@ -476,7 +469,7 @@ Array [
                   />
                   <label
                     className="a-label"
-                    htmlFor="efficacy-crt-question-1.3.1#0#_beneficial_a"
+                    htmlFor="efficacy-crt-question-1.3.1#0#a"
                   >
                     Yes
                   </label>
@@ -487,7 +480,7 @@ Array [
                   <input
                     checked={false}
                     className="a-radio"
-                    id="efficacy-crt-question-1.3.1#0#_beneficial_b"
+                    id="efficacy-crt-question-1.3.1#0#b"
                     name="efficacy-crt-question-1.3.1#0#_beneficial"
                     onChange={[Function]}
                     type="radio"
@@ -495,7 +488,7 @@ Array [
                   />
                   <label
                     className="a-label"
-                    htmlFor="efficacy-crt-question-1.3.1#0#_beneficial_b"
+                    htmlFor="efficacy-crt-question-1.3.1#0#b"
                   >
                     No
                   </label>
@@ -534,7 +527,7 @@ Array [
                   <input
                     checked={false}
                     className="a-radio"
-                    id="efficacy-crt-question-1.3.2#0#_beneficial_a"
+                    id="efficacy-crt-question-1.3.2#0#a"
                     name="efficacy-crt-question-1.3.2#0#_beneficial"
                     onChange={[Function]}
                     type="radio"
@@ -542,7 +535,7 @@ Array [
                   />
                   <label
                     className="a-label"
-                    htmlFor="efficacy-crt-question-1.3.2#0#_beneficial_a"
+                    htmlFor="efficacy-crt-question-1.3.2#0#a"
                   >
                     Yes
                   </label>
@@ -553,7 +546,7 @@ Array [
                   <input
                     checked={false}
                     className="a-radio"
-                    id="efficacy-crt-question-1.3.2#0#_beneficial_b"
+                    id="efficacy-crt-question-1.3.2#0#b"
                     name="efficacy-crt-question-1.3.2#0#_beneficial"
                     onChange={[Function]}
                     type="radio"
@@ -561,7 +554,7 @@ Array [
                   />
                   <label
                     className="a-label"
-                    htmlFor="efficacy-crt-question-1.3.2#0#_beneficial_b"
+                    htmlFor="efficacy-crt-question-1.3.2#0#b"
                   >
                     No
                   </label>
@@ -627,7 +620,7 @@ Array [
                   <input
                     checked={false}
                     className="a-radio"
-                    id="efficacy-crt-question-1.4.1#0#_a"
+                    id="efficacy-crt-question-1.4.1#0#a"
                     name="efficacy-crt-question-1.4.1#0#"
                     onChange={[Function]}
                     type="radio"
@@ -635,7 +628,7 @@ Array [
                   />
                   <label
                     className="a-label"
-                    htmlFor="efficacy-crt-question-1.4.1#0#_a"
+                    htmlFor="efficacy-crt-question-1.4.1#0#a"
                   >
                     Yes
                   </label>
@@ -646,7 +639,7 @@ Array [
                   <input
                     checked={false}
                     className="a-radio"
-                    id="efficacy-crt-question-1.4.1#0#_b"
+                    id="efficacy-crt-question-1.4.1#0#b"
                     name="efficacy-crt-question-1.4.1#0#"
                     onChange={[Function]}
                     type="radio"
@@ -654,7 +647,7 @@ Array [
                   />
                   <label
                     className="a-label"
-                    htmlFor="efficacy-crt-question-1.4.1#0#_b"
+                    htmlFor="efficacy-crt-question-1.4.1#0#b"
                   >
                     No
                   </label>
@@ -688,7 +681,7 @@ Array [
                   <input
                     checked={false}
                     className="a-radio"
-                    id="efficacy-crt-question-1.4.2#0#_a"
+                    id="efficacy-crt-question-1.4.2#0#a"
                     name="efficacy-crt-question-1.4.2#0#"
                     onChange={[Function]}
                     type="radio"
@@ -696,7 +689,7 @@ Array [
                   />
                   <label
                     className="a-label"
-                    htmlFor="efficacy-crt-question-1.4.2#0#_a"
+                    htmlFor="efficacy-crt-question-1.4.2#0#a"
                   >
                     Yes
                   </label>
@@ -707,7 +700,7 @@ Array [
                   <input
                     checked={false}
                     className="a-radio"
-                    id="efficacy-crt-question-1.4.2#0#_b"
+                    id="efficacy-crt-question-1.4.2#0#b"
                     name="efficacy-crt-question-1.4.2#0#"
                     onChange={[Function]}
                     type="radio"
@@ -715,7 +708,7 @@ Array [
                   />
                   <label
                     className="a-label"
-                    htmlFor="efficacy-crt-question-1.4.2#0#_b"
+                    htmlFor="efficacy-crt-question-1.4.2#0#b"
                   >
                     No
                   </label>
@@ -749,7 +742,7 @@ Array [
                   <input
                     checked={false}
                     className="a-radio"
-                    id="efficacy-crt-question-1.4.3#0#_a"
+                    id="efficacy-crt-question-1.4.3#0#a"
                     name="efficacy-crt-question-1.4.3#0#"
                     onChange={[Function]}
                     type="radio"
@@ -757,7 +750,7 @@ Array [
                   />
                   <label
                     className="a-label"
-                    htmlFor="efficacy-crt-question-1.4.3#0#_a"
+                    htmlFor="efficacy-crt-question-1.4.3#0#a"
                   >
                     Yes
                   </label>
@@ -768,7 +761,7 @@ Array [
                   <input
                     checked={false}
                     className="a-radio"
-                    id="efficacy-crt-question-1.4.3#0#_b"
+                    id="efficacy-crt-question-1.4.3#0#b"
                     name="efficacy-crt-question-1.4.3#0#"
                     onChange={[Function]}
                     type="radio"
@@ -776,7 +769,7 @@ Array [
                   />
                   <label
                     className="a-label"
-                    htmlFor="efficacy-crt-question-1.4.3#0#_b"
+                    htmlFor="efficacy-crt-question-1.4.3#0#b"
                   >
                     No
                   </label>
@@ -810,7 +803,7 @@ Array [
                   <input
                     checked={false}
                     className="a-radio"
-                    id="efficacy-crt-question-1.4.4#0#_a"
+                    id="efficacy-crt-question-1.4.4#0#a"
                     name="efficacy-crt-question-1.4.4#0#"
                     onChange={[Function]}
                     type="radio"
@@ -818,7 +811,7 @@ Array [
                   />
                   <label
                     className="a-label"
-                    htmlFor="efficacy-crt-question-1.4.4#0#_a"
+                    htmlFor="efficacy-crt-question-1.4.4#0#a"
                   >
                     Yes
                   </label>
@@ -829,7 +822,7 @@ Array [
                   <input
                     checked={false}
                     className="a-radio"
-                    id="efficacy-crt-question-1.4.4#0#_b"
+                    id="efficacy-crt-question-1.4.4#0#b"
                     name="efficacy-crt-question-1.4.4#0#"
                     onChange={[Function]}
                     type="radio"
@@ -837,7 +830,7 @@ Array [
                   />
                   <label
                     className="a-label"
-                    htmlFor="efficacy-crt-question-1.4.4#0#_b"
+                    htmlFor="efficacy-crt-question-1.4.4#0#b"
                   >
                     No
                   </label>
@@ -876,7 +869,7 @@ Array [
                   <input
                     checked={false}
                     className="a-radio"
-                    id="efficacy-crt-question-1.4.5#0#_beneficial_a"
+                    id="efficacy-crt-question-1.4.5#0#a"
                     name="efficacy-crt-question-1.4.5#0#_beneficial"
                     onChange={[Function]}
                     type="radio"
@@ -884,7 +877,7 @@ Array [
                   />
                   <label
                     className="a-label"
-                    htmlFor="efficacy-crt-question-1.4.5#0#_beneficial_a"
+                    htmlFor="efficacy-crt-question-1.4.5#0#a"
                   >
                     Yes
                   </label>
@@ -895,7 +888,7 @@ Array [
                   <input
                     checked={false}
                     className="a-radio"
-                    id="efficacy-crt-question-1.4.5#0#_beneficial_b"
+                    id="efficacy-crt-question-1.4.5#0#b"
                     name="efficacy-crt-question-1.4.5#0#_beneficial"
                     onChange={[Function]}
                     type="radio"
@@ -903,7 +896,7 @@ Array [
                   />
                   <label
                     className="a-label"
-                    htmlFor="efficacy-crt-question-1.4.5#0#_beneficial_b"
+                    htmlFor="efficacy-crt-question-1.4.5#0#b"
                   >
                     No
                   </label>
@@ -942,7 +935,7 @@ Array [
                   <input
                     checked={false}
                     className="a-radio"
-                    id="efficacy-crt-question-1.4.6#0#_beneficial_a"
+                    id="efficacy-crt-question-1.4.6#0#a"
                     name="efficacy-crt-question-1.4.6#0#_beneficial"
                     onChange={[Function]}
                     type="radio"
@@ -950,7 +943,7 @@ Array [
                   />
                   <label
                     className="a-label"
-                    htmlFor="efficacy-crt-question-1.4.6#0#_beneficial_a"
+                    htmlFor="efficacy-crt-question-1.4.6#0#a"
                   >
                     Yes
                   </label>
@@ -961,7 +954,7 @@ Array [
                   <input
                     checked={false}
                     className="a-radio"
-                    id="efficacy-crt-question-1.4.6#0#_beneficial_b"
+                    id="efficacy-crt-question-1.4.6#0#b"
                     name="efficacy-crt-question-1.4.6#0#_beneficial"
                     onChange={[Function]}
                     type="radio"
@@ -969,7 +962,7 @@ Array [
                   />
                   <label
                     className="a-label"
-                    htmlFor="efficacy-crt-question-1.4.6#0#_beneficial_b"
+                    htmlFor="efficacy-crt-question-1.4.6#0#b"
                   >
                     No
                   </label>
@@ -1035,7 +1028,7 @@ Array [
                   <input
                     checked={false}
                     className="a-radio"
-                    id="efficacy-crt-question-1.5#0#_a"
+                    id="efficacy-crt-question-1.5#0#a"
                     name="efficacy-crt-question-1.5#0#"
                     onChange={[Function]}
                     type="radio"
@@ -1043,7 +1036,7 @@ Array [
                   />
                   <label
                     className="a-label"
-                    htmlFor="efficacy-crt-question-1.5#0#_a"
+                    htmlFor="efficacy-crt-question-1.5#0#a"
                   >
                     Yes
                   </label>
@@ -1054,7 +1047,7 @@ Array [
                   <input
                     checked={false}
                     className="a-radio"
-                    id="efficacy-crt-question-1.5#0#_b"
+                    id="efficacy-crt-question-1.5#0#b"
                     name="efficacy-crt-question-1.5#0#"
                     onChange={[Function]}
                     type="radio"
@@ -1062,7 +1055,7 @@ Array [
                   />
                   <label
                     className="a-label"
-                    htmlFor="efficacy-crt-question-1.5#0#_b"
+                    htmlFor="efficacy-crt-question-1.5#0#b"
                   >
                     No
                   </label>
@@ -1128,7 +1121,7 @@ Array [
                   <input
                     checked={false}
                     className="a-radio"
-                    id="efficacy-crt-question-1.6#0#_a"
+                    id="efficacy-crt-question-1.6#0#a"
                     name="efficacy-crt-question-1.6#0#"
                     onChange={[Function]}
                     type="radio"
@@ -1136,7 +1129,7 @@ Array [
                   />
                   <label
                     className="a-label"
-                    htmlFor="efficacy-crt-question-1.6#0#_a"
+                    htmlFor="efficacy-crt-question-1.6#0#a"
                   >
                     Yes
                   </label>
@@ -1147,7 +1140,7 @@ Array [
                   <input
                     checked={false}
                     className="a-radio"
-                    id="efficacy-crt-question-1.6#0#_b"
+                    id="efficacy-crt-question-1.6#0#b"
                     name="efficacy-crt-question-1.6#0#"
                     onChange={[Function]}
                     type="radio"
@@ -1155,7 +1148,7 @@ Array [
                   />
                   <label
                     className="a-label"
-                    htmlFor="efficacy-crt-question-1.6#0#_b"
+                    htmlFor="efficacy-crt-question-1.6#0#b"
                   >
                     No
                   </label>
@@ -1224,6 +1217,9 @@ Array [
       I’m done reviewing studies
     </button>
   </div>,
+  <div
+    id="efficacy-crt-question-2"
+  />,
   <hr
     className="hr u-mb30 u-mt45"
   />,
@@ -1332,13 +1328,6 @@ Array [
   <hr
     className="hr u-mb30 u-mt30"
   />,
-  <p
-    className="u-mb60"
-  >
-    <strong>
-      All questions are required, unless otherwise noted.
-    </strong>
-  </p>,
   <div
     className="block block__flush-top"
     id="criterion_1"
@@ -1454,7 +1443,7 @@ Array [
                   <input
                     checked={false}
                     className="a-radio"
-                    id="efficacy-crt-question-1.1.1#0#_a"
+                    id="efficacy-crt-question-1.1.1#0#a"
                     name="efficacy-crt-question-1.1.1#0#"
                     onChange={[Function]}
                     type="radio"
@@ -1462,7 +1451,7 @@ Array [
                   />
                   <label
                     className="a-label"
-                    htmlFor="efficacy-crt-question-1.1.1#0#_a"
+                    htmlFor="efficacy-crt-question-1.1.1#0#a"
                   >
                     Yes
                   </label>
@@ -1473,7 +1462,7 @@ Array [
                   <input
                     checked={false}
                     className="a-radio"
-                    id="efficacy-crt-question-1.1.1#0#_b"
+                    id="efficacy-crt-question-1.1.1#0#b"
                     name="efficacy-crt-question-1.1.1#0#"
                     onChange={[Function]}
                     type="radio"
@@ -1481,7 +1470,7 @@ Array [
                   />
                   <label
                     className="a-label"
-                    htmlFor="efficacy-crt-question-1.1.1#0#_b"
+                    htmlFor="efficacy-crt-question-1.1.1#0#b"
                   >
                     No
                   </label>
@@ -1520,7 +1509,7 @@ Array [
                   <input
                     checked={false}
                     className="a-radio"
-                    id="efficacy-crt-question-1.1.2#0#_beneficial_a"
+                    id="efficacy-crt-question-1.1.2#0#a"
                     name="efficacy-crt-question-1.1.2#0#_beneficial"
                     onChange={[Function]}
                     type="radio"
@@ -1528,7 +1517,7 @@ Array [
                   />
                   <label
                     className="a-label"
-                    htmlFor="efficacy-crt-question-1.1.2#0#_beneficial_a"
+                    htmlFor="efficacy-crt-question-1.1.2#0#a"
                   >
                     Yes
                   </label>
@@ -1539,7 +1528,7 @@ Array [
                   <input
                     checked={false}
                     className="a-radio"
-                    id="efficacy-crt-question-1.1.2#0#_beneficial_b"
+                    id="efficacy-crt-question-1.1.2#0#b"
                     name="efficacy-crt-question-1.1.2#0#_beneficial"
                     onChange={[Function]}
                     type="radio"
@@ -1547,7 +1536,7 @@ Array [
                   />
                   <label
                     className="a-label"
-                    htmlFor="efficacy-crt-question-1.1.2#0#_beneficial_b"
+                    htmlFor="efficacy-crt-question-1.1.2#0#b"
                   >
                     No
                   </label>
@@ -1613,7 +1602,7 @@ Array [
                   <input
                     checked={false}
                     className="a-radio"
-                    id="efficacy-crt-question-1.2#0#_a"
+                    id="efficacy-crt-question-1.2#0#a"
                     name="efficacy-crt-question-1.2#0#"
                     onChange={[Function]}
                     type="radio"
@@ -1621,7 +1610,7 @@ Array [
                   />
                   <label
                     className="a-label"
-                    htmlFor="efficacy-crt-question-1.2#0#_a"
+                    htmlFor="efficacy-crt-question-1.2#0#a"
                   >
                     Yes
                   </label>
@@ -1632,7 +1621,7 @@ Array [
                   <input
                     checked={false}
                     className="a-radio"
-                    id="efficacy-crt-question-1.2#0#_b"
+                    id="efficacy-crt-question-1.2#0#b"
                     name="efficacy-crt-question-1.2#0#"
                     onChange={[Function]}
                     type="radio"
@@ -1640,7 +1629,7 @@ Array [
                   />
                   <label
                     className="a-label"
-                    htmlFor="efficacy-crt-question-1.2#0#_b"
+                    htmlFor="efficacy-crt-question-1.2#0#b"
                   >
                     No
                   </label>
@@ -1711,7 +1700,7 @@ Array [
                   <input
                     checked={false}
                     className="a-radio"
-                    id="efficacy-crt-question-1.3.1#0#_beneficial_a"
+                    id="efficacy-crt-question-1.3.1#0#a"
                     name="efficacy-crt-question-1.3.1#0#_beneficial"
                     onChange={[Function]}
                     type="radio"
@@ -1719,7 +1708,7 @@ Array [
                   />
                   <label
                     className="a-label"
-                    htmlFor="efficacy-crt-question-1.3.1#0#_beneficial_a"
+                    htmlFor="efficacy-crt-question-1.3.1#0#a"
                   >
                     Yes
                   </label>
@@ -1730,7 +1719,7 @@ Array [
                   <input
                     checked={false}
                     className="a-radio"
-                    id="efficacy-crt-question-1.3.1#0#_beneficial_b"
+                    id="efficacy-crt-question-1.3.1#0#b"
                     name="efficacy-crt-question-1.3.1#0#_beneficial"
                     onChange={[Function]}
                     type="radio"
@@ -1738,7 +1727,7 @@ Array [
                   />
                   <label
                     className="a-label"
-                    htmlFor="efficacy-crt-question-1.3.1#0#_beneficial_b"
+                    htmlFor="efficacy-crt-question-1.3.1#0#b"
                   >
                     No
                   </label>
@@ -1777,7 +1766,7 @@ Array [
                   <input
                     checked={false}
                     className="a-radio"
-                    id="efficacy-crt-question-1.3.2#0#_beneficial_a"
+                    id="efficacy-crt-question-1.3.2#0#a"
                     name="efficacy-crt-question-1.3.2#0#_beneficial"
                     onChange={[Function]}
                     type="radio"
@@ -1785,7 +1774,7 @@ Array [
                   />
                   <label
                     className="a-label"
-                    htmlFor="efficacy-crt-question-1.3.2#0#_beneficial_a"
+                    htmlFor="efficacy-crt-question-1.3.2#0#a"
                   >
                     Yes
                   </label>
@@ -1796,7 +1785,7 @@ Array [
                   <input
                     checked={false}
                     className="a-radio"
-                    id="efficacy-crt-question-1.3.2#0#_beneficial_b"
+                    id="efficacy-crt-question-1.3.2#0#b"
                     name="efficacy-crt-question-1.3.2#0#_beneficial"
                     onChange={[Function]}
                     type="radio"
@@ -1804,7 +1793,7 @@ Array [
                   />
                   <label
                     className="a-label"
-                    htmlFor="efficacy-crt-question-1.3.2#0#_beneficial_b"
+                    htmlFor="efficacy-crt-question-1.3.2#0#b"
                   >
                     No
                   </label>
@@ -1870,7 +1859,7 @@ Array [
                   <input
                     checked={false}
                     className="a-radio"
-                    id="efficacy-crt-question-1.4.1#0#_a"
+                    id="efficacy-crt-question-1.4.1#0#a"
                     name="efficacy-crt-question-1.4.1#0#"
                     onChange={[Function]}
                     type="radio"
@@ -1878,7 +1867,7 @@ Array [
                   />
                   <label
                     className="a-label"
-                    htmlFor="efficacy-crt-question-1.4.1#0#_a"
+                    htmlFor="efficacy-crt-question-1.4.1#0#a"
                   >
                     Yes
                   </label>
@@ -1889,7 +1878,7 @@ Array [
                   <input
                     checked={false}
                     className="a-radio"
-                    id="efficacy-crt-question-1.4.1#0#_b"
+                    id="efficacy-crt-question-1.4.1#0#b"
                     name="efficacy-crt-question-1.4.1#0#"
                     onChange={[Function]}
                     type="radio"
@@ -1897,7 +1886,7 @@ Array [
                   />
                   <label
                     className="a-label"
-                    htmlFor="efficacy-crt-question-1.4.1#0#_b"
+                    htmlFor="efficacy-crt-question-1.4.1#0#b"
                   >
                     No
                   </label>
@@ -1931,7 +1920,7 @@ Array [
                   <input
                     checked={false}
                     className="a-radio"
-                    id="efficacy-crt-question-1.4.2#0#_a"
+                    id="efficacy-crt-question-1.4.2#0#a"
                     name="efficacy-crt-question-1.4.2#0#"
                     onChange={[Function]}
                     type="radio"
@@ -1939,7 +1928,7 @@ Array [
                   />
                   <label
                     className="a-label"
-                    htmlFor="efficacy-crt-question-1.4.2#0#_a"
+                    htmlFor="efficacy-crt-question-1.4.2#0#a"
                   >
                     Yes
                   </label>
@@ -1950,7 +1939,7 @@ Array [
                   <input
                     checked={false}
                     className="a-radio"
-                    id="efficacy-crt-question-1.4.2#0#_b"
+                    id="efficacy-crt-question-1.4.2#0#b"
                     name="efficacy-crt-question-1.4.2#0#"
                     onChange={[Function]}
                     type="radio"
@@ -1958,7 +1947,7 @@ Array [
                   />
                   <label
                     className="a-label"
-                    htmlFor="efficacy-crt-question-1.4.2#0#_b"
+                    htmlFor="efficacy-crt-question-1.4.2#0#b"
                   >
                     No
                   </label>
@@ -1992,7 +1981,7 @@ Array [
                   <input
                     checked={false}
                     className="a-radio"
-                    id="efficacy-crt-question-1.4.3#0#_a"
+                    id="efficacy-crt-question-1.4.3#0#a"
                     name="efficacy-crt-question-1.4.3#0#"
                     onChange={[Function]}
                     type="radio"
@@ -2000,7 +1989,7 @@ Array [
                   />
                   <label
                     className="a-label"
-                    htmlFor="efficacy-crt-question-1.4.3#0#_a"
+                    htmlFor="efficacy-crt-question-1.4.3#0#a"
                   >
                     Yes
                   </label>
@@ -2011,7 +2000,7 @@ Array [
                   <input
                     checked={false}
                     className="a-radio"
-                    id="efficacy-crt-question-1.4.3#0#_b"
+                    id="efficacy-crt-question-1.4.3#0#b"
                     name="efficacy-crt-question-1.4.3#0#"
                     onChange={[Function]}
                     type="radio"
@@ -2019,7 +2008,7 @@ Array [
                   />
                   <label
                     className="a-label"
-                    htmlFor="efficacy-crt-question-1.4.3#0#_b"
+                    htmlFor="efficacy-crt-question-1.4.3#0#b"
                   >
                     No
                   </label>
@@ -2053,7 +2042,7 @@ Array [
                   <input
                     checked={false}
                     className="a-radio"
-                    id="efficacy-crt-question-1.4.4#0#_a"
+                    id="efficacy-crt-question-1.4.4#0#a"
                     name="efficacy-crt-question-1.4.4#0#"
                     onChange={[Function]}
                     type="radio"
@@ -2061,7 +2050,7 @@ Array [
                   />
                   <label
                     className="a-label"
-                    htmlFor="efficacy-crt-question-1.4.4#0#_a"
+                    htmlFor="efficacy-crt-question-1.4.4#0#a"
                   >
                     Yes
                   </label>
@@ -2072,7 +2061,7 @@ Array [
                   <input
                     checked={false}
                     className="a-radio"
-                    id="efficacy-crt-question-1.4.4#0#_b"
+                    id="efficacy-crt-question-1.4.4#0#b"
                     name="efficacy-crt-question-1.4.4#0#"
                     onChange={[Function]}
                     type="radio"
@@ -2080,7 +2069,7 @@ Array [
                   />
                   <label
                     className="a-label"
-                    htmlFor="efficacy-crt-question-1.4.4#0#_b"
+                    htmlFor="efficacy-crt-question-1.4.4#0#b"
                   >
                     No
                   </label>
@@ -2119,7 +2108,7 @@ Array [
                   <input
                     checked={false}
                     className="a-radio"
-                    id="efficacy-crt-question-1.4.5#0#_beneficial_a"
+                    id="efficacy-crt-question-1.4.5#0#a"
                     name="efficacy-crt-question-1.4.5#0#_beneficial"
                     onChange={[Function]}
                     type="radio"
@@ -2127,7 +2116,7 @@ Array [
                   />
                   <label
                     className="a-label"
-                    htmlFor="efficacy-crt-question-1.4.5#0#_beneficial_a"
+                    htmlFor="efficacy-crt-question-1.4.5#0#a"
                   >
                     Yes
                   </label>
@@ -2138,7 +2127,7 @@ Array [
                   <input
                     checked={false}
                     className="a-radio"
-                    id="efficacy-crt-question-1.4.5#0#_beneficial_b"
+                    id="efficacy-crt-question-1.4.5#0#b"
                     name="efficacy-crt-question-1.4.5#0#_beneficial"
                     onChange={[Function]}
                     type="radio"
@@ -2146,7 +2135,7 @@ Array [
                   />
                   <label
                     className="a-label"
-                    htmlFor="efficacy-crt-question-1.4.5#0#_beneficial_b"
+                    htmlFor="efficacy-crt-question-1.4.5#0#b"
                   >
                     No
                   </label>
@@ -2185,7 +2174,7 @@ Array [
                   <input
                     checked={false}
                     className="a-radio"
-                    id="efficacy-crt-question-1.4.6#0#_beneficial_a"
+                    id="efficacy-crt-question-1.4.6#0#a"
                     name="efficacy-crt-question-1.4.6#0#_beneficial"
                     onChange={[Function]}
                     type="radio"
@@ -2193,7 +2182,7 @@ Array [
                   />
                   <label
                     className="a-label"
-                    htmlFor="efficacy-crt-question-1.4.6#0#_beneficial_a"
+                    htmlFor="efficacy-crt-question-1.4.6#0#a"
                   >
                     Yes
                   </label>
@@ -2204,7 +2193,7 @@ Array [
                   <input
                     checked={false}
                     className="a-radio"
-                    id="efficacy-crt-question-1.4.6#0#_beneficial_b"
+                    id="efficacy-crt-question-1.4.6#0#b"
                     name="efficacy-crt-question-1.4.6#0#_beneficial"
                     onChange={[Function]}
                     type="radio"
@@ -2212,7 +2201,7 @@ Array [
                   />
                   <label
                     className="a-label"
-                    htmlFor="efficacy-crt-question-1.4.6#0#_beneficial_b"
+                    htmlFor="efficacy-crt-question-1.4.6#0#b"
                   >
                     No
                   </label>
@@ -2278,7 +2267,7 @@ Array [
                   <input
                     checked={false}
                     className="a-radio"
-                    id="efficacy-crt-question-1.5#0#_a"
+                    id="efficacy-crt-question-1.5#0#a"
                     name="efficacy-crt-question-1.5#0#"
                     onChange={[Function]}
                     type="radio"
@@ -2286,7 +2275,7 @@ Array [
                   />
                   <label
                     className="a-label"
-                    htmlFor="efficacy-crt-question-1.5#0#_a"
+                    htmlFor="efficacy-crt-question-1.5#0#a"
                   >
                     Yes
                   </label>
@@ -2297,7 +2286,7 @@ Array [
                   <input
                     checked={false}
                     className="a-radio"
-                    id="efficacy-crt-question-1.5#0#_b"
+                    id="efficacy-crt-question-1.5#0#b"
                     name="efficacy-crt-question-1.5#0#"
                     onChange={[Function]}
                     type="radio"
@@ -2305,7 +2294,7 @@ Array [
                   />
                   <label
                     className="a-label"
-                    htmlFor="efficacy-crt-question-1.5#0#_b"
+                    htmlFor="efficacy-crt-question-1.5#0#b"
                   >
                     No
                   </label>
@@ -2371,7 +2360,7 @@ Array [
                   <input
                     checked={false}
                     className="a-radio"
-                    id="efficacy-crt-question-1.6#0#_a"
+                    id="efficacy-crt-question-1.6#0#a"
                     name="efficacy-crt-question-1.6#0#"
                     onChange={[Function]}
                     type="radio"
@@ -2379,7 +2368,7 @@ Array [
                   />
                   <label
                     className="a-label"
-                    htmlFor="efficacy-crt-question-1.6#0#_a"
+                    htmlFor="efficacy-crt-question-1.6#0#a"
                   >
                     Yes
                   </label>
@@ -2390,7 +2379,7 @@ Array [
                   <input
                     checked={false}
                     className="a-radio"
-                    id="efficacy-crt-question-1.6#0#_b"
+                    id="efficacy-crt-question-1.6#0#b"
                     name="efficacy-crt-question-1.6#0#"
                     onChange={[Function]}
                     type="radio"
@@ -2398,7 +2387,7 @@ Array [
                   />
                   <label
                     className="a-label"
-                    htmlFor="efficacy-crt-question-1.6#0#_b"
+                    htmlFor="efficacy-crt-question-1.6#0#b"
                   >
                     No
                   </label>
@@ -2435,34 +2424,6 @@ Array [
         onBlur={[Function]}
         rows="6"
       />
-    </div>
-    <div
-      className="m-notification m-notification__visible m-notification__warning u-mb30"
-    >
-      <span
-        className="a-icon"
-      >
-        <svg
-          class="cf-icon-svg"
-          viewBox="0 0 1000 1200"
-          xmlns="http://www.w3.org/2000/svg"
-        >
-          <path
-            d="M500 105.2c-276.1 0-500 223.9-500 500s223.9 500 500 500 500-223.9 500-500-223.9-500-500-500zm-49.7 234.6c0-27.6 22.4-50 50-50s50 22.4 50 50v328.6c0 27.6-22.4 50-50 50s-50-22.4-50-50V339.8zm50 582.5c-39.6 0-71.7-32.1-71.7-71.7s32.1-71.7 71.7-71.7S572 811 572 850.6s-32.1 71.7-71.7 71.7z"
-          />
-        </svg>
-      </span>
-      <div
-        className="m-notification_content"
-      >
-        <div
-          className="m-notification_message"
-        >
-          <p>
-            You must enter a study name and answer all yes/no questions for this study before it can be scored.
-          </p>
-        </div>
-      </div>
     </div>
     <div
       className="u-mt15 u-mb30"
@@ -2575,7 +2536,7 @@ Array [
                   <input
                     checked={false}
                     className="a-radio"
-                    id="efficacy-crt-question-2.1_beneficial_a"
+                    id="efficacy-crt-question-2.1a"
                     name="efficacy-crt-question-2.1_beneficial"
                     onChange={[Function]}
                     type="radio"
@@ -2583,7 +2544,7 @@ Array [
                   />
                   <label
                     className="a-label"
-                    htmlFor="efficacy-crt-question-2.1_beneficial_a"
+                    htmlFor="efficacy-crt-question-2.1a"
                   >
                     Yes
                   </label>
@@ -2594,7 +2555,7 @@ Array [
                   <input
                     checked={false}
                     className="a-radio"
-                    id="efficacy-crt-question-2.1_beneficial_b"
+                    id="efficacy-crt-question-2.1b"
                     name="efficacy-crt-question-2.1_beneficial"
                     onChange={[Function]}
                     type="radio"
@@ -2602,7 +2563,7 @@ Array [
                   />
                   <label
                     className="a-label"
-                    htmlFor="efficacy-crt-question-2.1_beneficial_b"
+                    htmlFor="efficacy-crt-question-2.1b"
                   >
                     No
                   </label>
@@ -2673,7 +2634,7 @@ Array [
                   <input
                     checked={false}
                     className="a-radio"
-                    id="efficacy-crt-question-2.2_beneficial_a"
+                    id="efficacy-crt-question-2.2a"
                     name="efficacy-crt-question-2.2_beneficial"
                     onChange={[Function]}
                     type="radio"
@@ -2681,7 +2642,7 @@ Array [
                   />
                   <label
                     className="a-label"
-                    htmlFor="efficacy-crt-question-2.2_beneficial_a"
+                    htmlFor="efficacy-crt-question-2.2a"
                   >
                     Yes
                   </label>
@@ -2692,7 +2653,7 @@ Array [
                   <input
                     checked={false}
                     className="a-radio"
-                    id="efficacy-crt-question-2.2_beneficial_b"
+                    id="efficacy-crt-question-2.2b"
                     name="efficacy-crt-question-2.2_beneficial"
                     onChange={[Function]}
                     type="radio"
@@ -2700,7 +2661,7 @@ Array [
                   />
                   <label
                     className="a-label"
-                    htmlFor="efficacy-crt-question-2.2_beneficial_b"
+                    htmlFor="efficacy-crt-question-2.2b"
                   >
                     No
                   </label>
@@ -2741,6 +2702,7 @@ Array [
   </div>,
   <div
     className="block block__flush-top"
+    id="efficacy-crt-question-3"
   >
     <h3
       className="h2"
@@ -2874,13 +2836,6 @@ Array [
   <hr
     className="hr u-mb30 u-mt30"
   />,
-  <p
-    className="u-mb60"
-  >
-    <strong>
-      All questions are required, unless otherwise noted.
-    </strong>
-  </p>,
   <div
     className="block block__flush-top"
     id="criterion_1"
@@ -2996,7 +2951,7 @@ Array [
                   <input
                     checked={false}
                     className="a-radio"
-                    id="efficacy-crt-question-1.1.1#0#_a"
+                    id="efficacy-crt-question-1.1.1#0#a"
                     name="efficacy-crt-question-1.1.1#0#"
                     onChange={[Function]}
                     type="radio"
@@ -3004,7 +2959,7 @@ Array [
                   />
                   <label
                     className="a-label"
-                    htmlFor="efficacy-crt-question-1.1.1#0#_a"
+                    htmlFor="efficacy-crt-question-1.1.1#0#a"
                   >
                     Yes
                   </label>
@@ -3015,7 +2970,7 @@ Array [
                   <input
                     checked={false}
                     className="a-radio"
-                    id="efficacy-crt-question-1.1.1#0#_b"
+                    id="efficacy-crt-question-1.1.1#0#b"
                     name="efficacy-crt-question-1.1.1#0#"
                     onChange={[Function]}
                     type="radio"
@@ -3023,7 +2978,7 @@ Array [
                   />
                   <label
                     className="a-label"
-                    htmlFor="efficacy-crt-question-1.1.1#0#_b"
+                    htmlFor="efficacy-crt-question-1.1.1#0#b"
                   >
                     No
                   </label>
@@ -3062,7 +3017,7 @@ Array [
                   <input
                     checked={false}
                     className="a-radio"
-                    id="efficacy-crt-question-1.1.2#0#_beneficial_a"
+                    id="efficacy-crt-question-1.1.2#0#a"
                     name="efficacy-crt-question-1.1.2#0#_beneficial"
                     onChange={[Function]}
                     type="radio"
@@ -3070,7 +3025,7 @@ Array [
                   />
                   <label
                     className="a-label"
-                    htmlFor="efficacy-crt-question-1.1.2#0#_beneficial_a"
+                    htmlFor="efficacy-crt-question-1.1.2#0#a"
                   >
                     Yes
                   </label>
@@ -3081,7 +3036,7 @@ Array [
                   <input
                     checked={false}
                     className="a-radio"
-                    id="efficacy-crt-question-1.1.2#0#_beneficial_b"
+                    id="efficacy-crt-question-1.1.2#0#b"
                     name="efficacy-crt-question-1.1.2#0#_beneficial"
                     onChange={[Function]}
                     type="radio"
@@ -3089,7 +3044,7 @@ Array [
                   />
                   <label
                     className="a-label"
-                    htmlFor="efficacy-crt-question-1.1.2#0#_beneficial_b"
+                    htmlFor="efficacy-crt-question-1.1.2#0#b"
                   >
                     No
                   </label>
@@ -3155,7 +3110,7 @@ Array [
                   <input
                     checked={false}
                     className="a-radio"
-                    id="efficacy-crt-question-1.2#0#_a"
+                    id="efficacy-crt-question-1.2#0#a"
                     name="efficacy-crt-question-1.2#0#"
                     onChange={[Function]}
                     type="radio"
@@ -3163,7 +3118,7 @@ Array [
                   />
                   <label
                     className="a-label"
-                    htmlFor="efficacy-crt-question-1.2#0#_a"
+                    htmlFor="efficacy-crt-question-1.2#0#a"
                   >
                     Yes
                   </label>
@@ -3174,7 +3129,7 @@ Array [
                   <input
                     checked={false}
                     className="a-radio"
-                    id="efficacy-crt-question-1.2#0#_b"
+                    id="efficacy-crt-question-1.2#0#b"
                     name="efficacy-crt-question-1.2#0#"
                     onChange={[Function]}
                     type="radio"
@@ -3182,7 +3137,7 @@ Array [
                   />
                   <label
                     className="a-label"
-                    htmlFor="efficacy-crt-question-1.2#0#_b"
+                    htmlFor="efficacy-crt-question-1.2#0#b"
                   >
                     No
                   </label>
@@ -3253,7 +3208,7 @@ Array [
                   <input
                     checked={false}
                     className="a-radio"
-                    id="efficacy-crt-question-1.3.1#0#_beneficial_a"
+                    id="efficacy-crt-question-1.3.1#0#a"
                     name="efficacy-crt-question-1.3.1#0#_beneficial"
                     onChange={[Function]}
                     type="radio"
@@ -3261,7 +3216,7 @@ Array [
                   />
                   <label
                     className="a-label"
-                    htmlFor="efficacy-crt-question-1.3.1#0#_beneficial_a"
+                    htmlFor="efficacy-crt-question-1.3.1#0#a"
                   >
                     Yes
                   </label>
@@ -3272,7 +3227,7 @@ Array [
                   <input
                     checked={false}
                     className="a-radio"
-                    id="efficacy-crt-question-1.3.1#0#_beneficial_b"
+                    id="efficacy-crt-question-1.3.1#0#b"
                     name="efficacy-crt-question-1.3.1#0#_beneficial"
                     onChange={[Function]}
                     type="radio"
@@ -3280,7 +3235,7 @@ Array [
                   />
                   <label
                     className="a-label"
-                    htmlFor="efficacy-crt-question-1.3.1#0#_beneficial_b"
+                    htmlFor="efficacy-crt-question-1.3.1#0#b"
                   >
                     No
                   </label>
@@ -3319,7 +3274,7 @@ Array [
                   <input
                     checked={false}
                     className="a-radio"
-                    id="efficacy-crt-question-1.3.2#0#_beneficial_a"
+                    id="efficacy-crt-question-1.3.2#0#a"
                     name="efficacy-crt-question-1.3.2#0#_beneficial"
                     onChange={[Function]}
                     type="radio"
@@ -3327,7 +3282,7 @@ Array [
                   />
                   <label
                     className="a-label"
-                    htmlFor="efficacy-crt-question-1.3.2#0#_beneficial_a"
+                    htmlFor="efficacy-crt-question-1.3.2#0#a"
                   >
                     Yes
                   </label>
@@ -3338,7 +3293,7 @@ Array [
                   <input
                     checked={false}
                     className="a-radio"
-                    id="efficacy-crt-question-1.3.2#0#_beneficial_b"
+                    id="efficacy-crt-question-1.3.2#0#b"
                     name="efficacy-crt-question-1.3.2#0#_beneficial"
                     onChange={[Function]}
                     type="radio"
@@ -3346,7 +3301,7 @@ Array [
                   />
                   <label
                     className="a-label"
-                    htmlFor="efficacy-crt-question-1.3.2#0#_beneficial_b"
+                    htmlFor="efficacy-crt-question-1.3.2#0#b"
                   >
                     No
                   </label>
@@ -3412,7 +3367,7 @@ Array [
                   <input
                     checked={false}
                     className="a-radio"
-                    id="efficacy-crt-question-1.4.1#0#_a"
+                    id="efficacy-crt-question-1.4.1#0#a"
                     name="efficacy-crt-question-1.4.1#0#"
                     onChange={[Function]}
                     type="radio"
@@ -3420,7 +3375,7 @@ Array [
                   />
                   <label
                     className="a-label"
-                    htmlFor="efficacy-crt-question-1.4.1#0#_a"
+                    htmlFor="efficacy-crt-question-1.4.1#0#a"
                   >
                     Yes
                   </label>
@@ -3431,7 +3386,7 @@ Array [
                   <input
                     checked={false}
                     className="a-radio"
-                    id="efficacy-crt-question-1.4.1#0#_b"
+                    id="efficacy-crt-question-1.4.1#0#b"
                     name="efficacy-crt-question-1.4.1#0#"
                     onChange={[Function]}
                     type="radio"
@@ -3439,7 +3394,7 @@ Array [
                   />
                   <label
                     className="a-label"
-                    htmlFor="efficacy-crt-question-1.4.1#0#_b"
+                    htmlFor="efficacy-crt-question-1.4.1#0#b"
                   >
                     No
                   </label>
@@ -3473,7 +3428,7 @@ Array [
                   <input
                     checked={false}
                     className="a-radio"
-                    id="efficacy-crt-question-1.4.2#0#_a"
+                    id="efficacy-crt-question-1.4.2#0#a"
                     name="efficacy-crt-question-1.4.2#0#"
                     onChange={[Function]}
                     type="radio"
@@ -3481,7 +3436,7 @@ Array [
                   />
                   <label
                     className="a-label"
-                    htmlFor="efficacy-crt-question-1.4.2#0#_a"
+                    htmlFor="efficacy-crt-question-1.4.2#0#a"
                   >
                     Yes
                   </label>
@@ -3492,7 +3447,7 @@ Array [
                   <input
                     checked={false}
                     className="a-radio"
-                    id="efficacy-crt-question-1.4.2#0#_b"
+                    id="efficacy-crt-question-1.4.2#0#b"
                     name="efficacy-crt-question-1.4.2#0#"
                     onChange={[Function]}
                     type="radio"
@@ -3500,7 +3455,7 @@ Array [
                   />
                   <label
                     className="a-label"
-                    htmlFor="efficacy-crt-question-1.4.2#0#_b"
+                    htmlFor="efficacy-crt-question-1.4.2#0#b"
                   >
                     No
                   </label>
@@ -3534,7 +3489,7 @@ Array [
                   <input
                     checked={false}
                     className="a-radio"
-                    id="efficacy-crt-question-1.4.3#0#_a"
+                    id="efficacy-crt-question-1.4.3#0#a"
                     name="efficacy-crt-question-1.4.3#0#"
                     onChange={[Function]}
                     type="radio"
@@ -3542,7 +3497,7 @@ Array [
                   />
                   <label
                     className="a-label"
-                    htmlFor="efficacy-crt-question-1.4.3#0#_a"
+                    htmlFor="efficacy-crt-question-1.4.3#0#a"
                   >
                     Yes
                   </label>
@@ -3553,7 +3508,7 @@ Array [
                   <input
                     checked={false}
                     className="a-radio"
-                    id="efficacy-crt-question-1.4.3#0#_b"
+                    id="efficacy-crt-question-1.4.3#0#b"
                     name="efficacy-crt-question-1.4.3#0#"
                     onChange={[Function]}
                     type="radio"
@@ -3561,7 +3516,7 @@ Array [
                   />
                   <label
                     className="a-label"
-                    htmlFor="efficacy-crt-question-1.4.3#0#_b"
+                    htmlFor="efficacy-crt-question-1.4.3#0#b"
                   >
                     No
                   </label>
@@ -3595,7 +3550,7 @@ Array [
                   <input
                     checked={false}
                     className="a-radio"
-                    id="efficacy-crt-question-1.4.4#0#_a"
+                    id="efficacy-crt-question-1.4.4#0#a"
                     name="efficacy-crt-question-1.4.4#0#"
                     onChange={[Function]}
                     type="radio"
@@ -3603,7 +3558,7 @@ Array [
                   />
                   <label
                     className="a-label"
-                    htmlFor="efficacy-crt-question-1.4.4#0#_a"
+                    htmlFor="efficacy-crt-question-1.4.4#0#a"
                   >
                     Yes
                   </label>
@@ -3614,7 +3569,7 @@ Array [
                   <input
                     checked={false}
                     className="a-radio"
-                    id="efficacy-crt-question-1.4.4#0#_b"
+                    id="efficacy-crt-question-1.4.4#0#b"
                     name="efficacy-crt-question-1.4.4#0#"
                     onChange={[Function]}
                     type="radio"
@@ -3622,7 +3577,7 @@ Array [
                   />
                   <label
                     className="a-label"
-                    htmlFor="efficacy-crt-question-1.4.4#0#_b"
+                    htmlFor="efficacy-crt-question-1.4.4#0#b"
                   >
                     No
                   </label>
@@ -3661,7 +3616,7 @@ Array [
                   <input
                     checked={false}
                     className="a-radio"
-                    id="efficacy-crt-question-1.4.5#0#_beneficial_a"
+                    id="efficacy-crt-question-1.4.5#0#a"
                     name="efficacy-crt-question-1.4.5#0#_beneficial"
                     onChange={[Function]}
                     type="radio"
@@ -3669,7 +3624,7 @@ Array [
                   />
                   <label
                     className="a-label"
-                    htmlFor="efficacy-crt-question-1.4.5#0#_beneficial_a"
+                    htmlFor="efficacy-crt-question-1.4.5#0#a"
                   >
                     Yes
                   </label>
@@ -3680,7 +3635,7 @@ Array [
                   <input
                     checked={false}
                     className="a-radio"
-                    id="efficacy-crt-question-1.4.5#0#_beneficial_b"
+                    id="efficacy-crt-question-1.4.5#0#b"
                     name="efficacy-crt-question-1.4.5#0#_beneficial"
                     onChange={[Function]}
                     type="radio"
@@ -3688,7 +3643,7 @@ Array [
                   />
                   <label
                     className="a-label"
-                    htmlFor="efficacy-crt-question-1.4.5#0#_beneficial_b"
+                    htmlFor="efficacy-crt-question-1.4.5#0#b"
                   >
                     No
                   </label>
@@ -3727,7 +3682,7 @@ Array [
                   <input
                     checked={false}
                     className="a-radio"
-                    id="efficacy-crt-question-1.4.6#0#_beneficial_a"
+                    id="efficacy-crt-question-1.4.6#0#a"
                     name="efficacy-crt-question-1.4.6#0#_beneficial"
                     onChange={[Function]}
                     type="radio"
@@ -3735,7 +3690,7 @@ Array [
                   />
                   <label
                     className="a-label"
-                    htmlFor="efficacy-crt-question-1.4.6#0#_beneficial_a"
+                    htmlFor="efficacy-crt-question-1.4.6#0#a"
                   >
                     Yes
                   </label>
@@ -3746,7 +3701,7 @@ Array [
                   <input
                     checked={false}
                     className="a-radio"
-                    id="efficacy-crt-question-1.4.6#0#_beneficial_b"
+                    id="efficacy-crt-question-1.4.6#0#b"
                     name="efficacy-crt-question-1.4.6#0#_beneficial"
                     onChange={[Function]}
                     type="radio"
@@ -3754,7 +3709,7 @@ Array [
                   />
                   <label
                     className="a-label"
-                    htmlFor="efficacy-crt-question-1.4.6#0#_beneficial_b"
+                    htmlFor="efficacy-crt-question-1.4.6#0#b"
                   >
                     No
                   </label>
@@ -3820,7 +3775,7 @@ Array [
                   <input
                     checked={false}
                     className="a-radio"
-                    id="efficacy-crt-question-1.5#0#_a"
+                    id="efficacy-crt-question-1.5#0#a"
                     name="efficacy-crt-question-1.5#0#"
                     onChange={[Function]}
                     type="radio"
@@ -3828,7 +3783,7 @@ Array [
                   />
                   <label
                     className="a-label"
-                    htmlFor="efficacy-crt-question-1.5#0#_a"
+                    htmlFor="efficacy-crt-question-1.5#0#a"
                   >
                     Yes
                   </label>
@@ -3839,7 +3794,7 @@ Array [
                   <input
                     checked={false}
                     className="a-radio"
-                    id="efficacy-crt-question-1.5#0#_b"
+                    id="efficacy-crt-question-1.5#0#b"
                     name="efficacy-crt-question-1.5#0#"
                     onChange={[Function]}
                     type="radio"
@@ -3847,7 +3802,7 @@ Array [
                   />
                   <label
                     className="a-label"
-                    htmlFor="efficacy-crt-question-1.5#0#_b"
+                    htmlFor="efficacy-crt-question-1.5#0#b"
                   >
                     No
                   </label>
@@ -3913,7 +3868,7 @@ Array [
                   <input
                     checked={false}
                     className="a-radio"
-                    id="efficacy-crt-question-1.6#0#_a"
+                    id="efficacy-crt-question-1.6#0#a"
                     name="efficacy-crt-question-1.6#0#"
                     onChange={[Function]}
                     type="radio"
@@ -3921,7 +3876,7 @@ Array [
                   />
                   <label
                     className="a-label"
-                    htmlFor="efficacy-crt-question-1.6#0#_a"
+                    htmlFor="efficacy-crt-question-1.6#0#a"
                   >
                     Yes
                   </label>
@@ -3932,7 +3887,7 @@ Array [
                   <input
                     checked={false}
                     className="a-radio"
-                    id="efficacy-crt-question-1.6#0#_b"
+                    id="efficacy-crt-question-1.6#0#b"
                     name="efficacy-crt-question-1.6#0#"
                     onChange={[Function]}
                     type="radio"
@@ -3940,7 +3895,7 @@ Array [
                   />
                   <label
                     className="a-label"
-                    htmlFor="efficacy-crt-question-1.6#0#_b"
+                    htmlFor="efficacy-crt-question-1.6#0#b"
                   >
                     No
                   </label>
@@ -3977,34 +3932,6 @@ Array [
         onBlur={[Function]}
         rows="6"
       />
-    </div>
-    <div
-      className="m-notification m-notification__visible m-notification__warning u-mb30"
-    >
-      <span
-        className="a-icon"
-      >
-        <svg
-          class="cf-icon-svg"
-          viewBox="0 0 1000 1200"
-          xmlns="http://www.w3.org/2000/svg"
-        >
-          <path
-            d="M500 105.2c-276.1 0-500 223.9-500 500s223.9 500 500 500 500-223.9 500-500-223.9-500-500-500zm-49.7 234.6c0-27.6 22.4-50 50-50s50 22.4 50 50v328.6c0 27.6-22.4 50-50 50s-50-22.4-50-50V339.8zm50 582.5c-39.6 0-71.7-32.1-71.7-71.7s32.1-71.7 71.7-71.7S572 811 572 850.6s-32.1 71.7-71.7 71.7z"
-          />
-        </svg>
-      </span>
-      <div
-        className="m-notification_content"
-      >
-        <div
-          className="m-notification_message"
-        >
-          <p>
-            You must enter a study name and answer all yes/no questions for this study before it can be scored.
-          </p>
-        </div>
-      </div>
     </div>
     <div
       className="u-mt15 u-mb30"
@@ -4117,7 +4044,7 @@ Array [
                   <input
                     checked={false}
                     className="a-radio"
-                    id="efficacy-crt-question-2.1_beneficial_a"
+                    id="efficacy-crt-question-2.1a"
                     name="efficacy-crt-question-2.1_beneficial"
                     onChange={[Function]}
                     type="radio"
@@ -4125,7 +4052,7 @@ Array [
                   />
                   <label
                     className="a-label"
-                    htmlFor="efficacy-crt-question-2.1_beneficial_a"
+                    htmlFor="efficacy-crt-question-2.1a"
                   >
                     Yes
                   </label>
@@ -4136,7 +4063,7 @@ Array [
                   <input
                     checked={false}
                     className="a-radio"
-                    id="efficacy-crt-question-2.1_beneficial_b"
+                    id="efficacy-crt-question-2.1b"
                     name="efficacy-crt-question-2.1_beneficial"
                     onChange={[Function]}
                     type="radio"
@@ -4144,7 +4071,7 @@ Array [
                   />
                   <label
                     className="a-label"
-                    htmlFor="efficacy-crt-question-2.1_beneficial_b"
+                    htmlFor="efficacy-crt-question-2.1b"
                   >
                     No
                   </label>
@@ -4215,7 +4142,7 @@ Array [
                   <input
                     checked={false}
                     className="a-radio"
-                    id="efficacy-crt-question-2.2_beneficial_a"
+                    id="efficacy-crt-question-2.2a"
                     name="efficacy-crt-question-2.2_beneficial"
                     onChange={[Function]}
                     type="radio"
@@ -4223,7 +4150,7 @@ Array [
                   />
                   <label
                     className="a-label"
-                    htmlFor="efficacy-crt-question-2.2_beneficial_a"
+                    htmlFor="efficacy-crt-question-2.2a"
                   >
                     Yes
                   </label>
@@ -4234,7 +4161,7 @@ Array [
                   <input
                     checked={false}
                     className="a-radio"
-                    id="efficacy-crt-question-2.2_beneficial_b"
+                    id="efficacy-crt-question-2.2b"
                     name="efficacy-crt-question-2.2_beneficial"
                     onChange={[Function]}
                     type="radio"
@@ -4242,7 +4169,7 @@ Array [
                   />
                   <label
                     className="a-label"
-                    htmlFor="efficacy-crt-question-2.2_beneficial_b"
+                    htmlFor="efficacy-crt-question-2.2b"
                   >
                     No
                   </label>
@@ -4356,7 +4283,7 @@ Array [
                   <input
                     checked={false}
                     className="a-radio"
-                    id="efficacy-crt-question-3.1_a"
+                    id="efficacy-crt-question-3.1a"
                     name="efficacy-crt-question-3.1"
                     onChange={[Function]}
                     type="radio"
@@ -4364,7 +4291,7 @@ Array [
                   />
                   <label
                     className="a-label"
-                    htmlFor="efficacy-crt-question-3.1_a"
+                    htmlFor="efficacy-crt-question-3.1a"
                   >
                     Yes
                   </label>
@@ -4375,7 +4302,7 @@ Array [
                   <input
                     checked={false}
                     className="a-radio"
-                    id="efficacy-crt-question-3.1_b"
+                    id="efficacy-crt-question-3.1b"
                     name="efficacy-crt-question-3.1"
                     onChange={[Function]}
                     type="radio"
@@ -4383,7 +4310,7 @@ Array [
                   />
                   <label
                     className="a-label"
-                    htmlFor="efficacy-crt-question-3.1_b"
+                    htmlFor="efficacy-crt-question-3.1b"
                   >
                     No
                   </label>
@@ -4449,7 +4376,7 @@ Array [
                   <input
                     checked={false}
                     className="a-radio"
-                    id="efficacy-crt-question-3.2.1_a"
+                    id="efficacy-crt-question-3.2.1a"
                     name="efficacy-crt-question-3.2.1"
                     onChange={[Function]}
                     type="radio"
@@ -4457,7 +4384,7 @@ Array [
                   />
                   <label
                     className="a-label"
-                    htmlFor="efficacy-crt-question-3.2.1_a"
+                    htmlFor="efficacy-crt-question-3.2.1a"
                   >
                     Yes
                   </label>
@@ -4468,7 +4395,7 @@ Array [
                   <input
                     checked={false}
                     className="a-radio"
-                    id="efficacy-crt-question-3.2.1_b"
+                    id="efficacy-crt-question-3.2.1b"
                     name="efficacy-crt-question-3.2.1"
                     onChange={[Function]}
                     type="radio"
@@ -4476,7 +4403,7 @@ Array [
                   />
                   <label
                     className="a-label"
-                    htmlFor="efficacy-crt-question-3.2.1_b"
+                    htmlFor="efficacy-crt-question-3.2.1b"
                   >
                     No
                   </label>
@@ -4515,7 +4442,7 @@ Array [
                   <input
                     checked={false}
                     className="a-radio"
-                    id="efficacy-crt-question-3.2.2_beneficial_a"
+                    id="efficacy-crt-question-3.2.2a"
                     name="efficacy-crt-question-3.2.2_beneficial"
                     onChange={[Function]}
                     type="radio"
@@ -4523,7 +4450,7 @@ Array [
                   />
                   <label
                     className="a-label"
-                    htmlFor="efficacy-crt-question-3.2.2_beneficial_a"
+                    htmlFor="efficacy-crt-question-3.2.2a"
                   >
                     Yes
                   </label>
@@ -4534,7 +4461,7 @@ Array [
                   <input
                     checked={false}
                     className="a-radio"
-                    id="efficacy-crt-question-3.2.2_beneficial_b"
+                    id="efficacy-crt-question-3.2.2b"
                     name="efficacy-crt-question-3.2.2_beneficial"
                     onChange={[Function]}
                     type="radio"
@@ -4542,7 +4469,7 @@ Array [
                   />
                   <label
                     className="a-label"
-                    htmlFor="efficacy-crt-question-3.2.2_beneficial_b"
+                    htmlFor="efficacy-crt-question-3.2.2b"
                   >
                     No
                   </label>
@@ -4689,13 +4616,6 @@ Array [
   <hr
     className="hr u-mb30 u-mt30"
   />,
-  <p
-    className="u-mb60"
-  >
-    <strong>
-      All questions are required, unless otherwise noted.
-    </strong>
-  </p>,
   <div
     className="block block__flush-top"
     id="criterion_1"
@@ -4811,7 +4731,7 @@ Array [
                   <input
                     checked={false}
                     className="a-radio"
-                    id="efficacy-crt-question-1.1.1#0#_a"
+                    id="efficacy-crt-question-1.1.1#0#a"
                     name="efficacy-crt-question-1.1.1#0#"
                     onChange={[Function]}
                     type="radio"
@@ -4819,7 +4739,7 @@ Array [
                   />
                   <label
                     className="a-label"
-                    htmlFor="efficacy-crt-question-1.1.1#0#_a"
+                    htmlFor="efficacy-crt-question-1.1.1#0#a"
                   >
                     Yes
                   </label>
@@ -4830,7 +4750,7 @@ Array [
                   <input
                     checked={false}
                     className="a-radio"
-                    id="efficacy-crt-question-1.1.1#0#_b"
+                    id="efficacy-crt-question-1.1.1#0#b"
                     name="efficacy-crt-question-1.1.1#0#"
                     onChange={[Function]}
                     type="radio"
@@ -4838,7 +4758,7 @@ Array [
                   />
                   <label
                     className="a-label"
-                    htmlFor="efficacy-crt-question-1.1.1#0#_b"
+                    htmlFor="efficacy-crt-question-1.1.1#0#b"
                   >
                     No
                   </label>
@@ -4877,7 +4797,7 @@ Array [
                   <input
                     checked={false}
                     className="a-radio"
-                    id="efficacy-crt-question-1.1.2#0#_beneficial_a"
+                    id="efficacy-crt-question-1.1.2#0#a"
                     name="efficacy-crt-question-1.1.2#0#_beneficial"
                     onChange={[Function]}
                     type="radio"
@@ -4885,7 +4805,7 @@ Array [
                   />
                   <label
                     className="a-label"
-                    htmlFor="efficacy-crt-question-1.1.2#0#_beneficial_a"
+                    htmlFor="efficacy-crt-question-1.1.2#0#a"
                   >
                     Yes
                   </label>
@@ -4896,7 +4816,7 @@ Array [
                   <input
                     checked={false}
                     className="a-radio"
-                    id="efficacy-crt-question-1.1.2#0#_beneficial_b"
+                    id="efficacy-crt-question-1.1.2#0#b"
                     name="efficacy-crt-question-1.1.2#0#_beneficial"
                     onChange={[Function]}
                     type="radio"
@@ -4904,7 +4824,7 @@ Array [
                   />
                   <label
                     className="a-label"
-                    htmlFor="efficacy-crt-question-1.1.2#0#_beneficial_b"
+                    htmlFor="efficacy-crt-question-1.1.2#0#b"
                   >
                     No
                   </label>
@@ -4970,7 +4890,7 @@ Array [
                   <input
                     checked={false}
                     className="a-radio"
-                    id="efficacy-crt-question-1.2#0#_a"
+                    id="efficacy-crt-question-1.2#0#a"
                     name="efficacy-crt-question-1.2#0#"
                     onChange={[Function]}
                     type="radio"
@@ -4978,7 +4898,7 @@ Array [
                   />
                   <label
                     className="a-label"
-                    htmlFor="efficacy-crt-question-1.2#0#_a"
+                    htmlFor="efficacy-crt-question-1.2#0#a"
                   >
                     Yes
                   </label>
@@ -4989,7 +4909,7 @@ Array [
                   <input
                     checked={false}
                     className="a-radio"
-                    id="efficacy-crt-question-1.2#0#_b"
+                    id="efficacy-crt-question-1.2#0#b"
                     name="efficacy-crt-question-1.2#0#"
                     onChange={[Function]}
                     type="radio"
@@ -4997,7 +4917,7 @@ Array [
                   />
                   <label
                     className="a-label"
-                    htmlFor="efficacy-crt-question-1.2#0#_b"
+                    htmlFor="efficacy-crt-question-1.2#0#b"
                   >
                     No
                   </label>
@@ -5068,7 +4988,7 @@ Array [
                   <input
                     checked={false}
                     className="a-radio"
-                    id="efficacy-crt-question-1.3.1#0#_beneficial_a"
+                    id="efficacy-crt-question-1.3.1#0#a"
                     name="efficacy-crt-question-1.3.1#0#_beneficial"
                     onChange={[Function]}
                     type="radio"
@@ -5076,7 +4996,7 @@ Array [
                   />
                   <label
                     className="a-label"
-                    htmlFor="efficacy-crt-question-1.3.1#0#_beneficial_a"
+                    htmlFor="efficacy-crt-question-1.3.1#0#a"
                   >
                     Yes
                   </label>
@@ -5087,7 +5007,7 @@ Array [
                   <input
                     checked={false}
                     className="a-radio"
-                    id="efficacy-crt-question-1.3.1#0#_beneficial_b"
+                    id="efficacy-crt-question-1.3.1#0#b"
                     name="efficacy-crt-question-1.3.1#0#_beneficial"
                     onChange={[Function]}
                     type="radio"
@@ -5095,7 +5015,7 @@ Array [
                   />
                   <label
                     className="a-label"
-                    htmlFor="efficacy-crt-question-1.3.1#0#_beneficial_b"
+                    htmlFor="efficacy-crt-question-1.3.1#0#b"
                   >
                     No
                   </label>
@@ -5134,7 +5054,7 @@ Array [
                   <input
                     checked={false}
                     className="a-radio"
-                    id="efficacy-crt-question-1.3.2#0#_beneficial_a"
+                    id="efficacy-crt-question-1.3.2#0#a"
                     name="efficacy-crt-question-1.3.2#0#_beneficial"
                     onChange={[Function]}
                     type="radio"
@@ -5142,7 +5062,7 @@ Array [
                   />
                   <label
                     className="a-label"
-                    htmlFor="efficacy-crt-question-1.3.2#0#_beneficial_a"
+                    htmlFor="efficacy-crt-question-1.3.2#0#a"
                   >
                     Yes
                   </label>
@@ -5153,7 +5073,7 @@ Array [
                   <input
                     checked={false}
                     className="a-radio"
-                    id="efficacy-crt-question-1.3.2#0#_beneficial_b"
+                    id="efficacy-crt-question-1.3.2#0#b"
                     name="efficacy-crt-question-1.3.2#0#_beneficial"
                     onChange={[Function]}
                     type="radio"
@@ -5161,7 +5081,7 @@ Array [
                   />
                   <label
                     className="a-label"
-                    htmlFor="efficacy-crt-question-1.3.2#0#_beneficial_b"
+                    htmlFor="efficacy-crt-question-1.3.2#0#b"
                   >
                     No
                   </label>
@@ -5227,7 +5147,7 @@ Array [
                   <input
                     checked={false}
                     className="a-radio"
-                    id="efficacy-crt-question-1.4.1#0#_a"
+                    id="efficacy-crt-question-1.4.1#0#a"
                     name="efficacy-crt-question-1.4.1#0#"
                     onChange={[Function]}
                     type="radio"
@@ -5235,7 +5155,7 @@ Array [
                   />
                   <label
                     className="a-label"
-                    htmlFor="efficacy-crt-question-1.4.1#0#_a"
+                    htmlFor="efficacy-crt-question-1.4.1#0#a"
                   >
                     Yes
                   </label>
@@ -5246,7 +5166,7 @@ Array [
                   <input
                     checked={false}
                     className="a-radio"
-                    id="efficacy-crt-question-1.4.1#0#_b"
+                    id="efficacy-crt-question-1.4.1#0#b"
                     name="efficacy-crt-question-1.4.1#0#"
                     onChange={[Function]}
                     type="radio"
@@ -5254,7 +5174,7 @@ Array [
                   />
                   <label
                     className="a-label"
-                    htmlFor="efficacy-crt-question-1.4.1#0#_b"
+                    htmlFor="efficacy-crt-question-1.4.1#0#b"
                   >
                     No
                   </label>
@@ -5288,7 +5208,7 @@ Array [
                   <input
                     checked={false}
                     className="a-radio"
-                    id="efficacy-crt-question-1.4.2#0#_a"
+                    id="efficacy-crt-question-1.4.2#0#a"
                     name="efficacy-crt-question-1.4.2#0#"
                     onChange={[Function]}
                     type="radio"
@@ -5296,7 +5216,7 @@ Array [
                   />
                   <label
                     className="a-label"
-                    htmlFor="efficacy-crt-question-1.4.2#0#_a"
+                    htmlFor="efficacy-crt-question-1.4.2#0#a"
                   >
                     Yes
                   </label>
@@ -5307,7 +5227,7 @@ Array [
                   <input
                     checked={false}
                     className="a-radio"
-                    id="efficacy-crt-question-1.4.2#0#_b"
+                    id="efficacy-crt-question-1.4.2#0#b"
                     name="efficacy-crt-question-1.4.2#0#"
                     onChange={[Function]}
                     type="radio"
@@ -5315,7 +5235,7 @@ Array [
                   />
                   <label
                     className="a-label"
-                    htmlFor="efficacy-crt-question-1.4.2#0#_b"
+                    htmlFor="efficacy-crt-question-1.4.2#0#b"
                   >
                     No
                   </label>
@@ -5349,7 +5269,7 @@ Array [
                   <input
                     checked={false}
                     className="a-radio"
-                    id="efficacy-crt-question-1.4.3#0#_a"
+                    id="efficacy-crt-question-1.4.3#0#a"
                     name="efficacy-crt-question-1.4.3#0#"
                     onChange={[Function]}
                     type="radio"
@@ -5357,7 +5277,7 @@ Array [
                   />
                   <label
                     className="a-label"
-                    htmlFor="efficacy-crt-question-1.4.3#0#_a"
+                    htmlFor="efficacy-crt-question-1.4.3#0#a"
                   >
                     Yes
                   </label>
@@ -5368,7 +5288,7 @@ Array [
                   <input
                     checked={false}
                     className="a-radio"
-                    id="efficacy-crt-question-1.4.3#0#_b"
+                    id="efficacy-crt-question-1.4.3#0#b"
                     name="efficacy-crt-question-1.4.3#0#"
                     onChange={[Function]}
                     type="radio"
@@ -5376,7 +5296,7 @@ Array [
                   />
                   <label
                     className="a-label"
-                    htmlFor="efficacy-crt-question-1.4.3#0#_b"
+                    htmlFor="efficacy-crt-question-1.4.3#0#b"
                   >
                     No
                   </label>
@@ -5410,7 +5330,7 @@ Array [
                   <input
                     checked={false}
                     className="a-radio"
-                    id="efficacy-crt-question-1.4.4#0#_a"
+                    id="efficacy-crt-question-1.4.4#0#a"
                     name="efficacy-crt-question-1.4.4#0#"
                     onChange={[Function]}
                     type="radio"
@@ -5418,7 +5338,7 @@ Array [
                   />
                   <label
                     className="a-label"
-                    htmlFor="efficacy-crt-question-1.4.4#0#_a"
+                    htmlFor="efficacy-crt-question-1.4.4#0#a"
                   >
                     Yes
                   </label>
@@ -5429,7 +5349,7 @@ Array [
                   <input
                     checked={false}
                     className="a-radio"
-                    id="efficacy-crt-question-1.4.4#0#_b"
+                    id="efficacy-crt-question-1.4.4#0#b"
                     name="efficacy-crt-question-1.4.4#0#"
                     onChange={[Function]}
                     type="radio"
@@ -5437,7 +5357,7 @@ Array [
                   />
                   <label
                     className="a-label"
-                    htmlFor="efficacy-crt-question-1.4.4#0#_b"
+                    htmlFor="efficacy-crt-question-1.4.4#0#b"
                   >
                     No
                   </label>
@@ -5476,7 +5396,7 @@ Array [
                   <input
                     checked={false}
                     className="a-radio"
-                    id="efficacy-crt-question-1.4.5#0#_beneficial_a"
+                    id="efficacy-crt-question-1.4.5#0#a"
                     name="efficacy-crt-question-1.4.5#0#_beneficial"
                     onChange={[Function]}
                     type="radio"
@@ -5484,7 +5404,7 @@ Array [
                   />
                   <label
                     className="a-label"
-                    htmlFor="efficacy-crt-question-1.4.5#0#_beneficial_a"
+                    htmlFor="efficacy-crt-question-1.4.5#0#a"
                   >
                     Yes
                   </label>
@@ -5495,7 +5415,7 @@ Array [
                   <input
                     checked={false}
                     className="a-radio"
-                    id="efficacy-crt-question-1.4.5#0#_beneficial_b"
+                    id="efficacy-crt-question-1.4.5#0#b"
                     name="efficacy-crt-question-1.4.5#0#_beneficial"
                     onChange={[Function]}
                     type="radio"
@@ -5503,7 +5423,7 @@ Array [
                   />
                   <label
                     className="a-label"
-                    htmlFor="efficacy-crt-question-1.4.5#0#_beneficial_b"
+                    htmlFor="efficacy-crt-question-1.4.5#0#b"
                   >
                     No
                   </label>
@@ -5542,7 +5462,7 @@ Array [
                   <input
                     checked={false}
                     className="a-radio"
-                    id="efficacy-crt-question-1.4.6#0#_beneficial_a"
+                    id="efficacy-crt-question-1.4.6#0#a"
                     name="efficacy-crt-question-1.4.6#0#_beneficial"
                     onChange={[Function]}
                     type="radio"
@@ -5550,7 +5470,7 @@ Array [
                   />
                   <label
                     className="a-label"
-                    htmlFor="efficacy-crt-question-1.4.6#0#_beneficial_a"
+                    htmlFor="efficacy-crt-question-1.4.6#0#a"
                   >
                     Yes
                   </label>
@@ -5561,7 +5481,7 @@ Array [
                   <input
                     checked={false}
                     className="a-radio"
-                    id="efficacy-crt-question-1.4.6#0#_beneficial_b"
+                    id="efficacy-crt-question-1.4.6#0#b"
                     name="efficacy-crt-question-1.4.6#0#_beneficial"
                     onChange={[Function]}
                     type="radio"
@@ -5569,7 +5489,7 @@ Array [
                   />
                   <label
                     className="a-label"
-                    htmlFor="efficacy-crt-question-1.4.6#0#_beneficial_b"
+                    htmlFor="efficacy-crt-question-1.4.6#0#b"
                   >
                     No
                   </label>
@@ -5635,7 +5555,7 @@ Array [
                   <input
                     checked={false}
                     className="a-radio"
-                    id="efficacy-crt-question-1.5#0#_a"
+                    id="efficacy-crt-question-1.5#0#a"
                     name="efficacy-crt-question-1.5#0#"
                     onChange={[Function]}
                     type="radio"
@@ -5643,7 +5563,7 @@ Array [
                   />
                   <label
                     className="a-label"
-                    htmlFor="efficacy-crt-question-1.5#0#_a"
+                    htmlFor="efficacy-crt-question-1.5#0#a"
                   >
                     Yes
                   </label>
@@ -5654,7 +5574,7 @@ Array [
                   <input
                     checked={false}
                     className="a-radio"
-                    id="efficacy-crt-question-1.5#0#_b"
+                    id="efficacy-crt-question-1.5#0#b"
                     name="efficacy-crt-question-1.5#0#"
                     onChange={[Function]}
                     type="radio"
@@ -5662,7 +5582,7 @@ Array [
                   />
                   <label
                     className="a-label"
-                    htmlFor="efficacy-crt-question-1.5#0#_b"
+                    htmlFor="efficacy-crt-question-1.5#0#b"
                   >
                     No
                   </label>
@@ -5728,7 +5648,7 @@ Array [
                   <input
                     checked={false}
                     className="a-radio"
-                    id="efficacy-crt-question-1.6#0#_a"
+                    id="efficacy-crt-question-1.6#0#a"
                     name="efficacy-crt-question-1.6#0#"
                     onChange={[Function]}
                     type="radio"
@@ -5736,7 +5656,7 @@ Array [
                   />
                   <label
                     className="a-label"
-                    htmlFor="efficacy-crt-question-1.6#0#_a"
+                    htmlFor="efficacy-crt-question-1.6#0#a"
                   >
                     Yes
                   </label>
@@ -5747,7 +5667,7 @@ Array [
                   <input
                     checked={false}
                     className="a-radio"
-                    id="efficacy-crt-question-1.6#0#_b"
+                    id="efficacy-crt-question-1.6#0#b"
                     name="efficacy-crt-question-1.6#0#"
                     onChange={[Function]}
                     type="radio"
@@ -5755,7 +5675,7 @@ Array [
                   />
                   <label
                     className="a-label"
-                    htmlFor="efficacy-crt-question-1.6#0#_b"
+                    htmlFor="efficacy-crt-question-1.6#0#b"
                   >
                     No
                   </label>
@@ -5852,6 +5772,9 @@ Array [
       </div>
     </div>
   </div>,
+  <div
+    id="efficacy-crt-question-2"
+  />,
   <hr
     className="hr u-mb30 u-mt45"
   />,

--- a/teachers_digital_platform/crtool/src/__tests__/__snapshots__/QualityCriterionPage.test.js.snap
+++ b/teachers_digital_platform/crtool/src/__tests__/__snapshots__/QualityCriterionPage.test.js.snap
@@ -80,13 +80,6 @@ Array [
   <hr
     className="hr u-mb30 u-mt30"
   />,
-  <p
-    className="u-mb60"
-  >
-    <strong>
-      All questions are required, unless otherwise noted.
-    </strong>
-  </p>,
   <div
     className="block block__flush-top"
     id="criterion_1"
@@ -938,6 +931,7 @@ Array [
   </div>,
   <div
     className="block block__flush-top"
+    id="quality-crt-question-2"
   >
     <h3
       className="h2"
@@ -966,13 +960,6 @@ Array [
   <hr
     className="hr u-mb30 u-mt45"
   />,
-  <p
-    className="u-mb30"
-  >
-    <strong>
-      Be sure to answer all yes/no questions to continue.
-    </strong>
-  </p>,
 ]
 `;
 
@@ -1056,13 +1043,6 @@ Array [
   <hr
     className="hr u-mb30 u-mt30"
   />,
-  <p
-    className="u-mb60"
-  >
-    <strong>
-      All questions are required, unless otherwise noted.
-    </strong>
-  </p>,
   <div
     className="block block__flush-top"
     id="criterion_1"
@@ -3515,13 +3495,6 @@ Array [
   <hr
     className="hr u-mb30 u-mt45"
   />,
-  <p
-    className="u-mb30"
-  >
-    <strong>
-      Be sure to answer all yes/no questions to continue.
-    </strong>
-  </p>,
 ]
 `;
 
@@ -3605,13 +3578,6 @@ Array [
   <hr
     className="hr u-mb30 u-mt30"
   />,
-  <p
-    className="u-mb60"
-  >
-    <strong>
-      All questions are required, unless otherwise noted.
-    </strong>
-  </p>,
   <div
     className="block block__flush-top"
     id="criterion_1"
@@ -4851,6 +4817,7 @@ Array [
   </div>,
   <div
     className="block block__flush-top"
+    id="quality-crt-question-3"
   >
     <h3
       className="h2"
@@ -4879,13 +4846,6 @@ Array [
   <hr
     className="hr u-mb30 u-mt45"
   />,
-  <p
-    className="u-mb30"
-  >
-    <strong>
-      Be sure to answer all yes/no questions to continue.
-    </strong>
-  </p>,
 ]
 `;
 
@@ -4969,13 +4929,6 @@ Array [
   <hr
     className="hr u-mb30 u-mt30"
   />,
-  <p
-    className="u-mb60"
-  >
-    <strong>
-      All questions are required, unless otherwise noted.
-    </strong>
-  </p>,
   <div
     className="block block__flush-top"
     id="criterion_1"
@@ -5827,6 +5780,7 @@ Array [
   </div>,
   <div
     className="block block__flush-top"
+    id="quality-crt-question-2"
   >
     <h3
       className="h2"
@@ -5855,13 +5809,6 @@ Array [
   <hr
     className="hr u-mb30 u-mt45"
   />,
-  <p
-    className="u-mb30"
-  >
-    <strong>
-      Be sure to answer all yes/no questions to continue.
-    </strong>
-  </p>,
 ]
 `;
 
@@ -5945,13 +5892,6 @@ Array [
   <hr
     className="hr u-mb30 u-mt30"
   />,
-  <p
-    className="u-mb60"
-  >
-    <strong>
-      All questions are required, unless otherwise noted.
-    </strong>
-  </p>,
   <div
     className="block block__flush-top"
     id="criterion_1"
@@ -6816,6 +6756,7 @@ Array [
   </div>,
   <div
     className="block block__flush-top"
+    id="quality-crt-question-2"
   >
     <h3
       className="h2"
@@ -6844,12 +6785,5 @@ Array [
   <hr
     className="hr u-mb30 u-mt45"
   />,
-  <p
-    className="u-mb30"
-  >
-    <strong>
-      Be sure to answer all yes/no questions to continue.
-    </strong>
-  </p>,
 ]
 `;

--- a/teachers_digital_platform/crtool/src/__tests__/__snapshots__/QualityCriterionPage.test.js.snap
+++ b/teachers_digital_platform/crtool/src/__tests__/__snapshots__/QualityCriterionPage.test.js.snap
@@ -5911,6 +5911,11 @@ Array [
         </svg>
       </span>
       Criterion 1: Accessibility
+      <span
+        class="u-fc-gray"
+      >
+         (complete)
+      </span>
     </h2>
     <p
       className="lead-paragraph u-mb45 u-mt15"

--- a/teachers_digital_platform/crtool/src/__tests__/__snapshots__/UtilityCriterionPage.test.js.snap
+++ b/teachers_digital_platform/crtool/src/__tests__/__snapshots__/UtilityCriterionPage.test.js.snap
@@ -85,13 +85,6 @@ Array [
   <hr
     className="hr u-mb30 u-mt30"
   />,
-  <p
-    className="u-mb60"
-  >
-    <strong>
-      All questions are required, unless otherwise noted.
-    </strong>
-  </p>,
   <div
     className="block block__flush-top"
     id="criterion_1"
@@ -916,6 +909,7 @@ Array [
   </div>,
   <div
     className="block block__flush-top"
+    id="utility-crt-question-2"
   >
     <h3
       className="h2"
@@ -944,13 +938,6 @@ Array [
   <hr
     className="hr u-mb30 u-mt45"
   />,
-  <p
-    className="u-mb30"
-  >
-    <strong>
-      Be sure to answer all yes/no questions to continue.
-    </strong>
-  </p>,
 ]
 `;
 
@@ -1039,13 +1026,6 @@ Array [
   <hr
     className="hr u-mb30 u-mt30"
   />,
-  <p
-    className="u-mb60"
-  >
-    <strong>
-      All questions are required, unless otherwise noted.
-    </strong>
-  </p>,
   <div
     className="block block__flush-top"
     id="criterion_1"
@@ -6132,13 +6112,6 @@ Array [
   <hr
     className="hr u-mb30 u-mt45"
   />,
-  <p
-    className="u-mb30"
-  >
-    <strong>
-      Be sure to answer all yes/no questions to continue.
-    </strong>
-  </p>,
 ]
 `;
 
@@ -6227,13 +6200,6 @@ Array [
   <hr
     className="hr u-mb30 u-mt30"
   />,
-  <p
-    className="u-mb60"
-  >
-    <strong>
-      All questions are required, unless otherwise noted.
-    </strong>
-  </p>,
   <div
     className="block block__flush-top"
     id="criterion_1"
@@ -8690,6 +8656,7 @@ Array [
   </div>,
   <div
     className="block block__flush-top"
+    id="utility-crt-question-3"
   >
     <h3
       className="h2"
@@ -8718,13 +8685,6 @@ Array [
   <hr
     className="hr u-mb30 u-mt45"
   />,
-  <p
-    className="u-mb30"
-  >
-    <strong>
-      Be sure to answer all yes/no questions to continue.
-    </strong>
-  </p>,
 ]
 `;
 
@@ -8813,13 +8773,6 @@ Array [
   <hr
     className="hr u-mb30 u-mt30"
   />,
-  <p
-    className="u-mb60"
-  >
-    <strong>
-      All questions are required, unless otherwise noted.
-    </strong>
-  </p>,
   <div
     className="block block__flush-top"
     id="criterion_1"
@@ -9644,6 +9597,7 @@ Array [
   </div>,
   <div
     className="block block__flush-top"
+    id="utility-crt-question-2"
   >
     <h3
       className="h2"
@@ -9672,13 +9626,6 @@ Array [
   <hr
     className="hr u-mb30 u-mt45"
   />,
-  <p
-    className="u-mb30"
-  >
-    <strong>
-      Be sure to answer all yes/no questions to continue.
-    </strong>
-  </p>,
 ]
 `;
 
@@ -9767,13 +9714,6 @@ Array [
   <hr
     className="hr u-mb30 u-mt30"
   />,
-  <p
-    className="u-mb60"
-  >
-    <strong>
-      All questions are required, unless otherwise noted.
-    </strong>
-  </p>,
   <div
     className="block block__flush-top"
     id="criterion_1"
@@ -10611,6 +10551,7 @@ Array [
   </div>,
   <div
     className="block block__flush-top"
+    id="utility-crt-question-2"
   >
     <h3
       className="h2"
@@ -10639,12 +10580,5 @@ Array [
   <hr
     className="hr u-mb30 u-mt45"
   />,
-  <p
-    className="u-mb30"
-  >
-    <strong>
-      Be sure to answer all yes/no questions to continue.
-    </strong>
-  </p>,
 ]
 `;

--- a/teachers_digital_platform/crtool/src/__tests__/__snapshots__/UtilityCriterionPage.test.js.snap
+++ b/teachers_digital_platform/crtool/src/__tests__/__snapshots__/UtilityCriterionPage.test.js.snap
@@ -9733,6 +9733,11 @@ Array [
         </svg>
       </span>
       Criterion 1: Materials to support cognitive development
+      <span
+        class="u-fc-gray"
+      >
+         (complete)
+      </span>
     </h2>
     <p
       className="lead-paragraph u-mb45 u-mt15"

--- a/teachers_digital_platform/crtool/src/js/business.logic/constants.js
+++ b/teachers_digital_platform/crtool/src/js/business.logic/constants.js
@@ -39,6 +39,11 @@ const C = {
     QUALITY_CRITERION_IS_COMPLETE: "quality_is_complete",
     EFFICACY_CRITERION_IS_COMPLETE: "efficacy_is_complete",
 
+    CONTENT_SHOW_ERRORS: "contentShowErrors",
+    UTILITY_SHOW_ERRORS: "utilityShowErrors",
+    QUALITY_SHOW_ERRORS: "qualityShowErrors",
+    EFFICACY_SHOW_ERRORS: "efficacyShowErrors",
+
     ICON_CHECK_ROUND: "check-round",
     ICON_CREDIT_REPORT: "credit-report",
     ICON_CREDIT_REPORT_ROUND: "credit-report-round",

--- a/teachers_digital_platform/crtool/src/js/business.logic/repository.js
+++ b/teachers_digital_platform/crtool/src/js/business.logic/repository.js
@@ -43,36 +43,52 @@ const Repository = {
         return localStorage.getItem(C.EFFICACY_STATUS);
     },
 
+    getContentShowErrors() {
+        return localStorage.getItem(C.CONTENT_SHOW_ERRORS) === "true";
+    },
+
+    getQualityShowErrors() {
+        return localStorage.getItem(C.QUALITY_SHOW_ERRORS) === "true";
+    },
+
+    getUtilityShowErrors() {
+        return localStorage.getItem(C.UTILITY_SHOW_ERRORS) === "true";
+    },
+
+    getEfficacyShowErrors() {
+        return localStorage.getItem(C.EFFICACY_SHOW_ERRORS) === "true";
+    },
+
     getContentIsDone() {
-        return localStorage.getItem(C.CONTENT_IS_DONE);
+        return localStorage.getItem(C.CONTENT_IS_DONE) === "true";
     },
 
     getQualityIsDone() {
-        return localStorage.getItem(C.QUALITY_IS_DONE);
+        return localStorage.getItem(C.QUALITY_IS_DONE) === "true";
     },
 
     getUtilityIsDone() {
-        return localStorage.getItem(C.UTILITY_IS_DONE);
+        return localStorage.getItem(C.UTILITY_IS_DONE) === "true";
     },
 
     getEfficacyIsDone() {
-        return localStorage.getItem(C.EFFICACY_IS_DONE);
+        return localStorage.getItem(C.EFFICACY_IS_DONE) === "true";
     },
 
     getContentViewSummary() {
-        return localStorage.getItem(C.CONTENT_SUMMARY_VIEW) || false;
+        return localStorage.getItem(C.CONTENT_SUMMARY_VIEW) === "true";
     },
 
     getQualityViewSummary() {
-        return localStorage.getItem(C.QUALITY_SUMMARY_VIEW) || false;
+        return localStorage.getItem(C.QUALITY_SUMMARY_VIEW) === "true";
     },
 
     getUtilityViewSummary() {
-        return localStorage.getItem(C.UTILITY_SUMMARY_VIEW) || false;
+        return localStorage.getItem(C.UTILITY_SUMMARY_VIEW) === "true";
     },
 
     getEfficacyViewSummary() {
-        return localStorage.getItem(C.EFFICACY_SUMMARY_VIEW) || false;
+        return localStorage.getItem(C.EFFICACY_SUMMARY_VIEW) === "true";
     },
 
     getCurriculumTitle() {
@@ -108,7 +124,7 @@ const Repository = {
     },
 
     getFinishAddingEfficacyStudies() {
-        return localStorage.getItem("finishAddingEfficacyStudies");
+        return localStorage.getItem("finishAddingEfficacyStudies") === "true";
     },
 
     getDistinctiveCompletedDate() {
@@ -160,6 +176,26 @@ const Repository = {
     saveNumberFinalSummaryViews(component, count) {
         localStorage.setItem("numberFinalSummaryViews", count);
         component.setState({numberFinalSummaryViews: count});
+    },
+
+    saveContentShowErrors(component, value) {
+        localStorage.setItem(C.CONTENT_SHOW_ERRORS, value);
+        component.setState({contentShowErrors: value});
+    },
+    
+    saveQualityShowErrors(component, value) {
+        localStorage.setItem(C.QUALITY_SHOW_ERRORS, value);
+        component.setState({qualityShowErrors: value});
+    },
+    
+    saveUtilityShowErrors(component, value) {
+        localStorage.setItem(C.UTILITY_SHOW_ERRORS, value);
+        component.setState({utilityShowErrors: value});
+    },
+    
+    saveEfficacyShowErrors(component, value) {
+        localStorage.setItem(C.EFFICACY_SHOW_ERRORS, value);
+        component.setState({efficacyShowErrors: value});
     },
 
     /*

--- a/teachers_digital_platform/crtool/src/js/business.logic/summary/efficacyCalculationService.js
+++ b/teachers_digital_platform/crtool/src/js/business.logic/summary/efficacyCalculationService.js
@@ -102,6 +102,20 @@ const EfficacyCalculationService = {
         return false;
     },
 
+    /*
+     * We need to know if a study exists that was started but not finished
+     */
+    unfinishedEfficacyStudyExists() {
+        let criterionScores = Repository.getCriterionScores(); // component.state does not reflect current change
+        for (var score in criterionScores) {
+            if (score.indexOf("efficacy-crt-1") >= 0 && criterionScores[score].answered_all_complete === false) {
+                return true;
+            }
+        }
+
+        return false;
+    },
+
     scoreScoeOfEvidenceIsLarge(component, hasTwoStrongStudies) {
         let criterionScore = component.state.criterionScores["efficacy-crt-2"];
         if (criterionScore === undefined) {

--- a/teachers_digital_platform/crtool/src/js/components/CustomerReviewToolComponent.js
+++ b/teachers_digital_platform/crtool/src/js/components/CustomerReviewToolComponent.js
@@ -13,7 +13,7 @@ import PrintAndSummaryPages from "./pages/PrintAndSummaryPages";
 import DateTimeFormater from "../business.logic/dateTimeFormatter";
 import Repository from "../business.logic/repository";
 import CriterionService from "../business.logic/criterionService";
-import efficacyCalculationService from "../business.logic/summary/efficacyCalculationService";
+import EfficacyCalculationService from "../business.logic/summary/efficacyCalculationService";
 
 export default class CustomerReviewToolComponent extends React.Component {
     constructor() {
@@ -31,6 +31,11 @@ export default class CustomerReviewToolComponent extends React.Component {
             qualityIsDone: Repository.getQualityIsDone(),
             utilityIsDone: Repository.getUtilityIsDone(),
             efficacyIsDone: Repository.getEfficacyIsDone(),
+
+            contentShowErrors: Repository.getContentShowErrors(),
+            qualityShowErrors: Repository.getQualityShowErrors(),
+            utilityShowErrors: Repository.getUtilityShowErrors(),
+            efficacyShowErrors: Repository.getEfficacyShowErrors(),
 
             contentIsSummaryView: Repository.getContentViewSummary(),
             qualityIsSummaryView: Repository.getQualityViewSummary(),
@@ -203,15 +208,76 @@ export default class CustomerReviewToolComponent extends React.Component {
         return "not reviewed";
     }
 
+    showErrorsForCurrentPage() {
+        if ( (this.state.currentPage === C.CONTENT_PAGE && this.state.contentShowErrors) ||
+             (this.state.currentPage === C.QUALITY_PAGE && this.state.qualityShowErrors)  ||
+             (this.state.currentPage === C.UTILITY_PAGE && this.state.utilityShowErrors)  ||
+             (this.state.currentPage === C.EFFICACY_PAGE && this.state.efficacyShowErrors) ) {
+            return true;
+        }
+
+        return false;
+    }
+
+    currentDimensionHasErrors() {
+        if (this.state.currentPage === C.EFFICACY_PAGE && this.efficacyDimensionHasErrors()) {
+            return true;
+        }
+
+        if ( (this.state.currentPage === C.CONTENT_PAGE && this.state.contentInProgress === C.STATUS_COMPLETE)  ||
+             (this.state.currentPage === C.QUALITY_PAGE && this.state.qualityInProgress === C.STATUS_COMPLETE)  ||
+             (this.state.currentPage === C.UTILITY_PAGE && this.state.utilityInProgress === C.STATUS_COMPLETE)  ||
+             (this.state.currentPage === C.EFFICACY_PAGE && this.state.efficacyInProgress === C.STATUS_COMPLETE) ) {
+            return false;
+        }
+
+        return true;
+    }
+
+    efficacyDimensionHasErrors() {
+        // If any studies are started but not completed it has errors
+        // If two strong studies exist and criterion 2 or 3 are not complete it has errors
+        return false;
+    }
+
     handleSummaryButtonClick() {
-        this.setDistinctiveCompletionDateNow(this.state.currentPage);
-        Repository.setDistinctiveDoneStatus(this, this.state.currentPage);
-        Repository.setDistinctiveStatus(this, this.state.currentPage, C.STATUS_COMPLETE);
-        this.setDimensionSummaryView(this.state.currentPage, true, "");
+        if (this.currentDimensionHasErrors()) {
+            if (this.state.currentPage === C.CONTENT_PAGE) {
+                Repository.saveContentShowErrors(this, true);
+            } else if (this.state.currentPage === C.QUALITY_PAGE) {
+                Repository.saveQualityShowErrors(this, true);
+            } else if (this.state.currentPage === C.UTILITY_PAGE) {
+                Repository.saveUtilityShowErrors(this, true);
+            } else if (this.state.currentPage === C.EFFICACY_PAGE) {
+                Repository.saveEfficacyShowErrors(this, true);
+            }
+            
+            this.handleSummaryButtonClickPostEvent(true);
+        } else {   
+            this.setDistinctiveCompletionDateNow(this.state.currentPage);
+            Repository.setDistinctiveDoneStatus(this, this.state.currentPage);
+            Repository.setDistinctiveStatus(this, this.state.currentPage, C.STATUS_COMPLETE);
+            this.setDimensionSummaryView(this.state.currentPage, true, "");
+            
+            this.handleSummaryButtonClickPostEvent(false);
+        }
 
         //Analytics click on "continue to {{dimension}} summary"
         let label = "Continue to " + this.state.currentPage.toLowerCase() + " summary"
         Analytics.sendEvent(Analytics.getDataLayerOptions("button clicked", label));
+    }
+
+    handleSummaryButtonClickPostEvent(hasErrors) {
+        //HACK: need to scroll to top of screen after we navigate.
+        setTimeout(function(){
+            let element = document.getElementById("main");
+
+            if (hasErrors) {
+                element = document.getElementById("form-level-errror-messaging");
+            }
+
+            element.scrollIntoView();
+        }, 100);
     }
 
     initializeStudyAnsers(key, study) {
@@ -233,6 +299,10 @@ export default class CustomerReviewToolComponent extends React.Component {
         CriterionService.handleFinishAddingEfficacyStudies(this, value);
         var numberOfStudies = this.state.criterionEfficacyStudies.length;
 
+        if (EfficacyCalculationService.unfinishedEfficacyStudyExists()) {
+            this.handleSummaryButtonClickPostEvent(true);
+        }
+
         //Analytics I'm done reviewing studies
         Analytics.sendEvent(Analytics.getDataLayerOptions("I am done reviewing studies", "Number of studies: " + numberOfStudies));
 
@@ -240,7 +310,7 @@ export default class CustomerReviewToolComponent extends React.Component {
         Analytics.sendEvent(Analytics.getDataLayerOptions("completed criterion", "Efficacy: 1"));  
 
         //Analytics individual study scores
-        Analytics.sendEvent(Analytics.getDataLayerOptions("study scores", efficacyCalculationService.getAllEfficacyStudyScoresForAnalytics(this)));
+        Analytics.sendEvent(Analytics.getDataLayerOptions("study scores", EfficacyCalculationService.getAllEfficacyStudyScoresForAnalytics(this)));
     }
 
     removeEfficacyStudy(efficacyStudyNumber) {
@@ -333,6 +403,11 @@ export default class CustomerReviewToolComponent extends React.Component {
             utilityIsDone:this.state.utilityIsDone,
             efficacyIsDone:this.state.efficacyIsDone,
 
+            contentShowErrors:this.state.contentShowErrors,
+            qualityShowErrors:this.state.qualityShowErrors,
+            utilityShowErrors:this.state.utilityShowErrors,
+            efficacyShowErrors:this.state.efficacyShowErrors,
+
             contentIsSummaryView:this.state.contentIsSummaryView,
             utilityIsSummaryView:this.state.utilityIsSummaryView,
             qualityIsSummaryView:this.state.qualityIsSummaryView,
@@ -348,6 +423,7 @@ export default class CustomerReviewToolComponent extends React.Component {
             criterionCompletionStatuses:this.state.criterionCompletionStatuses,
             finalSummaryShowEntireReview:this.state.finalSummaryShowEntireReview,
 
+            showErrorsForCurrentPage:this.showErrorsForCurrentPage.bind(this),
             sendAnalyticsForLinkClick:this.sendAnalyticsForLinkClick.bind(this),
             handleSummaryButtonClick:this.handleSummaryButtonClick.bind(this),
             handleFinalSummaryButtonClick:this.handleFinalSummaryButtonClick.bind(this),

--- a/teachers_digital_platform/crtool/src/js/components/buttons/RadioButtonEditable.js
+++ b/teachers_digital_platform/crtool/src/js/components/buttons/RadioButtonEditable.js
@@ -3,7 +3,7 @@ import React from "react";
 export default class RadioButtonEditable extends React.Component {
 
     generateUniqueId() {
-        return this.props.currentCriterionRefId + "_" + this.props.uniqueId;
+        return this.props.currentCriterionRefId.replace("_beneficial", "") + this.props.uniqueId;
     }
 
     render() {

--- a/teachers_digital_platform/crtool/src/js/components/buttons/SummaryButton.js
+++ b/teachers_digital_platform/crtool/src/js/components/buttons/SummaryButton.js
@@ -6,12 +6,6 @@ export default class SummaryButton extends React.Component {
 
     handleSummaryButtonClick() {
         this.props.handleSummaryButtonClick();
-
-        //HACK: need to scroll to top of screen after we navigate.
-        setTimeout(function(){
-            let main = document.getElementById("main");
-            main.scrollIntoView();
-        }, 100);
     }
 
     render() {
@@ -41,11 +35,24 @@ export default class SummaryButton extends React.Component {
                 </button>
             );
         } else {
-            return (
-                <button className="a-btn" disabled>
-                    Continue to {this.props.currentPage.toLowerCase()} summary
-                </button>
-            );
+            // Efficacy page will actually disable untill the "I'm done reviewing studies" is clicked
+            if (this.props.currentPage === C.EFFICACY_PAGE && 
+                (
+                    this.props.finishAddingEfficacyStudies !== true || 
+                    this.props.finishAddingEfficacyStudies === null
+                )) {
+                return (
+                    <button className="a-btn" disabled>
+                        Continue to {this.props.currentPage.toLowerCase()} summary
+                    </button>
+                );
+            } else {
+                return (
+                    <button className="a-btn" onClick={(e) => {this.handleSummaryButtonClick()}} >
+                        Continue to {this.props.currentPage.toLowerCase()} summary
+                    </button>
+                );
+            }
         }
     }
 }

--- a/teachers_digital_platform/crtool/src/js/components/common/EfficacyStudyNameComponent.js
+++ b/teachers_digital_platform/crtool/src/js/components/common/EfficacyStudyNameComponent.js
@@ -1,0 +1,52 @@
+import React from "react";
+
+import FieldLevelErrorMessageComponent from "./FieldLevelErrorMessageComponent";
+
+export default class EfficacyStudyNameComponent extends React.Component {
+
+    getFieldId() {
+        return "error-message-" + this.props.fieldId
+    }
+
+    fieldMissingValue() {
+        return this.props.studyAnswers[this.props.studyCount][this.props.generateStudyRefId("", "study")] === undefined || this.props.studyAnswers[this.props.studyCount][this.props.generateStudyRefId("", "study")] === '';
+    }
+
+    render() {
+        if (this.props.showErrorsForCurrentPage() && this.fieldMissingValue()) {
+            return (
+                <div className="m-form-field m-form-field__text m-form-field__error">
+                    <label className="a-label a-label__heading" for={this.props.generateStudyRefId("", "study")}>
+                        Study name
+                        <small className="a-label_helper a-label_helper__block">
+                            Enter name of study you’re reviewing
+                        </small>
+                    </label>
+                    <input className="a-text-input a-text-input__full a-text-input__error" type="text"
+                        id={this.props.generateStudyRefId("", "study")}
+                        ref={this.props.generateStudyRefId("", "study")}
+                        defaultValue={this.props.studyAnswers[this.props.studyCount][this.props.generateStudyRefId("", "study")]}
+                        onBlur={e=>this.props.criterionStudyAnswerChanged(this.props.generateStudyRefId("", "study"), e.target.value)} 
+                        aria-describedby="error-message-quality-crt-text-optional-1.1.1" />
+                        <FieldLevelErrorMessageComponent fieldId="quality-crt-text-optional-1.1.1" {...this.props} />
+                </div>
+            );
+        } else {
+            return (
+                <div className="m-form-field m-form-field__text">
+                    <label className="a-label a-label__heading" for={this.props.generateStudyRefId("", "study")}>
+                        Study name
+                        <small className="a-label_helper a-label_helper__block">
+                            Enter name of study you’re reviewing
+                        </small>
+                    </label>
+                    <input className="a-text-input a-text-input__full" type="text"
+                        id={this.props.generateStudyRefId("", "study")}
+                        ref={this.props.generateStudyRefId("", "study")}
+                        defaultValue={this.props.studyAnswers[this.props.studyCount][this.props.generateStudyRefId("", "study")]}
+                        onBlur={e=>this.props.criterionStudyAnswerChanged(this.props.generateStudyRefId("", "study"), e.target.value)} />
+                </div>
+            );
+        }
+    }
+}

--- a/teachers_digital_platform/crtool/src/js/components/common/FieldLevelErrorMessageComponent.js
+++ b/teachers_digital_platform/crtool/src/js/components/common/FieldLevelErrorMessageComponent.js
@@ -1,0 +1,29 @@
+import React from "react";
+
+import SvgIcon from "../svgs/SvgIcon";
+
+export default class FieldLevelErrorMessageComponent extends React.Component {
+
+    getFieldId() {
+        return "error-message-" + this.props.fieldId
+    }
+
+    fieldMissingValue() {
+        return this.props.criterionAnswers[this.props.fieldId] === undefined || this.props.criterionAnswers[this.props.fieldId] === '';
+    }
+
+    render() {
+        if (this.props.showErrorsForCurrentPage() && this.fieldMissingValue()) {
+            return (
+                <div class="a-error-message" id={this.getFieldId()} role="alert">
+                    <SvgIcon
+                        icon="x-round"
+                        hasSpaceAfter="true" />
+                    This is a required question, please answer.
+                </div>
+                );
+        } else {
+            return null;
+        }
+    }
+}

--- a/teachers_digital_platform/crtool/src/js/components/common/FormLevelErrrorMessageComponent.js
+++ b/teachers_digital_platform/crtool/src/js/components/common/FormLevelErrrorMessageComponent.js
@@ -1,0 +1,157 @@
+import React from "react";
+
+import C from "../../business.logic/constants";
+import SvgIcon from "../svgs/SvgIcon";
+import RequiredListItemLink from "../common/RequiredListItemLink";
+
+import { ContentElementaryCriterion } from "../../content_data/contentElementary";
+import { ContentMiddleCriterion } from "../../content_data/contentMiddle";
+import { ContentHighCriterion } from "../../content_data/contentHigh";
+import { QualityContent } from "../../content_data/qualityContent";
+import { UtilityContent } from "../../content_data/utilityContent";
+import { EfficacyContent } from "../../content_data/efficacyContent";
+import { EfficacyStudyContent } from "../../content_data/efficacyStudyContent";
+
+export default class FormLevelErrorMessageComponent extends React.Component {
+    getDimensionData() {
+        if (this.props.currentPage === C.CONTENT_PAGE) {
+            if (this.props.gradeRange === C.GRADE_ELEMENTARY) {
+                return ContentElementaryCriterion;
+            } else if (this.props.gradeRange === C.GRADE_MIDDLE) {
+                return ContentMiddleCriterion;
+            } else {
+                return ContentHighCriterion;
+            }
+        } else if (this.props.currentPage === C.QUALITY_PAGE) {
+            return QualityContent;
+        } else if (this.props.currentPage === C.UTILITY_PAGE) {
+            return UtilityContent;
+        } else if (this.props.currentPage === C.EFFICACY_PAGE) {
+            if (this.props.finishAddingEfficacyStudies === true) {
+                return EfficacyContent;   
+            } else {
+                return EfficacyStudyContent;
+            }
+        }
+    }
+
+    isEfficacyStudyRequiredIssues() {
+        if (this.props.currentPage === C.EFFICACY_PAGE && this.props.finishAddingEfficacyStudies !== true) {
+            return true;
+        }
+
+        return false;
+    }
+
+    getAllCriterionForCurrentPage() {
+        let content = this.getDimensionData();
+        let allCriterionObjects = [];
+
+        if (this.isEfficacyStudyRequiredIssues()) {
+            //Loop through each study
+            for (let studyKey in this.props.studyAnswers) {
+                // Manually add the Study Name field
+                let criterionKey = {criterionRefId: "efficacy-crt-question-#" + studyKey + "#study", componentText: "Study name" };
+                allCriterionObjects.push(criterionKey);
+
+                //Add all the other fields
+                this.pushAllCriterionIntoList(content, allCriterionObjects, studyKey)
+            }
+        } else {
+            this.pushAllCriterionIntoList(content, allCriterionObjects)
+        }
+
+        return allCriterionObjects;
+    }
+
+    pushAllCriterionIntoList(content, allCriterionObjects, studyKey) {
+        // This looping structure is based on the content_data JSON objects.  They are all the same for each Dimension
+        let isEfficacyStudyIssues = this.isEfficacyStudyRequiredIssues();
+        for (let criterionNumber in content.criterion) {
+            for (let rowIndex in content.criterion[criterionNumber].rows) {
+                for (let componentIndex in content.criterion[criterionNumber].rows[rowIndex].components) {
+
+                    let cloneMe = content.criterion[criterionNumber].rows[rowIndex].components[componentIndex];
+                    let criterionObject = Object.assign({}, cloneMe); 
+                    if (isEfficacyStudyIssues) {
+                        let newCriterionRefId = criterionObject.criterionRefId.replace("_study_", studyKey);
+                        criterionObject.criterionRefId = newCriterionRefId;
+                    } 
+
+                    allCriterionObjects.push(criterionObject);
+                }
+            }
+        }
+    }
+
+    getMissingRequierdFields() {
+        let missingCriterion = []; 
+        let currentDimension = this.props.currentPage.toLowerCase();
+        let allCriterionForPage = this.getAllCriterionForCurrentPage();
+        let isEfficacyStudyIssues = this.isEfficacyStudyRequiredIssues();
+
+        if (isEfficacyStudyIssues) {
+            for (let studyKey in this.props.studyAnswers) {
+                let studyCriterionAnswers = this.props.studyAnswers[studyKey];
+                this.pushMissingRequiredFieldsOnToList(isEfficacyStudyIssues, missingCriterion, currentDimension, allCriterionForPage, studyCriterionAnswers, studyKey);
+            }
+
+        } else {
+            this.pushMissingRequiredFieldsOnToList(isEfficacyStudyIssues, missingCriterion, currentDimension, allCriterionForPage, this.props.criterionAnswers, 0);
+        }
+
+        return missingCriterion;
+    }
+
+    pushMissingRequiredFieldsOnToList(isEfficacyStudyIssues, missingCriterion, currentDimension, allCriterionForPage, answers, studyKey) {
+        for (let index in allCriterionForPage) {
+            let key = allCriterionForPage[index].criterionRefId;
+            let value = answers[key];
+
+            if (isEfficacyStudyIssues) {
+                if (key.indexOf(currentDimension) >= 0 && key.indexOf("optional") < 0 && key.indexOf("#" + studyKey + "#") > 0) {
+                    this.addToMissingList(missingCriterion, value, index, allCriterionForPage);
+                }
+            } else {
+                if (key.indexOf(currentDimension) >= 0 && key.indexOf("optional") < 0) {
+                    this.addToMissingList(missingCriterion, value, index, allCriterionForPage);
+                }
+            }
+        }
+    }
+
+    addToMissingList(missingCriterion, value, index,  allCriterionForPage) {
+        if (value === "" || value === null || value === undefined) {
+            missingCriterion.push(allCriterionForPage[index]);
+        }
+    }
+
+    render() {
+        let missingRequiredFields = this.getMissingRequierdFields();
+        if (missingRequiredFields.length > 0) {
+            return (
+                <div className="m-notification
+                        m-notification__visible
+                        m-notification__error
+                        u-mb30">
+                    <SvgIcon icon={C.ICON_X_ROUND} />
+                    <div className="m-notification_content">
+                        <div className="h4 m-notification_message">
+                            <p>The following form fields are incomplete or have errors:</p>
+                            <ul>
+                                {
+                                    missingRequiredFields.map(
+                                        (criterion, i) => 
+                                        <RequiredListItemLink key={i} {...this.props} criterion={criterion} isEfficacyStudyRequiredIssues={this.isEfficacyStudyRequiredIssues.bind(this)}/>
+                                    )
+                                }
+                            </ul>
+                        </div>
+                    </div>
+                </div>
+            );
+        } else {
+            return null;
+        }
+    }
+}

--- a/teachers_digital_platform/crtool/src/js/components/common/RequiredListItemLink.js
+++ b/teachers_digital_platform/crtool/src/js/components/common/RequiredListItemLink.js
@@ -1,0 +1,59 @@
+import React from "react";
+
+export default class RequiredListItemLink extends React.Component {
+    expandCriterionLinks(element, number, criterionKey) {        
+        if (number < 2) {
+            return;
+        }
+
+        let criterionLinkId = criterionKey + "-" + number;
+        this.props.setCriterionTitleLinkClicked(criterionLinkId);
+
+        return this.expandCriterionLinks(element, number -1, criterionKey);
+    }
+
+    scrollToRequiredCriterion() {
+        let elementId = this.props.criterion.criterionRefId.replace("_beneficial", "");
+        let element = document.getElementById(elementId + "a");
+
+        if (element === null) {
+            let criterionKey = elementId.substr(0, elementId.indexOf(".")-2);
+            let startIndx = elementId.indexOf(".") - 1;
+            let lastChar = elementId.substr(startIndx, startIndx);
+            let number = parseInt(lastChar, 10);
+
+            if (number) {
+                this.expandCriterionLinks(element, number, criterionKey)
+            }
+        }
+
+        let isEfficacyStudy = this.props.isEfficacyStudyRequiredIssues();
+
+        //HACK: need to scroll to element after criterion links are expanded.
+        setTimeout(function() {
+            let element = document.getElementById(elementId + "a");
+
+            if (isEfficacyStudy && elementId.indexOf("study") > 0) {
+                element = document.getElementById(elementId);
+            }
+
+            element.scrollIntoView();
+            window.scrollBy(0, -20);
+        }, 100, elementId, isEfficacyStudy);
+        
+    }
+
+    getComponentText() {
+        return (<div dangerouslySetInnerHTML={{__html: this.props.criterion.componentText}} />);
+    }
+
+    render() {
+        return (
+            <li>
+                <button className="a-btn__heading a-btn a-btn__link" data-gtm_ignore="true" onClick={(e) => {this.scrollToRequiredCriterion();}}>
+                    {this.getComponentText()}
+                </button>
+            </li>
+        );
+    }
+}

--- a/teachers_digital_platform/crtool/src/js/components/pages/CriterionLinkWrapper.js
+++ b/teachers_digital_platform/crtool/src/js/components/pages/CriterionLinkWrapper.js
@@ -18,13 +18,13 @@ export default class CriterionLinkWrapper extends React.Component {
 
     renderCriterionTitle() {
         if (this.props.hideCriterion) {
-            return (null);
+            return (<div id={this.props.criterionKey}></div>);
         }else if (this.props.criterionClickedTitles !== undefined &&
                   this.props.criterionClickedTitles[this.props.criterionKey] === "clicked") {
             return (this.props.children);
         }else {
             return(
-                <div className="block block__flush-top">
+                <div id={this.props.criterionKey} className="block block__flush-top">
                     <h3 className="h2">
                         <button className="a-btn
                                             a-btn__heading

--- a/teachers_digital_platform/crtool/src/js/components/pages/EfficacyCriterionPage.js
+++ b/teachers_digital_platform/crtool/src/js/components/pages/EfficacyCriterionPage.js
@@ -65,16 +65,16 @@ export default class EfficacyCriterionPage extends React.Component {
     }
 
     renderDoneAddingStoriesButton() {
-        if (this.props.finishAddingEfficacyStudies) {
+        if (this.props.finishAddingEfficacyStudies !== true) {
             return (
-                <button className="a-btn u-mb30" disabled >
+                <button className="a-btn u-mb30"
+                    onClick={() => this.props.handleFinishAddingEfficacyStudies(true)} >
                     I’m done reviewing studies
                 </button>
             );
         } else {
             return (
-                <button className="a-btn u-mb30"
-                    onClick={() => this.props.handleFinishAddingEfficacyStudies(true)} >
+                <button className="a-btn u-mb30" disabled >
                     I’m done reviewing studies
                 </button>
             );
@@ -82,7 +82,7 @@ export default class EfficacyCriterionPage extends React.Component {
     }
 
     renderWarningContinueWithout2and3() {
-        if (!this.props.finishAddingEfficacyStudies || this.twoStrongStudiesExist()) {
+        if (this.props.finishAddingEfficacyStudies !== true || this.twoStrongStudiesExist() === true) {
             return (null);
         } else {
             return (
@@ -153,7 +153,7 @@ export default class EfficacyCriterionPage extends React.Component {
                 <hr className="hr
                                 u-mb30
                                 u-mt30" />
-                <p className="u-mb60"><strong>All questions are required, unless otherwise noted.</strong></p>
+                {this.props.renderFormLevelErrorMessage()}
                 <div className="block block__flush-top" id="criterion_1">
                     <h2>
                         <SvgIcon

--- a/teachers_digital_platform/crtool/src/js/components/pages/EfficacyCriterionPage.js
+++ b/teachers_digital_platform/crtool/src/js/components/pages/EfficacyCriterionPage.js
@@ -161,6 +161,7 @@ export default class EfficacyCriterionPage extends React.Component {
                             color="green"
                             hasSpaceAfter="true" />
                         Criterion 1: Strength of study (inclusion criteria)
+                        {this.props.finishAddingEfficacyStudies && <span class="u-fc-gray"> (complete)</span>}
                     </h2>
                     <p className="lead-paragraph u-mb45 u-mt15">
                         Is the study strong? Only strong studies (those that meet rigorous standards) can be used to determine the efficacy of a curriculum. The inclusion criteria will help you determine whether or not a study meets these standards of a strong study.
@@ -203,6 +204,7 @@ export default class EfficacyCriterionPage extends React.Component {
                             color="green"
                             hasSpaceAfter="true" />
                         Criterion 2: Scope of evidence
+                        {this.props.criterionCompletionStatuses["efficacy-crt-question-2"] === C.ICON_CHECK_ROUND && <span class="u-fc-gray"> (complete)</span>}
                     </h2>
                     <p className="lead-paragraph u-mb45 u-mt15">
                         Is there enough evidence (when looking at all the strong studies as a whole) to support the research that this is an effective curriculum?
@@ -266,6 +268,7 @@ export default class EfficacyCriterionPage extends React.Component {
                             color="green"
                             hasSpaceAfter="true" />
                         Criterion 3: Impact
+                        {this.props.criterionCompletionStatuses["efficacy-crt-question-3"] === C.ICON_CHECK_ROUND && <span class="u-fc-gray"> (complete)</span>}
                     </h2>
                     <p className="lead-paragraph u-mb45 u-mt15">
                         Is there enough evidence to support conclusions of consistent, strong, positive impact?

--- a/teachers_digital_platform/crtool/src/js/components/pages/QualityCriterionPage.js
+++ b/teachers_digital_platform/crtool/src/js/components/pages/QualityCriterionPage.js
@@ -4,6 +4,7 @@ import C from "../../business.logic/constants";
 import SvgIcon from "../svgs/SvgIcon";
 import SaveWorkModal from "../dialogs/SaveWorkModal";
 import CriterionLinkWrapper from "./CriterionLinkWrapper";
+import FieldLevelErrorMessageComponent from "../common/FieldLevelErrorMessageComponent";
 
 export default class QualityCriterionPage extends React.Component {
     criterionAnswerChanged(key, checkedValue) {
@@ -64,7 +65,7 @@ export default class QualityCriterionPage extends React.Component {
                 <hr className="hr
                                 u-mb30
                                 u-mt30" />
-                <p className="u-mb60"><strong>All questions are required, unless otherwise noted.</strong></p>
+                {this.props.renderFormLevelErrorMessage()}
                 <div className="block block__flush-top" id="criterion_1">
                     <h2>
                         <SvgIcon
@@ -94,6 +95,9 @@ export default class QualityCriterionPage extends React.Component {
                                                 <p>If there are <strong>paper-based materials:</strong></p>
                                                 <p>Are paper-based materials available at no cost or for a clearly stated price?</p>
                                             </legend>
+
+
+
                                             <div className="m-form-field m-form-field__text u-mt30">
                                                 <label className="a-label a-label__heading" for="quality-crt-text-optional-1.1.1">
                                                     Cost of materials per student
@@ -138,6 +142,7 @@ export default class QualityCriterionPage extends React.Component {
                                             </div>
                                         </div>
                                     </div>
+                                    <FieldLevelErrorMessageComponent fieldId="quality-crt-question-1.1.1" {...this.props} />
                                 </fieldset>
                                 <fieldset className="o-survey_fieldset">
                                     <div className="o-survey_component">
@@ -192,6 +197,7 @@ export default class QualityCriterionPage extends React.Component {
                                             </div>
                                         </div>
                                     </div>
+                                    <FieldLevelErrorMessageComponent fieldId="quality-crt-question-1.1.2" {...this.props} />
                                 </fieldset>
                                 <fieldset className="o-survey_fieldset">
                                     <div className="o-survey_component">
@@ -258,6 +264,7 @@ export default class QualityCriterionPage extends React.Component {
                                             </div>
                                         </div>
                                     </div>
+                                    <FieldLevelErrorMessageComponent fieldId="quality-crt-question-1.1.3_beneficial" {...this.props} />
                                 </fieldset>
                             </div>
                         </li>
@@ -323,6 +330,7 @@ export default class QualityCriterionPage extends React.Component {
                                             </div>
                                         </div>
                                     </div>
+                                    <FieldLevelErrorMessageComponent fieldId="quality-crt-question-1.2.1" {...this.props} />
                                 </fieldset>
                                 <fieldset className="o-survey_fieldset">
                                     <div className="o-survey_component">
@@ -362,6 +370,7 @@ export default class QualityCriterionPage extends React.Component {
                                             </div>
                                         </div>
                                     </div>
+                                    <FieldLevelErrorMessageComponent fieldId="quality-crt-question-1.2.2" {...this.props} />
                                 </fieldset>
                             </div>
                         </li>
@@ -425,6 +434,7 @@ export default class QualityCriterionPage extends React.Component {
                                             </div>
                                         </div>
                                     </div>
+                                    <FieldLevelErrorMessageComponent fieldId="quality-crt-question-1.3.1_beneficial" {...this.props} />
                                 </fieldset>
                                 <fieldset className="o-survey_fieldset">
                                     <div className="o-survey_component">
@@ -476,6 +486,7 @@ export default class QualityCriterionPage extends React.Component {
                                             </div>
                                         </div>
                                     </div>
+                                    <FieldLevelErrorMessageComponent fieldId="quality-crt-question-1.3.2_beneficial" {...this.props} />
                                 </fieldset>
                             </div>
                         </li>
@@ -528,6 +539,7 @@ export default class QualityCriterionPage extends React.Component {
                                             </div>
                                         </div>
                                     </div>
+                                    <FieldLevelErrorMessageComponent fieldId="quality-crt-question-1.4_beneficial" {...this.props} />
                                 </fieldset>
                             </div>
                         </li>
@@ -613,6 +625,7 @@ export default class QualityCriterionPage extends React.Component {
                                             </div>
                                         </div>
                                     </div>
+                                    <FieldLevelErrorMessageComponent fieldId="quality-crt-question-2.1" {...this.props} />
                                 </fieldset>
                             </div>
                         </li>
@@ -664,6 +677,7 @@ export default class QualityCriterionPage extends React.Component {
                                             </div>
                                         </div>
                                     </div>
+                                    <FieldLevelErrorMessageComponent fieldId="quality-crt-question-2.2.1" {...this.props} />
                                 </fieldset>
                                 <fieldset className="o-survey_fieldset">
                                     <div className="o-survey_component">
@@ -703,6 +717,7 @@ export default class QualityCriterionPage extends React.Component {
                                             </div>
                                         </div>
                                     </div>
+                                    <FieldLevelErrorMessageComponent fieldId="quality-crt-question-2.2.2" {...this.props} />
                                 </fieldset>
                             </div>
                         </li>
@@ -754,6 +769,7 @@ export default class QualityCriterionPage extends React.Component {
                                             </div>
                                         </div>
                                     </div>
+                                    <FieldLevelErrorMessageComponent fieldId="quality-crt-question-2.3" {...this.props} />
                                 </fieldset>
                             </div>
                         </li>
@@ -839,6 +855,7 @@ export default class QualityCriterionPage extends React.Component {
                                             </div>
                                         </div>
                                     </div>
+                                    <FieldLevelErrorMessageComponent fieldId="quality-crt-question-3.1.1" {...this.props} />
                                 </fieldset>
                                 <fieldset className="o-survey_fieldset">
                                     <div className="o-survey_component">
@@ -878,6 +895,7 @@ export default class QualityCriterionPage extends React.Component {
                                             </div>
                                         </div>
                                     </div>
+                                    <FieldLevelErrorMessageComponent fieldId="quality-crt-question-3.1.2" {...this.props} />
                                 </fieldset>
                             </div>
                         </li>
@@ -929,6 +947,7 @@ export default class QualityCriterionPage extends React.Component {
                                             </div>
                                         </div>
                                     </div>
+                                    <FieldLevelErrorMessageComponent fieldId="quality-crt-question-3.2.1" {...this.props} />
                                 </fieldset>
                                 <fieldset className="o-survey_fieldset">
                                     <div className="o-survey_component">
@@ -968,6 +987,7 @@ export default class QualityCriterionPage extends React.Component {
                                             </div>
                                         </div>
                                     </div>
+                                    <FieldLevelErrorMessageComponent fieldId="quality-crt-question-3.2.2" {...this.props} />
                                 </fieldset>
                             </div>
                         </li>
@@ -1019,6 +1039,7 @@ export default class QualityCriterionPage extends React.Component {
                                             </div>
                                         </div>
                                     </div>
+                                    <FieldLevelErrorMessageComponent fieldId="quality-crt-question-3.3.1" {...this.props} />
                                 </fieldset>
                                 <fieldset className="o-survey_fieldset">
                                     <div className="o-survey_component">
@@ -1058,6 +1079,7 @@ export default class QualityCriterionPage extends React.Component {
                                             </div>
                                         </div>
                                     </div>
+                                    <FieldLevelErrorMessageComponent fieldId="quality-crt-question-3.3.2" {...this.props} />
                                 </fieldset>
                                 <fieldset className="o-survey_fieldset">
                                     <div className="o-survey_component">
@@ -1098,6 +1120,7 @@ export default class QualityCriterionPage extends React.Component {
                                             </div>
                                         </div>
                                     </div>
+                                    <FieldLevelErrorMessageComponent fieldId="quality-crt-question-3.3.3_beneficial" {...this.props} />
                                 </fieldset>
                             </div>
                         </li>
@@ -1183,6 +1206,7 @@ export default class QualityCriterionPage extends React.Component {
                                             </div>
                                         </div>
                                     </div>
+                                    <FieldLevelErrorMessageComponent fieldId="quality-crt-question-4.1.1" {...this.props} />
                                 </fieldset>
                                 <fieldset className="o-survey_fieldset">
                                     <div className="o-survey_component">
@@ -1222,6 +1246,7 @@ export default class QualityCriterionPage extends React.Component {
                                             </div>
                                         </div>
                                     </div>
+                                    <FieldLevelErrorMessageComponent fieldId="quality-crt-question-4.1.2" {...this.props} />
                                 </fieldset>
                                 <fieldset className="o-survey_fieldset">
                                     <div className="o-survey_component">
@@ -1261,6 +1286,7 @@ export default class QualityCriterionPage extends React.Component {
                                             </div>
                                         </div>
                                     </div>
+                                    <FieldLevelErrorMessageComponent fieldId="quality-crt-question-4.1.3" {...this.props} />
                                 </fieldset>
                                 <fieldset className="o-survey_fieldset">
                                     <div className="o-survey_component">
@@ -1300,6 +1326,7 @@ export default class QualityCriterionPage extends React.Component {
                                             </div>
                                         </div>
                                     </div>
+                                    <FieldLevelErrorMessageComponent fieldId="quality-crt-question-4.1.4" {...this.props} />
                                 </fieldset>
                             </div>
                         </li>
@@ -1351,6 +1378,7 @@ export default class QualityCriterionPage extends React.Component {
                                             </div>
                                         </div>
                                     </div>
+                                    <FieldLevelErrorMessageComponent fieldId="quality-crt-question-4.2.1" {...this.props} />
                                 </fieldset>
                                 <fieldset className="o-survey_fieldset">
                                     <div className="o-survey_component">
@@ -1390,6 +1418,7 @@ export default class QualityCriterionPage extends React.Component {
                                             </div>
                                         </div>
                                     </div>
+                                    <FieldLevelErrorMessageComponent fieldId="quality-crt-question-4.2.2" {...this.props} />
                                 </fieldset>
                                 <fieldset className="o-survey_fieldset">
                                     <div className="o-survey_component">
@@ -1429,6 +1458,7 @@ export default class QualityCriterionPage extends React.Component {
                                             </div>
                                         </div>
                                     </div>
+                                    <FieldLevelErrorMessageComponent fieldId="quality-crt-question-4.2.3" {...this.props} />
                                 </fieldset>
                                 <fieldset className="o-survey_fieldset">
                                     <div className="o-survey_component">
@@ -1468,6 +1498,7 @@ export default class QualityCriterionPage extends React.Component {
                                             </div>
                                         </div>
                                     </div>
+                                    <FieldLevelErrorMessageComponent fieldId="quality-crt-question-4.2.4" {...this.props} />
                                 </fieldset>
                             </div>
                         </li>
@@ -1498,7 +1529,6 @@ export default class QualityCriterionPage extends React.Component {
                                         u-mb30
                                         u-mt45" />
                 }
-                <p className="u-mb30"><strong>Be sure to answer all yes/no questions to continue.</strong></p>
             </React.Fragment>
         );
     }

--- a/teachers_digital_platform/crtool/src/js/components/pages/QualityCriterionPage.js
+++ b/teachers_digital_platform/crtool/src/js/components/pages/QualityCriterionPage.js
@@ -73,6 +73,7 @@ export default class QualityCriterionPage extends React.Component {
                             color="green"
                             hasSpaceAfter="true" />
                         Criterion 1: Accessibility
+                        {this.props.criterionCompletionStatuses["quality-crt-question-1"] === C.ICON_CHECK_ROUND && <span class="u-fc-gray"> (complete)</span>}
                     </h2>
                     <p className="lead-paragraph u-mb45 u-mt15">
                         Are curriculum materials physically accessible to teachers and students in a typical school setting?
@@ -572,6 +573,7 @@ export default class QualityCriterionPage extends React.Component {
                             color="green"
                             hasSpaceAfter="true" />
                         Criterion 2: Accuracy and timeliness
+                        {this.props.criterionCompletionStatuses["quality-crt-question-2"] === C.ICON_CHECK_ROUND && <span class="u-fc-gray"> (complete)</span>}
                     </h2>
                     <p className="lead-paragraph u-mb45 u-mt15">
                         Are curriculum materials current and free of error?
@@ -802,6 +804,7 @@ export default class QualityCriterionPage extends React.Component {
                             color="green"
                             hasSpaceAfter="true" />
                         Criterion 3: Objectivity
+                        {this.props.criterionCompletionStatuses["quality-crt-question-3"] === C.ICON_CHECK_ROUND && <span class="u-fc-gray"> (complete)</span>}
                     </h2>
                     <p className="lead-paragraph u-mb45 u-mt15">
                         Are the curriculum materials objective?
@@ -1153,6 +1156,7 @@ export default class QualityCriterionPage extends React.Component {
                             color="green"
                             hasSpaceAfter="true" />
                         Criterion 4: Visual appearance
+                        {this.props.criterionCompletionStatuses["quality-crt-question-4"] === C.ICON_CHECK_ROUND && <span class="u-fc-gray"> (complete)</span>}
                     </h2>
                     <p className="lead-paragraph u-mb45 u-mt15">
                         Is the visual appearance of the student materials conducive to learning?

--- a/teachers_digital_platform/crtool/src/js/components/pages/SurveyPageContainer.js
+++ b/teachers_digital_platform/crtool/src/js/components/pages/SurveyPageContainer.js
@@ -14,47 +14,65 @@ import QualitySummaryPage from "./QualitySummaryPage";
 import EfficacyCriterionPage from "./EfficacyCriterionPage";
 import EfficacySummaryPage from "./EfficacySummaryPage";
 import StartCriterionPage from "./StartCriterionPage";
+import FormLevelErrorMessageComponent from "../common/FormLevelErrrorMessageComponent";
 
 export default class SurveyPageContainer extends React.Component {
+    renderFormLevelErrorMessage() {
+        if (this.props.showErrorsForCurrentPage()) {
+            return (
+                <div id="form-level-errror-messaging">
+                    <FormLevelErrorMessageComponent {...this.props} />
+                </div>
+            );
+        } else {
+            return <div id="form-level-errror-messaging" ></div>;
+        }
+    }
+
     render() {
+        const applicationProps = {
+            ...this.props,
+            renderFormLevelErrorMessage:this.renderFormLevelErrorMessage.bind(this),
+        }
+
         if (this.props.currentPage === C.CONTENT_PAGE) {
             if (this.props.contentIsSummaryView === true) {
                 if (this.props.gradeRange === C.GRADE_ELEMENTARY) {
-                    return (<ContentElementarySummaryPage {...this.props} />);
+                    return (<ContentElementarySummaryPage {...applicationProps} />);
                 } else if (this.props.gradeRange === C.GRADE_MIDDLE) {
-                    return (<ContentMiddleSummaryPage {...this.props} />);
+                    return (<ContentMiddleSummaryPage {...applicationProps} />);
                 } else {
-                    return (<ContentHighSummaryPage {...this.props} />);
+                    return (<ContentHighSummaryPage {...applicationProps} />);
                 }
             } else {
                 if (this.props.gradeRange === C.GRADE_ELEMENTARY) {
-                    return (<ContentElementaryCriterionPage {...this.props} />);
+                    return (<ContentElementaryCriterionPage {...applicationProps} />);
                 } else if (this.props.gradeRange === C.GRADE_MIDDLE) {
-                    return (<ContentMiddleCriterionPage {...this.props} />);
+                    return (<ContentMiddleCriterionPage {...applicationProps} />);
                 } else {
-                    return (<ContentHighCriterionPage {...this.props} />);
+                    return (<ContentHighCriterionPage {...applicationProps} />);
                 }
             }
         } else if (this.props.currentPage === C.UTILITY_PAGE) {
             if (this.props.utilityIsSummaryView === true) {
-                return (<UtilitySummaryPage {...this.props} />);
+                return (<UtilitySummaryPage {...applicationProps} />);
             } else {
-                return (<UtilityCriterionPage {...this.props} /> );
+                return (<UtilityCriterionPage {...applicationProps} /> );
             }
         } else if (this.props.currentPage === C.QUALITY_PAGE) {
             if (this.props.qualityIsSummaryView === true) {
-                return (<QualitySummaryPage {...this.props} />);
+                return (<QualitySummaryPage {...applicationProps} />);
             } else {
-                return (<QualityCriterionPage {...this.props} />);
+                return (<QualityCriterionPage {...applicationProps} />);
             }
         } else if (this.props.currentPage === C.EFFICACY_PAGE) {
             if (this.props.efficacyIsSummaryView === true) {
-                return (<EfficacySummaryPage {...this.props} />);
+                return (<EfficacySummaryPage {...applicationProps} />);
             } else {
-                return (<EfficacyCriterionPage {...this.props} />);
+                return (<EfficacyCriterionPage {...applicationProps} />);
             }
         } else {
-            return (<StartCriterionPage  {...this.props} />);
+            return (<StartCriterionPage  {...applicationProps} />);
         }
     }
 }

--- a/teachers_digital_platform/crtool/src/js/components/pages/UtilityCriterionPage.js
+++ b/teachers_digital_platform/crtool/src/js/components/pages/UtilityCriterionPage.js
@@ -73,6 +73,7 @@ export default class UtilityCriterionPage extends React.Component {
                             color="green"
                             hasSpaceAfter="true" />
                         Criterion 1: Materials to support cognitive development
+                        {this.props.criterionCompletionStatuses["utility-crt-question-1"] === C.ICON_CHECK_ROUND && <span class="u-fc-gray"> (complete)</span>}
                     </h2>
                     <p className="lead-paragraph u-mb45 u-mt15">
                         Do the materials provide instructional suggestions designed to support the cognitive development of students’ financial capability?
@@ -555,6 +556,7 @@ export default class UtilityCriterionPage extends React.Component {
                             color="green"
                             hasSpaceAfter="true" />
                         Criterion 2: Differentiated instruction for diverse populations
+                        {this.props.criterionCompletionStatuses["utility-crt-question-2"] === C.ICON_CHECK_ROUND && <span class="u-fc-gray"> (complete)</span>}
                     </h2>
                     <p className="lead-paragraph u-mb45 u-mt15">
                         Do materials support engagement among a diverse population of students by providing suggestions to differentiate instruction, exercises, and activities? Consider students’ race, ethnicity, gender, socioeconomic circumstances, special education needs, and English language proficiency.
@@ -1526,6 +1528,7 @@ export default class UtilityCriterionPage extends React.Component {
                             color="green"
                             hasSpaceAfter="true" />
                         Criterion 3: Quality materials for lesson planning
+                        {this.props.criterionCompletionStatuses["utility-crt-question-3"] === C.ICON_CHECK_ROUND && <span class="u-fc-gray"> (complete)</span>}
                     </h2>
                     <p className="lead-paragraph u-mb45 u-mt15">
                         Do materials allow teachers to easily plan and deliver financial education instruction to students and integrate lessons into other subjects?
@@ -2183,6 +2186,7 @@ export default class UtilityCriterionPage extends React.Component {
                             color="green"
                             hasSpaceAfter="true" />
                         Criterion 4: Materials to assess mastery
+                        {this.props.criterionCompletionStatuses["utility-crt-question-4"] === C.ICON_CHECK_ROUND && <span class="u-fc-gray"> (complete)</span>}
                     </h3>
                     <p className="lead-paragraph u-mb45 u-mt15">
                         Do materials include a range of formative and summative assessments to support teaching and help teachers assess mastery?
@@ -2773,6 +2777,7 @@ export default class UtilityCriterionPage extends React.Component {
                             color="green"
                             hasSpaceAfter="true" />
                         Criterion 5: Instructional supports
+                        {this.props.criterionCompletionStatuses["utility-crt-question-5"] === C.ICON_CHECK_ROUND && <span class="u-fc-gray"> (complete)</span>}
                     </h3>
                     <p className="lead-paragraph u-mb45 u-mt15">
                         Are curriculum materials instructional for teachers, in terms of helping them provide clear and accurate financial education instruction to students?

--- a/teachers_digital_platform/crtool/src/js/components/pages/UtilityCriterionPage.js
+++ b/teachers_digital_platform/crtool/src/js/components/pages/UtilityCriterionPage.js
@@ -4,6 +4,7 @@ import C from "../../business.logic/constants";
 import SvgIcon from "../svgs/SvgIcon";
 import SaveWorkModal from "../dialogs/SaveWorkModal";
 import CriterionLinkWrapper from "./CriterionLinkWrapper";
+import FieldLevelErrorMessageComponent from "../common/FieldLevelErrorMessageComponent";
 
 export default class UtilityCriterionPage extends React.Component {
     criterionAnswerChanged(key, checkedValue) {
@@ -64,7 +65,7 @@ export default class UtilityCriterionPage extends React.Component {
                 <hr className="hr
                                 u-mb30
                                 u-mt30" />
-                <p className="u-mb60"><strong>All questions are required, unless otherwise noted.</strong></p>
+                {this.props.renderFormLevelErrorMessage()}
                 <div className="block block__flush-top" id="criterion_1">
                     <h2>
                         <SvgIcon
@@ -125,6 +126,7 @@ export default class UtilityCriterionPage extends React.Component {
                                             </div>
                                         </div>
                                     </div>
+                                    <FieldLevelErrorMessageComponent fieldId="utility-crt-question-1.1.1" {...this.props} />
                                 </fieldset>
                                 <fieldset className="o-survey_fieldset">
                                     <div className="o-survey_component">
@@ -164,6 +166,7 @@ export default class UtilityCriterionPage extends React.Component {
                                             </div>
                                         </div>
                                     </div>
+                                    <FieldLevelErrorMessageComponent fieldId="utility-crt-question-1.1.2" {...this.props} />
                                 </fieldset>
                                 <fieldset className="o-survey_fieldset">
                                     <div className="o-survey_component">
@@ -203,6 +206,7 @@ export default class UtilityCriterionPage extends React.Component {
                                             </div>
                                         </div>
                                     </div>
+                                    <FieldLevelErrorMessageComponent fieldId="utility-crt-question-1.1.3" {...this.props} />
                                 </fieldset>
                             </div>
                         </li>
@@ -254,6 +258,7 @@ export default class UtilityCriterionPage extends React.Component {
                                             </div>
                                         </div>
                                     </div>
+                                    <FieldLevelErrorMessageComponent fieldId="utility-crt-question-1.2.1" {...this.props} />
                                 </fieldset>
                                 <fieldset className="o-survey_fieldset">
                                     <div className="o-survey_component">
@@ -293,6 +298,7 @@ export default class UtilityCriterionPage extends React.Component {
                                             </div>
                                         </div>
                                     </div>
+                                    <FieldLevelErrorMessageComponent fieldId="utility-crt-question-1.2.2" {...this.props} />
                                 </fieldset>
                                 <fieldset className="o-survey_fieldset">
                                     <div className="o-survey_component">
@@ -332,6 +338,7 @@ export default class UtilityCriterionPage extends React.Component {
                                             </div>
                                         </div>
                                     </div>
+                                    <FieldLevelErrorMessageComponent fieldId="utility-crt-question-1.2.3" {...this.props} />
                                 </fieldset>
                                 <fieldset className="o-survey_fieldset">
                                     <div className="o-survey_component">
@@ -371,6 +378,7 @@ export default class UtilityCriterionPage extends React.Component {
                                             </div>
                                         </div>
                                     </div>
+                                    <FieldLevelErrorMessageComponent fieldId="utility-crt-question-1.2.4" {...this.props} />
                                 </fieldset>
                             </div>
                         </li>
@@ -422,6 +430,7 @@ export default class UtilityCriterionPage extends React.Component {
                                             </div>
                                         </div>
                                     </div>
+                                    <FieldLevelErrorMessageComponent fieldId="utility-crt-question-1.3.1" {...this.props} />
                                 </fieldset>
                                 <fieldset className="o-survey_fieldset">
                                     <div className="o-survey_component">
@@ -461,6 +470,7 @@ export default class UtilityCriterionPage extends React.Component {
                                             </div>
                                         </div>
                                     </div>
+                                    <FieldLevelErrorMessageComponent fieldId="utility-crt-question-1.3.2" {...this.props} />
                                 </fieldset>
                             </div>
                         </li>
@@ -512,6 +522,7 @@ export default class UtilityCriterionPage extends React.Component {
                                             </div>
                                         </div>
                                     </div>
+                                    <FieldLevelErrorMessageComponent fieldId="utility-crt-question-1.4" {...this.props} />
                                 </fieldset>
                             </div>
                         </li>
@@ -597,6 +608,7 @@ export default class UtilityCriterionPage extends React.Component {
                                             </div>
                                         </div>
                                     </div>
+                                    <FieldLevelErrorMessageComponent fieldId="utility-crt-question-2.1.1" {...this.props} />
                                 </fieldset>
                                 <fieldset className="o-survey_fieldset">
                                     <div className="o-survey_component">
@@ -636,6 +648,7 @@ export default class UtilityCriterionPage extends React.Component {
                                             </div>
                                         </div>
                                     </div>
+                                    <FieldLevelErrorMessageComponent fieldId="utility-crt-question-2.1.2" {...this.props} />
                                 </fieldset>
                                 <fieldset className="o-survey_fieldset">
                                     <div className="o-survey_component">
@@ -675,6 +688,7 @@ export default class UtilityCriterionPage extends React.Component {
                                             </div>
                                         </div>
                                     </div>
+                                    <FieldLevelErrorMessageComponent fieldId="utility-crt-question-2.1.3" {...this.props} />
                                 </fieldset>
                                 <fieldset className="o-survey_fieldset">
                                     <div className="o-survey_component">
@@ -714,6 +728,7 @@ export default class UtilityCriterionPage extends React.Component {
                                             </div>
                                         </div>
                                     </div>
+                                    <FieldLevelErrorMessageComponent fieldId="utility-crt-question-2.1.4" {...this.props} />
                                 </fieldset>
                                 <fieldset className="o-survey_fieldset">
                                     <div className="o-survey_component">
@@ -753,6 +768,7 @@ export default class UtilityCriterionPage extends React.Component {
                                             </div>
                                         </div>
                                     </div>
+                                    <FieldLevelErrorMessageComponent fieldId="utility-crt-question-2.1.5" {...this.props} />
                                 </fieldset>
                                 <fieldset className="o-survey_fieldset">
                                     <div className="o-survey_component">
@@ -792,6 +808,7 @@ export default class UtilityCriterionPage extends React.Component {
                                             </div>
                                         </div>
                                     </div>
+                                    <FieldLevelErrorMessageComponent fieldId="utility-crt-question-2.1.6" {...this.props} />
                                 </fieldset>
                                 <fieldset className="o-survey_fieldset">
                                     <div className="o-survey_component">
@@ -832,6 +849,7 @@ export default class UtilityCriterionPage extends React.Component {
                                             </div>
                                         </div>
                                     </div>
+                                    <FieldLevelErrorMessageComponent fieldId="utility-crt-question-2.1.7_beneficial" {...this.props} />
                                 </fieldset>
                                 <fieldset className="o-survey_fieldset">
                                     <div className="o-survey_component">
@@ -872,6 +890,7 @@ export default class UtilityCriterionPage extends React.Component {
                                             </div>
                                         </div>
                                     </div>
+                                    <FieldLevelErrorMessageComponent fieldId="utility-crt-question-2.1.8_beneficial" {...this.props} />
                                 </fieldset>
                                 <fieldset className="o-survey_fieldset">
                                     <div className="o-survey_component">
@@ -912,6 +931,7 @@ export default class UtilityCriterionPage extends React.Component {
                                             </div>
                                         </div>
                                     </div>
+                                    <FieldLevelErrorMessageComponent fieldId="utility-crt-question-2.1.9_beneficial" {...this.props} />
                                 </fieldset>
                                 <fieldset className="o-survey_fieldset">
                                     <div className="o-survey_component">
@@ -951,6 +971,7 @@ export default class UtilityCriterionPage extends React.Component {
                                             </div>
                                         </div>
                                     </div>
+                                    <FieldLevelErrorMessageComponent fieldId="utility-crt-question-2.1.10" {...this.props} />
                                 </fieldset>
                             </div>
                         </li>
@@ -1002,6 +1023,7 @@ export default class UtilityCriterionPage extends React.Component {
                                             </div>
                                         </div>
                                     </div>
+                                    <FieldLevelErrorMessageComponent fieldId="utility-crt-question-2.2.1" {...this.props} />
                                 </fieldset>
                                 <fieldset className="o-survey_fieldset">
                                     <div className="o-survey_component">
@@ -1041,6 +1063,7 @@ export default class UtilityCriterionPage extends React.Component {
                                             </div>
                                         </div>
                                     </div>
+                                    <FieldLevelErrorMessageComponent fieldId="utility-crt-question-2.2.2" {...this.props} />
                                 </fieldset>
                                 <fieldset className="o-survey_fieldset">
                                     <div className="o-survey_component">
@@ -1081,6 +1104,7 @@ export default class UtilityCriterionPage extends React.Component {
                                             </div>
                                         </div>
                                     </div>
+                                    <FieldLevelErrorMessageComponent fieldId="utility-crt-question-2.2.3_beneficial" {...this.props} />
                                 </fieldset>
                             </div>
                         </li>
@@ -1132,6 +1156,7 @@ export default class UtilityCriterionPage extends React.Component {
                                             </div>
                                         </div>
                                     </div>
+                                    <FieldLevelErrorMessageComponent fieldId="utility-crt-question-2.3.1" {...this.props} />
                                 </fieldset>
                                 <fieldset className="o-survey_fieldset">
                                     <div className="o-survey_component">
@@ -1171,6 +1196,7 @@ export default class UtilityCriterionPage extends React.Component {
                                             </div>
                                         </div>
                                     </div>
+                                    <FieldLevelErrorMessageComponent fieldId="utility-crt-question-2.3.2" {...this.props} />
                                 </fieldset>
                                 <fieldset className="o-survey_fieldset">
                                     <div className="o-survey_component">
@@ -1211,6 +1237,7 @@ export default class UtilityCriterionPage extends React.Component {
                                             </div>
                                         </div>
                                     </div>
+                                    <FieldLevelErrorMessageComponent fieldId="utility-crt-question-2.3.3_beneficial" {...this.props} />
                                 </fieldset>
                                 <fieldset className="o-survey_fieldset">
                                     <div className="o-survey_component">
@@ -1251,6 +1278,7 @@ export default class UtilityCriterionPage extends React.Component {
                                             </div>
                                         </div>
                                     </div>
+                                    <FieldLevelErrorMessageComponent fieldId="utility-crt-question-2.3.4_beneficial" {...this.props} />
                                 </fieldset>
                                 <fieldset className="o-survey_fieldset">
                                     <div className="o-survey_component">
@@ -1291,6 +1319,7 @@ export default class UtilityCriterionPage extends React.Component {
                                             </div>
                                         </div>
                                     </div>
+                                    <FieldLevelErrorMessageComponent fieldId="utility-crt-question-2.3.5_beneficial" {...this.props} />
                                 </fieldset>
                                 <fieldset className="o-survey_fieldset">
                                     <div className="o-survey_component">
@@ -1345,6 +1374,7 @@ export default class UtilityCriterionPage extends React.Component {
                                             </div>
                                         </div>
                                     </div>
+                                    <FieldLevelErrorMessageComponent fieldId="utility-crt-question-2.3.6_beneficial" {...this.props} />
                                 </fieldset>
                             </div>
                         </li>
@@ -1411,6 +1441,7 @@ export default class UtilityCriterionPage extends React.Component {
                                             </div>
                                         </div>
                                     </div>
+                                    <FieldLevelErrorMessageComponent fieldId="utility-crt-question-2.4_beneficial" {...this.props} />
                                 </fieldset>
                             </div>
                         </li>
@@ -1462,6 +1493,7 @@ export default class UtilityCriterionPage extends React.Component {
                                             </div>
                                         </div>
                                     </div>
+                                    <FieldLevelErrorMessageComponent fieldId="utility-crt-question-2.5" {...this.props} />
                                 </fieldset>
                             </div>
                         </li>
@@ -1547,6 +1579,7 @@ export default class UtilityCriterionPage extends React.Component {
                                             </div>
                                         </div>
                                     </div>
+                                    <FieldLevelErrorMessageComponent fieldId="utility-crt-question-3.1.1" {...this.props} />
                                 </fieldset>
                                 <fieldset className="o-survey_fieldset">
                                     <div className="o-survey_component">
@@ -1595,6 +1628,7 @@ export default class UtilityCriterionPage extends React.Component {
                                             </div>
                                         </div>
                                     </div>
+                                    <FieldLevelErrorMessageComponent fieldId="utility-crt-question-3.1.2" {...this.props} />
                                 </fieldset>
                                 <fieldset className="o-survey_fieldset">
                                     <div className="o-survey_component">
@@ -1634,6 +1668,7 @@ export default class UtilityCriterionPage extends React.Component {
                                             </div>
                                         </div>
                                     </div>
+                                    <FieldLevelErrorMessageComponent fieldId="utility-crt-question-3.1.3" {...this.props} />
                                 </fieldset>
                                 <fieldset className="o-survey_fieldset">
                                     <div className="o-survey_component">
@@ -1673,6 +1708,7 @@ export default class UtilityCriterionPage extends React.Component {
                                             </div>
                                         </div>
                                     </div>
+                                    <FieldLevelErrorMessageComponent fieldId="utility-crt-question-3.1.4" {...this.props} />
                                 </fieldset>
                                 <fieldset className="o-survey_fieldset">
                                     <div className="o-survey_component">
@@ -1712,6 +1748,7 @@ export default class UtilityCriterionPage extends React.Component {
                                             </div>
                                         </div>
                                     </div>
+                                    <FieldLevelErrorMessageComponent fieldId="utility-crt-question-3.1.5" {...this.props} />
                                 </fieldset>
                                 <fieldset className="o-survey_fieldset">
                                     <div className="o-survey_component">
@@ -1751,6 +1788,7 @@ export default class UtilityCriterionPage extends React.Component {
                                             </div>
                                         </div>
                                     </div>
+                                    <FieldLevelErrorMessageComponent fieldId="utility-crt-question-3.1.6" {...this.props} />
                                 </fieldset>
                                 <fieldset className="o-survey_fieldset">
                                     <div className="o-survey_component">
@@ -1791,6 +1829,7 @@ export default class UtilityCriterionPage extends React.Component {
                                             </div>
                                         </div>
                                     </div>
+                                    <FieldLevelErrorMessageComponent fieldId="utility-crt-question-3.1.7_beneficial" {...this.props} />
                                 </fieldset>
                             </div>
                         </li>
@@ -1843,6 +1882,7 @@ export default class UtilityCriterionPage extends React.Component {
                                             </div>
                                         </div>
                                     </div>
+                                    <FieldLevelErrorMessageComponent fieldId="utility-crt-question-3.2" {...this.props} />
                                 </fieldset>
                             </div>
                         </li>
@@ -1894,6 +1934,7 @@ export default class UtilityCriterionPage extends React.Component {
                                             </div>
                                         </div>
                                     </div>
+                                    <FieldLevelErrorMessageComponent fieldId="utility-crt-question-3.3.1" {...this.props} />
                                 </fieldset>
                                 <fieldset className="o-survey_fieldset">
                                     <div className="o-survey_component">
@@ -1934,6 +1975,7 @@ export default class UtilityCriterionPage extends React.Component {
                                             </div>
                                         </div>
                                     </div>
+                                    <FieldLevelErrorMessageComponent fieldId="utility-crt-question-3.3.2_beneficial" {...this.props} />
                                 </fieldset>
                                 <fieldset className="o-survey_fieldset">
                                     <div className="o-survey_component">
@@ -1988,6 +2030,7 @@ export default class UtilityCriterionPage extends React.Component {
                                             </div>
                                         </div>
                                     </div>
+                                    <FieldLevelErrorMessageComponent fieldId="utility-crt-question-3.3.3_beneficial" {...this.props} />
                                 </fieldset>
                             </div>
                         </li>
@@ -2040,6 +2083,7 @@ export default class UtilityCriterionPage extends React.Component {
                                             </div>
                                         </div>
                                     </div>
+                                    <FieldLevelErrorMessageComponent fieldId="utility-crt-question-3.4_beneficial" {...this.props} />
                                 </fieldset>
                             </div>
                         </li>
@@ -2106,6 +2150,7 @@ export default class UtilityCriterionPage extends React.Component {
                                             </div>
                                         </div>
                                     </div>
+                                    <FieldLevelErrorMessageComponent fieldId="utility-crt-question-3.5_beneficial" {...this.props} />
                                 </fieldset>
                             </div>
                         </li>
@@ -2191,6 +2236,7 @@ export default class UtilityCriterionPage extends React.Component {
                                             </div>
                                         </div>
                                     </div>
+                                    <FieldLevelErrorMessageComponent fieldId="utility-crt-question-4.1.1" {...this.props} />
                                 </fieldset>
                                 <fieldset className="o-survey_fieldset">
                                     <div className="o-survey_component">
@@ -2230,6 +2276,7 @@ export default class UtilityCriterionPage extends React.Component {
                                             </div>
                                         </div>
                                     </div>
+                                    <FieldLevelErrorMessageComponent fieldId="utility-crt-question-4.1.2" {...this.props} />
                                 </fieldset>
                                 <fieldset className="o-survey_fieldset">
                                     <div className="o-survey_component">
@@ -2270,6 +2317,7 @@ export default class UtilityCriterionPage extends React.Component {
                                             </div>
                                         </div>
                                     </div>
+                                    <FieldLevelErrorMessageComponent fieldId="utility-crt-question-4.1.3_beneficial" {...this.props} />
                                 </fieldset>
                             </div>
                         </li>
@@ -2321,6 +2369,7 @@ export default class UtilityCriterionPage extends React.Component {
                                             </div>
                                         </div>
                                     </div>
+                                    <FieldLevelErrorMessageComponent fieldId="utility-crt-question-4.2.1" {...this.props} />
                                 </fieldset>
                                 <fieldset className="o-survey_fieldset">
                                     <div className="o-survey_component">
@@ -2360,6 +2409,7 @@ export default class UtilityCriterionPage extends React.Component {
                                             </div>
                                         </div>
                                     </div>
+                                    <FieldLevelErrorMessageComponent fieldId="utility-crt-question-4.2.2" {...this.props} />
                                 </fieldset>
                             </div>
                         </li>
@@ -2412,6 +2462,7 @@ export default class UtilityCriterionPage extends React.Component {
                                             </div>
                                         </div>
                                     </div>
+                                    <FieldLevelErrorMessageComponent fieldId="utility-crt-question-4.3_beneficial" {...this.props} />
                                 </fieldset>
                             </div>
                         </li>
@@ -2463,6 +2514,7 @@ export default class UtilityCriterionPage extends React.Component {
                                             </div>
                                         </div>
                                     </div>
+                                    <FieldLevelErrorMessageComponent fieldId="utility-crt-question-4.4.1" {...this.props} />
                                 </fieldset>
                                 <fieldset className="o-survey_fieldset">
                                     <div className="o-survey_component">
@@ -2503,6 +2555,7 @@ export default class UtilityCriterionPage extends React.Component {
                                             </div>
                                         </div>
                                     </div>
+                                    <FieldLevelErrorMessageComponent fieldId="utility-crt-question-4.4.2_beneficial" {...this.props} />
                                 </fieldset>
                             </div>
                         </li>
@@ -2554,6 +2607,7 @@ export default class UtilityCriterionPage extends React.Component {
                                             </div>
                                         </div>
                                     </div>
+                                    <FieldLevelErrorMessageComponent fieldId="utility-crt-question-4.5.1" {...this.props} />
                                 </fieldset>
                                 <fieldset className="o-survey_fieldset">
                                     <div className="o-survey_component">
@@ -2593,6 +2647,7 @@ export default class UtilityCriterionPage extends React.Component {
                                             </div>
                                         </div>
                                     </div>
+                                    <FieldLevelErrorMessageComponent fieldId="utility-crt-question-4.5.2" {...this.props} />
                                 </fieldset>
                                 <fieldset className="o-survey_fieldset">
                                     <div className="o-survey_component">
@@ -2633,6 +2688,7 @@ export default class UtilityCriterionPage extends React.Component {
                                             </div>
                                         </div>
                                     </div>
+                                    <FieldLevelErrorMessageComponent fieldId="utility-crt-question-4.5.3_beneficial" {...this.props} />
                                 </fieldset>
                             </div>
                         </li>
@@ -2684,6 +2740,7 @@ export default class UtilityCriterionPage extends React.Component {
                                             </div>
                                         </div>
                                     </div>
+                                    <FieldLevelErrorMessageComponent fieldId="utility-crt-question-4.6" {...this.props} />
                                 </fieldset>
                             </div>
                         </li>
@@ -2769,6 +2826,7 @@ export default class UtilityCriterionPage extends React.Component {
                                             </div>
                                         </div>
                                     </div>
+                                    <FieldLevelErrorMessageComponent fieldId="utility-crt-question-5.1.1" {...this.props} />
                                 </fieldset>
                                 <fieldset className="o-survey_fieldset">
                                     <div className="o-survey_component">
@@ -2823,6 +2881,7 @@ export default class UtilityCriterionPage extends React.Component {
                                             </div>
                                         </div>
                                     </div>
+                                    <FieldLevelErrorMessageComponent fieldId="utility-crt-question-5.1.2_beneficial" {...this.props} />
                                 </fieldset>
                             </div>
                         </li>
@@ -2874,6 +2933,7 @@ export default class UtilityCriterionPage extends React.Component {
                                             </div>
                                         </div>
                                     </div>
+                                    <FieldLevelErrorMessageComponent fieldId="utility-crt-question-5.2.1" {...this.props} />
                                 </fieldset>
                                 <fieldset className="o-survey_fieldset">
                                     <div className="o-survey_component">
@@ -2914,6 +2974,7 @@ export default class UtilityCriterionPage extends React.Component {
                                             </div>
                                         </div>
                                     </div>
+                                    <FieldLevelErrorMessageComponent fieldId="utility-crt-question-5.2.2_beneficial" {...this.props} />
                                 </fieldset>
                                 <fieldset className="o-survey_fieldset">
                                     <div className="o-survey_component">
@@ -2968,6 +3029,7 @@ export default class UtilityCriterionPage extends React.Component {
                                             </div>
                                         </div>
                                     </div>
+                                    <FieldLevelErrorMessageComponent fieldId="utility-crt-question-5.2.3_beneficial" {...this.props} />
                                 </fieldset>
                             </div>
                         </li>
@@ -2999,7 +3061,6 @@ export default class UtilityCriterionPage extends React.Component {
                                         u-mb30
                                         u-mt45" />
                 }
-                <p className="u-mb30"><strong>Be sure to answer all yes/no questions to continue.</strong></p>
             </React.Fragment>
         );
     }

--- a/teachers_digital_platform/crtool/src/js/components/pages/content/ContentElementaryCriterionPage.js
+++ b/teachers_digital_platform/crtool/src/js/components/pages/content/ContentElementaryCriterionPage.js
@@ -69,6 +69,7 @@ export default class ContentElementaryCriterionPage extends React.Component {
                             color="green"
                             hasSpaceAfter="true" />
                         Criterion 1: Earning, income, and careers
+                        {this.props.criterionCompletionStatuses["content-elementary-crt-question-1"] === C.ICON_CHECK_ROUND && <span class="u-fc-gray"> (complete)</span>}
                     </h2>
                     <p className="lead-paragraph u-mb45 u-mt15">
                         Does the curriculum address grade-level appropriate topics for earning, income, and careers?
@@ -207,6 +208,7 @@ export default class ContentElementaryCriterionPage extends React.Component {
                             color="green"
                             hasSpaceAfter="true" />
                         Criterion 2: Saving and investing
+                        {this.props.criterionCompletionStatuses["content-elementary-crt-question-2"] === C.ICON_CHECK_ROUND && <span class="u-fc-gray"> (complete)</span>}
                     </h2>
                     <p className="lead-paragraph u-mb45 u-mt15">
                         Does the curriculum address grade-level appropriate topics for saving and investing?
@@ -437,6 +439,7 @@ export default class ContentElementaryCriterionPage extends React.Component {
                             color="green"
                             hasSpaceAfter="true" />
                         Criterion 3: Spending
+                        {this.props.criterionCompletionStatuses["content-elementary-crt-question-3"] === C.ICON_CHECK_ROUND && <span class="u-fc-gray"> (complete)</span>}
                     </h2>
                     <p className="lead-paragraph u-mb45 u-mt15">
                         Does the curriculum address grade-level appropriate topics for spending?
@@ -735,6 +738,7 @@ export default class ContentElementaryCriterionPage extends React.Component {
                             color="green"
                             hasSpaceAfter="true" />
                         Criterion 4: Borrowing and credit
+                        {this.props.criterionCompletionStatuses["content-elementary-crt-question-4"] === C.ICON_CHECK_ROUND && <span class="u-fc-gray"> (complete)</span>}
                     </h2>
                     <p className="lead-paragraph u-mb45 u-mt15">
                         Does the curriculum address grade-level appropriate topics for borrowing and credit?
@@ -861,6 +865,7 @@ export default class ContentElementaryCriterionPage extends React.Component {
                             color="green"
                             hasSpaceAfter="true" />
                         Criterion 5: Managing financial risk
+                        {this.props.criterionCompletionStatuses["content-elementary-crt-question-5"] === C.ICON_CHECK_ROUND && <span class="u-fc-gray"> (complete)</span>}
                     </h2>
                     <p className="lead-paragraph u-mb45 u-mt15">
                         Does the curriculum address grade-level appropriate topics for managing potential financial risk, including insurance?
@@ -987,6 +992,7 @@ export default class ContentElementaryCriterionPage extends React.Component {
                             color="green"
                             hasSpaceAfter="true" />
                         Criterion 6: Financial responsibility and money management
+                        {this.props.criterionCompletionStatuses["content-elementary-crt-question-6"] === C.ICON_CHECK_ROUND && <span class="u-fc-gray"> (complete)</span>}
                     </h2>
                     <p className="lead-paragraph u-mb45 u-mt15">
                         Does the curriculum address grade-level appropriate topics for financial responsibility, money management, and financial decisions?

--- a/teachers_digital_platform/crtool/src/js/components/pages/content/ContentElementaryCriterionPage.js
+++ b/teachers_digital_platform/crtool/src/js/components/pages/content/ContentElementaryCriterionPage.js
@@ -4,6 +4,7 @@ import C from "../../../business.logic/constants";
 import SvgIcon from "../../svgs/SvgIcon";
 import SaveWorkModal from "../../dialogs/SaveWorkModal";
 import CriterionLinkWrapper from "../CriterionLinkWrapper";
+import FieldLevelErrorMessageComponent from "../../common/FieldLevelErrorMessageComponent";
 
 export default class ContentElementaryCriterionPage extends React.Component {
     criterionAnswerChanged(key, checkedValue) {
@@ -60,7 +61,7 @@ export default class ContentElementaryCriterionPage extends React.Component {
                 <hr className="hr
                                 u-mb30
                                 u-mt30" />
-                <p className="u-mb60"><strong>All questions are required, unless otherwise noted.</strong></p>
+                {this.props.renderFormLevelErrorMessage()}
                 <div className="block block__flush-top" id="criterion_1">
                     <h2>
                         <SvgIcon
@@ -121,6 +122,7 @@ export default class ContentElementaryCriterionPage extends React.Component {
                                             </div>
                                         </div>
                                     </div>
+                                    <FieldLevelErrorMessageComponent fieldId="content-elementary-crt-question-1.1" {...this.props} />
                                 </fieldset>
                             </div>
                         </li>
@@ -172,6 +174,7 @@ export default class ContentElementaryCriterionPage extends React.Component {
                                             </div>
                                         </div>
                                     </div>
+                                    <FieldLevelErrorMessageComponent fieldId="content-elementary-crt-question-1.2" {...this.props} />
                                 </fieldset>
                             </div>
                         </li>
@@ -257,6 +260,7 @@ export default class ContentElementaryCriterionPage extends React.Component {
                                             </div>
                                         </div>
                                     </div>
+                                    <FieldLevelErrorMessageComponent fieldId="content-elementary-crt-question-2.1.1" {...this.props} />
                                 </fieldset>
                                 <fieldset className="o-survey_fieldset">
                                     <div className="o-survey_component">
@@ -296,6 +300,7 @@ export default class ContentElementaryCriterionPage extends React.Component {
                                             </div>
                                         </div>
                                     </div>
+                                    <FieldLevelErrorMessageComponent fieldId="content-elementary-crt-question-2.1.2" {...this.props} />
                                 </fieldset>
                             </div>
                         </li>
@@ -347,6 +352,7 @@ export default class ContentElementaryCriterionPage extends React.Component {
                                             </div>
                                         </div>
                                     </div>
+                                    <FieldLevelErrorMessageComponent fieldId="content-elementary-crt-question-2.2" {...this.props} />
                                 </fieldset>
                             </div>
                         </li>
@@ -398,6 +404,7 @@ export default class ContentElementaryCriterionPage extends React.Component {
                                             </div>
                                         </div>
                                     </div>
+                                    <FieldLevelErrorMessageComponent fieldId="content-elementary-crt-question-2.3" {...this.props} />
                                 </fieldset>
                             </div>
                         </li>
@@ -483,6 +490,7 @@ export default class ContentElementaryCriterionPage extends React.Component {
                                             </div>
                                         </div>
                                     </div>
+                                    <FieldLevelErrorMessageComponent fieldId="content-elementary-crt-question-3.1.1" {...this.props} />
                                 </fieldset>
                                 <fieldset className="o-survey_fieldset">
                                     <div className="o-survey_component">
@@ -522,6 +530,7 @@ export default class ContentElementaryCriterionPage extends React.Component {
                                             </div>
                                         </div>
                                     </div>
+                                    <FieldLevelErrorMessageComponent fieldId="content-elementary-crt-question-3.1.2" {...this.props} />
                                 </fieldset>
                             </div>
                         </li>
@@ -573,6 +582,7 @@ export default class ContentElementaryCriterionPage extends React.Component {
                                             </div>
                                         </div>
                                     </div>
+                                    <FieldLevelErrorMessageComponent fieldId="content-elementary-crt-question-3.2.1" {...this.props} />
                                 </fieldset>
                                 <fieldset className="o-survey_fieldset">
                                     <div className="o-survey_component">
@@ -612,6 +622,7 @@ export default class ContentElementaryCriterionPage extends React.Component {
                                             </div>
                                         </div>
                                     </div>
+                                    <FieldLevelErrorMessageComponent fieldId="content-elementary-crt-question-3.2.2" {...this.props} />
                                 </fieldset>
                                 <fieldset className="o-survey_fieldset">
                                     <div className="o-survey_component">
@@ -651,6 +662,7 @@ export default class ContentElementaryCriterionPage extends React.Component {
                                             </div>
                                         </div>
                                     </div>
+                                    <FieldLevelErrorMessageComponent fieldId="content-elementary-crt-question-3.2.3" {...this.props} />
                                 </fieldset>
                                 <fieldset className="o-survey_fieldset">
                                     <div className="o-survey_component">
@@ -690,6 +702,7 @@ export default class ContentElementaryCriterionPage extends React.Component {
                                             </div>
                                         </div>
                                     </div>
+                                    <FieldLevelErrorMessageComponent fieldId="content-elementary-crt-question-3.2.4" {...this.props} />
                                 </fieldset>
                             </div>
                         </li>
@@ -775,6 +788,7 @@ export default class ContentElementaryCriterionPage extends React.Component {
                                             </div>
                                         </div>
                                     </div>
+                                    <FieldLevelErrorMessageComponent fieldId="content-elementary-crt-question-4.1.1" {...this.props} />
                                 </fieldset>
                                 <fieldset className="o-survey_fieldset">
                                     <div className="o-survey_component">
@@ -814,6 +828,7 @@ export default class ContentElementaryCriterionPage extends React.Component {
                                             </div>
                                         </div>
                                     </div>
+                                    <FieldLevelErrorMessageComponent fieldId="content-elementary-crt-question-4.1.2" {...this.props} />
                                 </fieldset>
                             </div>
                         </li>
@@ -899,6 +914,7 @@ export default class ContentElementaryCriterionPage extends React.Component {
                                             </div>
                                         </div>
                                     </div>
+                                    <FieldLevelErrorMessageComponent fieldId="content-elementary-crt-question-5.1.1" {...this.props} />
                                 </fieldset>
                                 <fieldset className="o-survey_fieldset">
                                     <div className="o-survey_component">
@@ -938,6 +954,7 @@ export default class ContentElementaryCriterionPage extends React.Component {
                                             </div>
                                         </div>
                                     </div>
+                                    <FieldLevelErrorMessageComponent fieldId="content-elementary-crt-question-5.1.2" {...this.props} />
                                 </fieldset>
                             </div>
                         </li>
@@ -1023,6 +1040,7 @@ export default class ContentElementaryCriterionPage extends React.Component {
                                             </div>
                                         </div>
                                     </div>
+                                    <FieldLevelErrorMessageComponent fieldId="content-elementary-crt-question-6.1" {...this.props} />
                                 </fieldset>
                             </div>
                         </li>
@@ -1055,7 +1073,6 @@ export default class ContentElementaryCriterionPage extends React.Component {
                                         u-mb30
                                         u-mt45" />
                 }
-                <p className="u-mb30"><strong>Be sure to answer all yes/no questions to continue.</strong></p>
             </React.Fragment>
         );
 

--- a/teachers_digital_platform/crtool/src/js/components/pages/content/ContentHighCriterionPage.js
+++ b/teachers_digital_platform/crtool/src/js/components/pages/content/ContentHighCriterionPage.js
@@ -69,6 +69,7 @@ export default class ContentHighCriterionPage extends React.Component {
                             color="green"
                             hasSpaceAfter="true" />
                         Criterion 1: Earning, income, and careers
+                        {this.props.criterionCompletionStatuses["content-high-crt-question-1"] === C.ICON_CHECK_ROUND && <span class="u-fc-gray"> (complete)</span>}
                     </h2>
                     <p className="lead-paragraph u-mb45 u-mt15">
                         Does the curriculum address grade-level appropriate topics for earning, income, and careers?
@@ -367,6 +368,7 @@ export default class ContentHighCriterionPage extends React.Component {
                             color="green"
                             hasSpaceAfter="true" />
                         Criterion 2: Saving and investing
+                        {this.props.criterionCompletionStatuses["content-high-crt-question-2"] === C.ICON_CHECK_ROUND && <span class="u-fc-gray"> (complete)</span>}
                     </h2>
                     <p className="lead-paragraph u-mb45 u-mt15">
                         Does the curriculum address grade-level appropriate topics for saving and investing?
@@ -809,6 +811,7 @@ export default class ContentHighCriterionPage extends React.Component {
                             color="green"
                             hasSpaceAfter="true" />
                         Criterion 3: Spending
+                        {this.props.criterionCompletionStatuses["content-high-crt-question-3"] === C.ICON_CHECK_ROUND && <span class="u-fc-gray"> (complete)</span>}
                     </h2>
                     <p className="lead-paragraph u-mb45 u-mt15">
                         Does the curriculum address grade-level appropriate topics for spending?
@@ -1027,6 +1030,7 @@ export default class ContentHighCriterionPage extends React.Component {
                             color="green"
                             hasSpaceAfter="true" />
                         Criterion 4: Borrowing and credit
+                        {this.props.criterionCompletionStatuses["content-high-crt-question-4"] === C.ICON_CHECK_ROUND && <span class="u-fc-gray"> (complete)</span>}
                     </h2>
                     <p className="lead-paragraph u-mb45 u-mt15">
                         Does the curriculum address grade-level appropriate topics for borrowing and credit?
@@ -1497,6 +1501,7 @@ export default class ContentHighCriterionPage extends React.Component {
                             color="green"
                             hasSpaceAfter="true" />
                         Criterion 5: Managing financial risk
+                        {this.props.criterionCompletionStatuses["content-high-crt-question-5"] === C.ICON_CHECK_ROUND && <span class="u-fc-gray"> (complete)</span>}
                     </h2>
                     <p className="lead-paragraph u-mb45 u-mt15">
                         Does the curriculum address grade-level appropriate topics for managing potential financial risk, including insurance?
@@ -1847,6 +1852,7 @@ export default class ContentHighCriterionPage extends React.Component {
                             color="green"
                             hasSpaceAfter="true" />
                         Criterion 6: Financial responsibility and money management
+                        {this.props.criterionCompletionStatuses["content-high-crt-question-6"] === C.ICON_CHECK_ROUND && <span class="u-fc-gray"> (complete)</span>}
                     </h2>
                     <p className="lead-paragraph u-mb45 u-mt15">
                         Does the curriculum address grade-level appropriate topics for financial responsibility, money management, and financial decisions?

--- a/teachers_digital_platform/crtool/src/js/components/pages/content/ContentHighCriterionPage.js
+++ b/teachers_digital_platform/crtool/src/js/components/pages/content/ContentHighCriterionPage.js
@@ -4,6 +4,7 @@ import C from "../../../business.logic/constants";
 import SvgIcon from "../../svgs/SvgIcon";
 import SaveWorkModal from "../../dialogs/SaveWorkModal";
 import CriterionLinkWrapper from "../CriterionLinkWrapper";
+import FieldLevelErrorMessageComponent from "../../common/FieldLevelErrorMessageComponent";
 
 export default class ContentHighCriterionPage extends React.Component {
     criterionAnswerChanged(key, checkedValue) {
@@ -60,7 +61,7 @@ export default class ContentHighCriterionPage extends React.Component {
                 <hr className="hr
                                 u-mb30
                                 u-mt30" />
-                <p className="u-mb60"><strong>All questions are required, unless otherwise noted.</strong></p>
+                {this.props.renderFormLevelErrorMessage()}
                 <div className="block block__flush-top" id="criterion_1">
                     <h2>
                         <SvgIcon
@@ -121,6 +122,7 @@ export default class ContentHighCriterionPage extends React.Component {
                                             </div>
                                         </div>
                                     </div>
+                                    <FieldLevelErrorMessageComponent fieldId="content-high-crt-question-1.1" {...this.props} />
                                 </fieldset>
                             </div>
                         </li>
@@ -172,6 +174,7 @@ export default class ContentHighCriterionPage extends React.Component {
                                             </div>
                                         </div>
                                     </div>
+                                    <FieldLevelErrorMessageComponent fieldId="content-high-crt-question-1.2.1" {...this.props} />
                                 </fieldset>
                                 <fieldset className="o-survey_fieldset">
                                     <div className="o-survey_component">
@@ -211,6 +214,7 @@ export default class ContentHighCriterionPage extends React.Component {
                                             </div>
                                         </div>
                                     </div>
+                                    <FieldLevelErrorMessageComponent fieldId="content-high-crt-question-1.2.2" {...this.props} />
                                 </fieldset>
                                 <fieldset className="o-survey_fieldset">
                                     <div className="o-survey_component">
@@ -250,6 +254,7 @@ export default class ContentHighCriterionPage extends React.Component {
                                             </div>
                                         </div>
                                     </div>
+                                    <FieldLevelErrorMessageComponent fieldId="content-high-crt-question-1.2.3" {...this.props} />
                                 </fieldset>
                                 <fieldset className="o-survey_fieldset">
                                     <div className="o-survey_component">
@@ -289,6 +294,7 @@ export default class ContentHighCriterionPage extends React.Component {
                                             </div>
                                         </div>
                                     </div>
+                                    <FieldLevelErrorMessageComponent fieldId="content-high-crt-question-1.2.4" {...this.props} />
                                 </fieldset>
                                 <fieldset className="o-survey_fieldset">
                                     <div className="o-survey_component">
@@ -328,6 +334,7 @@ export default class ContentHighCriterionPage extends React.Component {
                                             </div>
                                         </div>
                                     </div>
+                                    <FieldLevelErrorMessageComponent fieldId="content-high-crt-question-1.2.5" {...this.props} />
                                 </fieldset>
                             </div>
                         </li>
@@ -413,6 +420,7 @@ export default class ContentHighCriterionPage extends React.Component {
                                             </div>
                                         </div>
                                     </div>
+                                    <FieldLevelErrorMessageComponent fieldId="content-high-crt-question-2.1.1" {...this.props} />
                                 </fieldset>
                                 <fieldset className="o-survey_fieldset">
                                     <div className="o-survey_component">
@@ -452,6 +460,7 @@ export default class ContentHighCriterionPage extends React.Component {
                                             </div>
                                         </div>
                                     </div>
+                                    <FieldLevelErrorMessageComponent fieldId="content-high-crt-question-2.1.2" {...this.props} />
                                 </fieldset>
                                 <fieldset className="o-survey_fieldset">
                                     <div className="o-survey_component">
@@ -491,6 +500,7 @@ export default class ContentHighCriterionPage extends React.Component {
                                             </div>
                                         </div>
                                     </div>
+                                    <FieldLevelErrorMessageComponent fieldId="content-high-crt-question-2.1.3" {...this.props} />
                                 </fieldset>
                                 <fieldset className="o-survey_fieldset">
                                     <div className="o-survey_component">
@@ -530,6 +540,7 @@ export default class ContentHighCriterionPage extends React.Component {
                                             </div>
                                         </div>
                                     </div>
+                                    <FieldLevelErrorMessageComponent fieldId="content-high-crt-question-2.1.4" {...this.props} />
                                 </fieldset>
                                 <fieldset className="o-survey_fieldset">
                                     <div className="o-survey_component">
@@ -569,6 +580,7 @@ export default class ContentHighCriterionPage extends React.Component {
                                             </div>
                                         </div>
                                     </div>
+                                    <FieldLevelErrorMessageComponent fieldId="content-high-crt-question-2.1.5" {...this.props} />
                                 </fieldset>
                             </div>
                         </li>
@@ -620,6 +632,7 @@ export default class ContentHighCriterionPage extends React.Component {
                                             </div>
                                         </div>
                                     </div>
+                                    <FieldLevelErrorMessageComponent fieldId="content-high-crt-question-2.2" {...this.props} />
                                 </fieldset>
                             </div>
                         </li>
@@ -671,6 +684,7 @@ export default class ContentHighCriterionPage extends React.Component {
                                             </div>
                                         </div>
                                     </div>
+                                    <FieldLevelErrorMessageComponent fieldId="content-high-crt-question-2.3" {...this.props} />
                                 </fieldset>
                             </div>
                         </li>
@@ -722,6 +736,7 @@ export default class ContentHighCriterionPage extends React.Component {
                                             </div>
                                         </div>
                                     </div>
+                                    <FieldLevelErrorMessageComponent fieldId="content-high-crt-question-2.4.1" {...this.props} />
                                 </fieldset>
                                 <fieldset className="o-survey_fieldset">
                                     <div className="o-survey_component">
@@ -761,6 +776,7 @@ export default class ContentHighCriterionPage extends React.Component {
                                             </div>
                                         </div>
                                     </div>
+                                    <FieldLevelErrorMessageComponent fieldId="content-high-crt-question-2.4.2" {...this.props} />
                                 </fieldset>
                             </div>
                         </li>
@@ -846,6 +862,7 @@ export default class ContentHighCriterionPage extends React.Component {
                                             </div>
                                         </div>
                                     </div>
+                                    <FieldLevelErrorMessageComponent fieldId="content-high-crt-question-3.1" {...this.props} />
                                 </fieldset>
                             </div>
                         </li>
@@ -897,6 +914,7 @@ export default class ContentHighCriterionPage extends React.Component {
                                             </div>
                                         </div>
                                     </div>
+                                    <FieldLevelErrorMessageComponent fieldId="content-high-crt-question-3.2.1" {...this.props} />
                                 </fieldset>
                                 <fieldset className="o-survey_fieldset">
                                     <div className="o-survey_component">
@@ -936,6 +954,7 @@ export default class ContentHighCriterionPage extends React.Component {
                                             </div>
                                         </div>
                                     </div>
+                                    <FieldLevelErrorMessageComponent fieldId="content-high-crt-question-3.2.2" {...this.props} />
                                 </fieldset>
                                 <fieldset className="o-survey_fieldset">
                                     <div className="o-survey_component">
@@ -975,6 +994,7 @@ export default class ContentHighCriterionPage extends React.Component {
                                             </div>
                                         </div>
                                     </div>
+                                    <FieldLevelErrorMessageComponent fieldId="content-high-crt-question-3.2.3" {...this.props} />
                                 </fieldset>
                             </div>
                         </li>
@@ -1060,6 +1080,7 @@ export default class ContentHighCriterionPage extends React.Component {
                                             </div>
                                         </div>
                                     </div>
+                                    <FieldLevelErrorMessageComponent fieldId="content-high-crt-question-4.1" {...this.props} />
                                 </fieldset>
                             </div>
                         </li>
@@ -1111,6 +1132,7 @@ export default class ContentHighCriterionPage extends React.Component {
                                             </div>
                                         </div>
                                     </div>
+                                    <FieldLevelErrorMessageComponent fieldId="content-high-crt-question-4.2.1" {...this.props} />
                                 </fieldset>
                                 <fieldset className="o-survey_fieldset">
                                     <div className="o-survey_component">
@@ -1150,6 +1172,7 @@ export default class ContentHighCriterionPage extends React.Component {
                                             </div>
                                         </div>
                                     </div>
+                                    <FieldLevelErrorMessageComponent fieldId="content-high-crt-question-4.2.2" {...this.props} />
                                 </fieldset>
                                 <fieldset className="o-survey_fieldset">
                                     <div className="o-survey_component">
@@ -1189,6 +1212,7 @@ export default class ContentHighCriterionPage extends React.Component {
                                             </div>
                                         </div>
                                     </div>
+                                    <FieldLevelErrorMessageComponent fieldId="content-high-crt-question-4.2.3" {...this.props} />
                                 </fieldset>
                                 <fieldset className="o-survey_fieldset">
                                     <div className="o-survey_component">
@@ -1228,6 +1252,7 @@ export default class ContentHighCriterionPage extends React.Component {
                                             </div>
                                         </div>
                                     </div>
+                                    <FieldLevelErrorMessageComponent fieldId="content-high-crt-question-4.2.4" {...this.props} />
                                 </fieldset>
                             </div>
                         </li>
@@ -1279,6 +1304,7 @@ export default class ContentHighCriterionPage extends React.Component {
                                             </div>
                                         </div>
                                     </div>
+                                    <FieldLevelErrorMessageComponent fieldId="content-high-crt-question-4.3.1" {...this.props} />
                                 </fieldset>
                                 <fieldset className="o-survey_fieldset">
                                     <div className="o-survey_component">
@@ -1318,6 +1344,7 @@ export default class ContentHighCriterionPage extends React.Component {
                                             </div>
                                         </div>
                                     </div>
+                                    <FieldLevelErrorMessageComponent fieldId="content-high-crt-question-4.3.2" {...this.props} />
                                 </fieldset>
                                 <fieldset className="o-survey_fieldset">
                                     <div className="o-survey_component">
@@ -1357,6 +1384,7 @@ export default class ContentHighCriterionPage extends React.Component {
                                             </div>
                                         </div>
                                     </div>
+                                    <FieldLevelErrorMessageComponent fieldId="content-high-crt-question-4.3.3" {...this.props} />
                                 </fieldset>
                                 <fieldset className="o-survey_fieldset">
                                     <div className="o-survey_component">
@@ -1396,6 +1424,7 @@ export default class ContentHighCriterionPage extends React.Component {
                                             </div>
                                         </div>
                                     </div>
+                                    <FieldLevelErrorMessageComponent fieldId="content-high-crt-question-4.3.4" {...this.props} />
                                 </fieldset>
                                 <fieldset className="o-survey_fieldset">
                                     <div className="o-survey_component">
@@ -1435,6 +1464,7 @@ export default class ContentHighCriterionPage extends React.Component {
                                             </div>
                                         </div>
                                     </div>
+                                    <FieldLevelErrorMessageComponent fieldId="content-high-crt-question-4.3.5" {...this.props} />
                                 </fieldset>
                             </div>
                         </li>
@@ -1520,6 +1550,7 @@ export default class ContentHighCriterionPage extends React.Component {
                                             </div>
                                         </div>
                                     </div>
+                                    <FieldLevelErrorMessageComponent fieldId="content-high-crt-question-5.1.1" {...this.props} />
                                 </fieldset>
                                 <fieldset className="o-survey_fieldset">
                                     <div className="o-survey_component">
@@ -1559,6 +1590,7 @@ export default class ContentHighCriterionPage extends React.Component {
                                             </div>
                                         </div>
                                     </div>
+                                    <FieldLevelErrorMessageComponent fieldId="content-high-crt-question-5.1.2" {...this.props} />
                                 </fieldset>
                                 <fieldset className="o-survey_fieldset">
                                     <div className="o-survey_component">
@@ -1598,6 +1630,7 @@ export default class ContentHighCriterionPage extends React.Component {
                                             </div>
                                         </div>
                                     </div>
+                                    <FieldLevelErrorMessageComponent fieldId="content-high-crt-question-5.1.3" {...this.props} />
                                 </fieldset>
                             </div>
                         </li>
@@ -1649,6 +1682,7 @@ export default class ContentHighCriterionPage extends React.Component {
                                             </div>
                                         </div>
                                     </div>
+                                    <FieldLevelErrorMessageComponent fieldId="content-high-crt-question-5.2.1" {...this.props} />
                                 </fieldset>
                                 <fieldset className="o-survey_fieldset">
                                     <div className="o-survey_component">
@@ -1688,6 +1722,7 @@ export default class ContentHighCriterionPage extends React.Component {
                                             </div>
                                         </div>
                                     </div>
+                                    <FieldLevelErrorMessageComponent fieldId="content-high-crt-question-5.2.2" {...this.props} />
                                 </fieldset>
                                 <fieldset className="o-survey_fieldset">
                                     <div className="o-survey_component">
@@ -1727,6 +1762,7 @@ export default class ContentHighCriterionPage extends React.Component {
                                             </div>
                                         </div>
                                     </div>
+                                    <FieldLevelErrorMessageComponent fieldId="content-high-crt-question-5.2.3" {...this.props} />
                                 </fieldset>
                             </div>
                         </li>
@@ -1778,6 +1814,7 @@ export default class ContentHighCriterionPage extends React.Component {
                                             </div>
                                         </div>
                                     </div>
+                                    <FieldLevelErrorMessageComponent fieldId="content-high-crt-question-5.3" {...this.props} />
                                 </fieldset>
                             </div>
                         </li>
@@ -1863,6 +1900,7 @@ export default class ContentHighCriterionPage extends React.Component {
                                             </div>
                                         </div>
                                     </div>
+                                    <FieldLevelErrorMessageComponent fieldId="content-high-crt-question-6.1.1" {...this.props} />
                                 </fieldset>
                                 <fieldset className="o-survey_fieldset">
                                     <div className="o-survey_component">
@@ -1902,6 +1940,7 @@ export default class ContentHighCriterionPage extends React.Component {
                                             </div>
                                         </div>
                                     </div>
+                                    <FieldLevelErrorMessageComponent fieldId="content-high-crt-question-6.1.2" {...this.props} />
                                 </fieldset>
                             </div>
                         </li>
@@ -1953,6 +1992,7 @@ export default class ContentHighCriterionPage extends React.Component {
                                             </div>
                                         </div>
                                     </div>
+                                    <FieldLevelErrorMessageComponent fieldId="content-high-crt-question-6.2" {...this.props} />
                                 </fieldset>
                             </div>
                         </li>
@@ -1985,7 +2025,6 @@ export default class ContentHighCriterionPage extends React.Component {
                                         u-mb30
                                         u-mt45" />
                 }
-                <p className="u-mb30"><strong>Be sure to answer all yes/no questions to continue.</strong></p>
             </React.Fragment>
         );
     }

--- a/teachers_digital_platform/crtool/src/js/components/pages/content/ContentMiddleCriterionPage.js
+++ b/teachers_digital_platform/crtool/src/js/components/pages/content/ContentMiddleCriterionPage.js
@@ -4,6 +4,7 @@ import C from "../../../business.logic/constants";
 import SvgIcon from "../../svgs/SvgIcon";
 import SaveWorkModal from "../../dialogs/SaveWorkModal";
 import CriterionLinkWrapper from "../CriterionLinkWrapper";
+import FieldLevelErrorMessageComponent from "../../common/FieldLevelErrorMessageComponent";
 
 export default class ContentMiddleCriterionPage extends React.Component {
     criterionAnswerChanged(key, checkedValue) {
@@ -60,7 +61,7 @@ export default class ContentMiddleCriterionPage extends React.Component {
                 <hr className="hr
                                 u-mb30
                                 u-mt30" />
-                <p className="u-mb60"><strong>All questions are required, unless otherwise noted.</strong></p>
+                {this.props.renderFormLevelErrorMessage()}
                 <div className="block block__flush-top" id="criterion_1">
                     <h2>
                         <SvgIcon
@@ -121,6 +122,7 @@ export default class ContentMiddleCriterionPage extends React.Component {
                                             </div>
                                         </div>
                                     </div>
+                                    <FieldLevelErrorMessageComponent fieldId="content-middle-crt-question-1.1" {...this.props} />
                                 </fieldset>
                             </div>
                         </li>
@@ -172,6 +174,7 @@ export default class ContentMiddleCriterionPage extends React.Component {
                                             </div>
                                         </div>
                                     </div>
+                                    <FieldLevelErrorMessageComponent fieldId="content-middle-crt-question-1.2.1" {...this.props} />
                                 </fieldset>
                                 <fieldset className="o-survey_fieldset">
                                     <div className="o-survey_component">
@@ -211,6 +214,7 @@ export default class ContentMiddleCriterionPage extends React.Component {
                                             </div>
                                         </div>
                                     </div>
+                                    <FieldLevelErrorMessageComponent fieldId="content-middle-crt-question-1.2.2" {...this.props} />
                                 </fieldset>
                             </div>
                         </li>
@@ -296,6 +300,7 @@ export default class ContentMiddleCriterionPage extends React.Component {
                                             </div>
                                         </div>
                                     </div>
+                                    <FieldLevelErrorMessageComponent fieldId="content-middle-crt-question-2.1.1" {...this.props} />
                                 </fieldset>
                                 <fieldset className="o-survey_fieldset">
                                     <div className="o-survey_component">
@@ -335,6 +340,7 @@ export default class ContentMiddleCriterionPage extends React.Component {
                                             </div>
                                         </div>
                                     </div>
+                                    <FieldLevelErrorMessageComponent fieldId="content-middle-crt-question-2.1.2" {...this.props} />
                                 </fieldset>
                             </div>
                         </li>
@@ -386,6 +392,7 @@ export default class ContentMiddleCriterionPage extends React.Component {
                                             </div>
                                         </div>
                                     </div>
+                                    <FieldLevelErrorMessageComponent fieldId="content-middle-crt-question-2.2.1" {...this.props} />
                                 </fieldset>
                                 <fieldset className="o-survey_fieldset">
                                     <div className="o-survey_component">
@@ -425,6 +432,7 @@ export default class ContentMiddleCriterionPage extends React.Component {
                                             </div>
                                         </div>
                                     </div>
+                                    <FieldLevelErrorMessageComponent fieldId="content-middle-crt-question-2.2.2" {...this.props} />
                                 </fieldset>
                             </div>
                         </li>
@@ -476,6 +484,7 @@ export default class ContentMiddleCriterionPage extends React.Component {
                                             </div>
                                         </div>
                                     </div>
+                                    <FieldLevelErrorMessageComponent fieldId="content-middle-crt-question-2.3.1" {...this.props} />
                                 </fieldset>
                                 <fieldset className="o-survey_fieldset">
                                     <div className="o-survey_component">
@@ -515,6 +524,7 @@ export default class ContentMiddleCriterionPage extends React.Component {
                                             </div>
                                         </div>
                                     </div>
+                                    <FieldLevelErrorMessageComponent fieldId="content-middle-crt-question-2.3.2" {...this.props} />
                                 </fieldset>
                             </div>
                         </li>
@@ -566,6 +576,7 @@ export default class ContentMiddleCriterionPage extends React.Component {
                                             </div>
                                         </div>
                                     </div>
+                                    <FieldLevelErrorMessageComponent fieldId="content-middle-crt-question-2.4.1" {...this.props} />
                                 </fieldset>
                                 <fieldset className="o-survey_fieldset">
                                     <div className="o-survey_component">
@@ -605,6 +616,7 @@ export default class ContentMiddleCriterionPage extends React.Component {
                                             </div>
                                         </div>
                                     </div>
+                                    <FieldLevelErrorMessageComponent fieldId="content-middle-crt-question-2.4.2" {...this.props} />
                                 </fieldset>
                             </div>
                         </li>
@@ -690,6 +702,7 @@ export default class ContentMiddleCriterionPage extends React.Component {
                                             </div>
                                         </div>
                                     </div>
+                                    <FieldLevelErrorMessageComponent fieldId="content-middle-crt-question-3.1" {...this.props} />
                                 </fieldset>
                             </div>
                         </li>
@@ -741,6 +754,7 @@ export default class ContentMiddleCriterionPage extends React.Component {
                                             </div>
                                         </div>
                                     </div>
+                                    <FieldLevelErrorMessageComponent fieldId="content-middle-crt-question-3.2.1" {...this.props} />
                                 </fieldset>
                                 <fieldset className="o-survey_fieldset">
                                     <div className="o-survey_component">
@@ -780,6 +794,7 @@ export default class ContentMiddleCriterionPage extends React.Component {
                                             </div>
                                         </div>
                                     </div>
+                                    <FieldLevelErrorMessageComponent fieldId="content-middle-crt-question-3.2.2" {...this.props} />
                                 </fieldset>
                                 <fieldset className="o-survey_fieldset">
                                     <div className="o-survey_component">
@@ -819,6 +834,7 @@ export default class ContentMiddleCriterionPage extends React.Component {
                                             </div>
                                         </div>
                                     </div>
+                                    <FieldLevelErrorMessageComponent fieldId="content-middle-crt-question-3.2.3" {...this.props} />
                                 </fieldset>
                                 <fieldset className="o-survey_fieldset">
                                     <div className="o-survey_component">
@@ -858,6 +874,7 @@ export default class ContentMiddleCriterionPage extends React.Component {
                                             </div>
                                         </div>
                                     </div>
+                                    <FieldLevelErrorMessageComponent fieldId="content-middle-crt-question-3.2.4" {...this.props} />
                                 </fieldset>
                             </div>
                         </li>
@@ -943,6 +960,7 @@ export default class ContentMiddleCriterionPage extends React.Component {
                                             </div>
                                         </div>
                                     </div>
+                                    <FieldLevelErrorMessageComponent fieldId="content-middle-crt-question-4.1" {...this.props} />
                                 </fieldset>
                             </div>
                         </li>
@@ -994,6 +1012,7 @@ export default class ContentMiddleCriterionPage extends React.Component {
                                             </div>
                                         </div>
                                     </div>
+                                    <FieldLevelErrorMessageComponent fieldId="content-middle-crt-question-4.2.1" {...this.props} />
                                 </fieldset>
                                 <fieldset className="o-survey_fieldset">
                                     <div className="o-survey_component">
@@ -1033,6 +1052,7 @@ export default class ContentMiddleCriterionPage extends React.Component {
                                             </div>
                                         </div>
                                     </div>
+                                    <FieldLevelErrorMessageComponent fieldId="content-middle-crt-question-4.2.2" {...this.props} />
                                 </fieldset>
                                 <fieldset className="o-survey_fieldset">
                                     <div className="o-survey_component">
@@ -1072,6 +1092,7 @@ export default class ContentMiddleCriterionPage extends React.Component {
                                             </div>
                                         </div>
                                     </div>
+                                    <FieldLevelErrorMessageComponent fieldId="content-middle-crt-question-4.2.3" {...this.props} />
                                 </fieldset>
                                 <fieldset className="o-survey_fieldset">
                                     <div className="o-survey_component">
@@ -1111,6 +1132,7 @@ export default class ContentMiddleCriterionPage extends React.Component {
                                             </div>
                                         </div>
                                     </div>
+                                    <FieldLevelErrorMessageComponent fieldId="content-middle-crt-question-4.2.4" {...this.props} />
                                 </fieldset>
                             </div>
                         </li>
@@ -1162,6 +1184,7 @@ export default class ContentMiddleCriterionPage extends React.Component {
                                             </div>
                                         </div>
                                     </div>
+                                    <FieldLevelErrorMessageComponent fieldId="content-middle-crt-question-4.3.1" {...this.props} />
                                 </fieldset>
                                 <fieldset className="o-survey_fieldset">
                                     <div className="o-survey_component">
@@ -1201,6 +1224,7 @@ export default class ContentMiddleCriterionPage extends React.Component {
                                             </div>
                                         </div>
                                     </div>
+                                    <FieldLevelErrorMessageComponent fieldId="content-middle-crt-question-4.3.2" {...this.props} />
                                 </fieldset>
                             </div>
                         </li>
@@ -1286,6 +1310,7 @@ export default class ContentMiddleCriterionPage extends React.Component {
                                             </div>
                                         </div>
                                     </div>
+                                    <FieldLevelErrorMessageComponent fieldId="content-middle-crt-question-5.1" {...this.props} />
                                 </fieldset>
                             </div>
                         </li>
@@ -1337,6 +1362,7 @@ export default class ContentMiddleCriterionPage extends React.Component {
                                             </div>
                                         </div>
                                     </div>
+                                    <FieldLevelErrorMessageComponent fieldId="content-middle-crt-question-5.2.1" {...this.props} />
                                 </fieldset>
                                 <fieldset className="o-survey_fieldset">
                                     <div className="o-survey_component">
@@ -1376,6 +1402,7 @@ export default class ContentMiddleCriterionPage extends React.Component {
                                             </div>
                                         </div>
                                     </div>
+                                    <FieldLevelErrorMessageComponent fieldId="content-middle-crt-question-5.2.2" {...this.props} />
                                 </fieldset>
                             </div>
                         </li>
@@ -1427,6 +1454,7 @@ export default class ContentMiddleCriterionPage extends React.Component {
                                             </div>
                                         </div>
                                     </div>
+                                    <FieldLevelErrorMessageComponent fieldId="content-middle-crt-question-5.3" {...this.props} />
                                 </fieldset>
                             </div>
                         </li>
@@ -1512,6 +1540,7 @@ export default class ContentMiddleCriterionPage extends React.Component {
                                             </div>
                                         </div>
                                     </div>
+                                    <FieldLevelErrorMessageComponent fieldId="content-middle-crt-question-6.1.1" {...this.props} />
                                 </fieldset>
                                 <fieldset className="o-survey_fieldset">
                                     <div className="o-survey_component">
@@ -1551,6 +1580,7 @@ export default class ContentMiddleCriterionPage extends React.Component {
                                             </div>
                                         </div>
                                     </div>
+                                    <FieldLevelErrorMessageComponent fieldId="content-middle-crt-question-6.1.2" {...this.props} />
                                 </fieldset>
                             </div>
                         </li>
@@ -1583,7 +1613,6 @@ export default class ContentMiddleCriterionPage extends React.Component {
                                         u-mb30
                                         u-mt45" />
                 }
-                <p className="u-mb30"><strong>Be sure to answer all yes/no questions to continue.</strong></p>
             </React.Fragment>
         );
     }

--- a/teachers_digital_platform/crtool/src/js/components/pages/content/ContentMiddleCriterionPage.js
+++ b/teachers_digital_platform/crtool/src/js/components/pages/content/ContentMiddleCriterionPage.js
@@ -69,6 +69,7 @@ export default class ContentMiddleCriterionPage extends React.Component {
                             color="green"
                             hasSpaceAfter="true" />
                         Criterion 1: Earning, income, and careers
+                        {this.props.criterionCompletionStatuses["content-middle-crt-question-1"] === C.ICON_CHECK_ROUND && <span class="u-fc-gray"> (complete)</span>}
                     </h2>
                     <p className="lead-paragraph u-mb45 u-mt15">
                         Does the curriculum address grade-level appropriate topics for earning, income, and careers?
@@ -247,6 +248,7 @@ export default class ContentMiddleCriterionPage extends React.Component {
                             color="green"
                             hasSpaceAfter="true" />
                         Criterion 2: Saving and Investing
+                        {this.props.criterionCompletionStatuses["content-middle-crt-question-2"] === C.ICON_CHECK_ROUND && <span class="u-fc-gray"> (complete)</span>}
                     </h2>
                     <p className="lead-paragraph u-mb45 u-mt15">
                         Does the curriculum address grade-level appropriate topics for saving and investing?
@@ -649,6 +651,7 @@ export default class ContentMiddleCriterionPage extends React.Component {
                             color="green"
                             hasSpaceAfter="true" />
                         Criterion 3: Spending
+                        {this.props.criterionCompletionStatuses["content-middle-crt-question-3"] === C.ICON_CHECK_ROUND && <span class="u-fc-gray"> (complete)</span>}
                     </h2>
                     <p className="lead-paragraph u-mb45 u-mt15">
                         Does the curriculum address grade-level appropriate topics for spending?
@@ -907,6 +910,7 @@ export default class ContentMiddleCriterionPage extends React.Component {
                             color="green"
                             hasSpaceAfter="true" />
                         Criterion 4: Borrowing and credit
+                        {this.props.criterionCompletionStatuses["content-middle-crt-question-4"] === C.ICON_CHECK_ROUND && <span class="u-fc-gray"> (complete)</span>}
                     </h2>
                     <p className="lead-paragraph u-mb45 u-mt15">
                         Does the curriculum address grade-level appropriate topics for borrowing and credit?
@@ -1257,6 +1261,7 @@ export default class ContentMiddleCriterionPage extends React.Component {
                             color="green"
                             hasSpaceAfter="true" />
                         Criterion 5: Managing financial risk
+                        {this.props.criterionCompletionStatuses["content-middle-crt-question-5"] === C.ICON_CHECK_ROUND && <span class="u-fc-gray"> (complete)</span>}
                     </h2>
                     <p className="lead-paragraph u-mb45 u-mt15">
                         Does the curriculum address grade-level appropriate topics for managing potential financial risk, including insurance?
@@ -1487,6 +1492,7 @@ export default class ContentMiddleCriterionPage extends React.Component {
                             color="green"
                             hasSpaceAfter="true" />
                         Criterion 6: Financial responsibility and money management
+                        {this.props.criterionCompletionStatuses["content-middle-crt-question-6"] === C.ICON_CHECK_ROUND && <span class="u-fc-gray"> (complete)</span>}
                     </h2>
                     <p className="lead-paragraph u-mb45 u-mt15">
                         Does the curriculum address grade-level appropriate topics for financial responsibility, money management, and financial decisions?

--- a/teachers_digital_platform/crtool/src/js/components/pages/partial.pages/EditableSubComponentRow.js
+++ b/teachers_digital_platform/crtool/src/js/components/pages/partial.pages/EditableSubComponentRow.js
@@ -2,6 +2,7 @@
 import React from "react";
 
 import RadioButtonEditable from "../../buttons/RadioButtonEditable";
+import FieldLevelErrorMessageComponent from "../../common/FieldLevelErrorMessageComponent";
 
 export default class EditableSubComponentRow extends React.Component {
 
@@ -48,6 +49,7 @@ export default class EditableSubComponentRow extends React.Component {
                             {...this.props} />
                     </div>
                 </div>
+                <FieldLevelErrorMessageComponent fieldId={this.props.currentCriterionRefId} {...this.props} />
             </fieldset>
         );
     }

--- a/teachers_digital_platform/crtool/src/js/components/pages/partial.pages/EfficacyStudyComponent.js
+++ b/teachers_digital_platform/crtool/src/js/components/pages/partial.pages/EfficacyStudyComponent.js
@@ -2,6 +2,7 @@ import React from "react";
 
 import EfficacyStudyScoreComponent from "./EfficacyStudyScoreComponent";
 import EditableSubComponentRow from "./EditableSubComponentRow";
+import EfficacyStudyNameComponent from "../../common/EfficacyStudyNameComponent";
 import SvgIcon from "../../svgs/SvgIcon";
 
 export default class EfficacyStudyComponent extends React.Component {
@@ -71,19 +72,10 @@ export default class EfficacyStudyComponent extends React.Component {
             <React.Fragment>
                 <div className="u-mt45 u-mb30">
                     {this.showRemoveButton()}
-                    <div className="m-form-field m-form-field__text">
-                        <label className="a-label a-label__heading" for={this.generateStudyRefId("", "study")}>
-                            Study name
-                            <small className="a-label_helper a-label_helper__block">
-                                Enter name of study you’re reviewing
-                            </small>
-                        </label>
-                        <input className="a-text-input a-text-input__full" type="text"
-                            id={this.generateStudyRefId("", "study")}
-                            ref={this.generateStudyRefId("", "study")}
-                            defaultValue={this.props.studyAnswers[this.props.studyCount][this.generateStudyRefId("", "study")]}
-                            onBlur={e=>this.criterionStudyAnswerChanged(this.generateStudyRefId("", "study"), e.target.value)} />
-                    </div>
+                    <EfficacyStudyNameComponent 
+                        criterionStudyAnswerChanged={this.criterionStudyAnswerChanged.bind(this)} 
+                        generateStudyRefId={this.generateStudyRefId.bind(this)}
+                        {...this.props} />
                 </div>
                 <ol className="m-list__unstyled">
                     <li className="o-survey">

--- a/teachers_digital_platform/crtool/src/js/components/pages/partial.pages/EfficacyStudyScoreComponent.js
+++ b/teachers_digital_platform/crtool/src/js/components/pages/partial.pages/EfficacyStudyScoreComponent.js
@@ -1,7 +1,5 @@
 import React from "react";
 
-import SvgIcon from "../../svgs/SvgIcon";
-
 export default class EfficacyStudyScoreComponent extends React.Component {
 
     criterionClassNameFor(level) {
@@ -27,21 +25,7 @@ export default class EfficacyStudyScoreComponent extends React.Component {
     }
 
     render() {
-        if (this.props.studyScore !== undefined && !this.props.studyScore.answered_all_complete) {
-            return (
-                <div className="m-notification
-                                m-notification__visible
-                                m-notification__warning
-                                u-mb30">
-                    <SvgIcon icon="exclamation-mark-round" />
-                    <div className="m-notification_content">
-                        <div className="m-notification_message">
-                            <p>You must enter a study name and answer all yes/no questions for this study before it can be scored.</p>
-                        </div>
-                    </div>
-                </div>
-            );
-        } else if (this.props.studyScore !== undefined && this.props.studyScore.answered_all_complete) {
+        if (this.props.studyScore !== undefined && this.props.studyScore.answered_all_complete) {
             return (
                 <React.Fragment>
                 <h4 className="h2">Score for {this.props.studyScoreName}</h4>

--- a/teachers_digital_platform/crtool/src/js/components/pages/partial.pages/EfficacyStudyScoreComponent.js
+++ b/teachers_digital_platform/crtool/src/js/components/pages/partial.pages/EfficacyStudyScoreComponent.js
@@ -24,6 +24,15 @@ export default class EfficacyStudyScoreComponent extends React.Component {
         return (studyScore.all_essential_yes === true);
     }
 
+    generateClassNameForScore(isActive) {
+        let className = "m-form-field_radio-text";
+        if (isActive) {
+            className += " is-active";
+        }
+
+        return className;
+    }
+
     render() {
         if (this.props.studyScore !== undefined && this.props.studyScore.answered_all_complete) {
             return (
@@ -40,7 +49,7 @@ export default class EfficacyStudyScoreComponent extends React.Component {
                                         <circle cx="11" cy="11" r="10" className="m-form-field_radio-icon-stroke"></circle>
                                         <circle cx="11" cy="11" r="7" className="m-form-field_radio-icon-fill"></circle>
                                     </svg>
-                                    <div className="m-form-field_radio-text is-active">
+                                    <div className={this.generateClassNameForScore(this.studyIsStrong())}>
                                     { this.studyIsStrong() && <div><strong>The study is strong.</strong></div> }
                                     { !this.studyIsStrong() && <div>The study is strong.</div> }
                                         All essential components were met.
@@ -57,7 +66,7 @@ export default class EfficacyStudyScoreComponent extends React.Component {
                                         <circle cx="11" cy="11" r="10" className="m-form-field_radio-icon-stroke"></circle>
                                         <circle cx="11" cy="11" r="7" className="m-form-field_radio-icon-fill"></circle>
                                     </svg>
-                                    <div className="m-form-field_radio-text">
+                                    <div className={this.generateClassNameForScore(!this.studyIsStrong())}>
                                     { !this.studyIsStrong() && <div><strong>The study is not strong.</strong></div> }
                                     { this.studyIsStrong() && <div>The study is not strong.</div> }
                                         Not all essential components were met.

--- a/teachers_digital_platform/crtool/src/js/content_data/utilityContent.js
+++ b/teachers_digital_platform/crtool/src/js/content_data/utilityContent.js
@@ -264,7 +264,7 @@ export const UtilityContent = {
                         {
                             showNaButton: true,
                             showBeneficialText: false,
-                            criterionRefId: "utility-crt-question-2.3.1",
+                            criterionRefId: "utility-crt-question-2.4",
                             hasInlineHtml: false,
                             componentText: "If technology is used, does the use of technology add value? (e.g., online assessments that direct students to questions at the correct level)",
                         },
@@ -277,7 +277,7 @@ export const UtilityContent = {
                         {
                             showNaButton: false,
                             showBeneficialText: false,
-                            criterionRefId: "utility-crt-question-2.3.1",
+                            criterionRefId: "utility-crt-question-2.5",
                             hasInlineHtml: true,
                             componentText: "Do student activities and supporting materials provide opportunities for students to <strong>practice</strong> their learning in real-world contexts?",
                         },

--- a/teachers_digital_platform/css/organisms/survey.less
+++ b/teachers_digital_platform/css/organisms/survey.less
@@ -86,6 +86,10 @@ li.o-survey {
         margin-top: unit( 30px / @base-font-size-px, em );
         padding-top: unit( 30px / @base-font-size-px, em );
     }
+
+    .a-error-message {
+        margin-top: unit( ( @grid_gutter-width / 2 ) / @base-font-size-px, em );
+    }
 }
 
 .o-survey_component {


### PR DESCRIPTION
…Utility

# DO NOT MERGE 
- Right now this is working except for Efficacy.  
  - When clicking on the "continue to efficacy summary" button it will show the hidden required fields.  This will need to be an altered functionality compared to other dimensions
- Field level has not been implemented yet.

## NOTE: 
- Could one of the Fewd's stub out one of the field level error messages?  I can hide & show it I just can not style it right

## Additions
Added error messaging to the following Dimensions:
- Content Elementary
- Content Middle
- Content High
- Utility
- Quality

(Efficacy is still in the works)

## Review

- @dcmouyard @rrstoll 

[Preview this PR without the whitespace changes](?w=0)
