### PR TITLE
Test with cfgov refresh

### DIFF
--- a/install_cfgov_refresh.sh
+++ b/install_cfgov_refresh.sh
@@ -1,0 +1,7 @@
+#!/bin/sh
+
+git clone https://github.com/cfpb/cfgov-refresh
+cd cfgov-refresh
+pip install -r requirements/wagtail.txt
+pip install -r requirements/libraries.txt
+pip install -r requirements/test.txt

--- a/teachers_digital_platform/tests/settings.py
+++ b/teachers_digital_platform/tests/settings.py
@@ -1,2 +1,1 @@
-# Put any test settings that might be needed here
-SECRET_KEY = 'testing'
+from cfgov.settings.test_nomigrations import *

--- a/tox.ini
+++ b/tox.ini
@@ -5,10 +5,12 @@ envlist=lint,py{27,36}-dj{18,111}
 [testenv]
 install_command=pip install -e ".[testing]" -U {opts} {packages}
 commands=
+    ./install_cfgov_refresh.sh
     coverage erase
     coverage run --source='teachers_digital_platform' {envbindir}/django-admin.py test {posargs}
 setenv=
     DJANGO_SETTINGS_MODULE=teachers_digital_platform.tests.settings
+    PYTHONPATH={toxinidir}/cfgov-refresh/cfgov:{env:PYTHONPATH:}
 
 basepython=
     py27: python2.7

--- a/tox.ini
+++ b/tox.ini
@@ -1,6 +1,6 @@
 [tox]
 skipsdist=True
-envlist=lint,py{27,36}-dj{18,111} 
+envlist=lint,py{27,36}-dj{18}
 
 [testenv]
 install_command=pip install -e ".[testing]" -U {opts} {packages}


### PR DESCRIPTION
This PR will enable Python unit tests that are written against code that inherits from the cfgov-refresh Python packages to run successfully in Travis in this repository.

## Checklist

* [ ] Changes are limited to a single goal (no scope creep)
* [ ] Code can be automatically merged (no conflicts)
* [ ] Code follows the standards laid out in the [front end playbook](https://github.com/cfpb/front-end)
* [ ] Passes all existing automated tests
* [ ] New functions include new tests
* [ ] New functions are documented (with a description, list of inputs, and expected output)
* [ ] Placeholder code is flagged
* [ ] Visually tested in supported browsers and devices
* [ ] Project documentation has been updated (including the "Unreleased" section of the CHANGELOG)
