### PR TITLE
Change CFPB to BCFP on summary pages

### DIFF
--- a/teachers_digital_platform/crtool/src/__tests__/__snapshots__/EfficacyPrintPage.test.js.snap
+++ b/teachers_digital_platform/crtool/src/__tests__/__snapshots__/EfficacyPrintPage.test.js.snap
@@ -5,7 +5,7 @@ Array [
   <div
     className="h5"
   >
-    CFPB curriculum review tool
+    BCFP curriculum review tool
   </div>,
   <h1>
     Efficacy

--- a/teachers_digital_platform/crtool/src/__tests__/__snapshots__/QualiyPrintPage.test.js.snap
+++ b/teachers_digital_platform/crtool/src/__tests__/__snapshots__/QualiyPrintPage.test.js.snap
@@ -5,7 +5,7 @@ Array [
   <div
     className="h5"
   >
-    CFPB curriculum review tool
+    BCFP curriculum review tool
   </div>,
   <h1>
     Quality

--- a/teachers_digital_platform/crtool/src/__tests__/__snapshots__/UtilityPrintPage.test.js.snap
+++ b/teachers_digital_platform/crtool/src/__tests__/__snapshots__/UtilityPrintPage.test.js.snap
@@ -5,7 +5,7 @@ Array [
   <div
     className="h5"
   >
-    CFPB curriculum review tool
+    BCFP curriculum review tool
   </div>,
   <h1>
     Utility

--- a/teachers_digital_platform/crtool/src/js/components/common/DimensionInformation.js
+++ b/teachers_digital_platform/crtool/src/js/components/common/DimensionInformation.js
@@ -14,7 +14,7 @@ export default class DimensionInformation extends React.Component {
         if (this.props.currentPrintButton !== C.START_PAGE && this.props.currentPrintButton !== "") {
             return (
                 <React.Fragment>
-                    <div className="h5">CFPB curriculum review tool</div>
+                    <div className="h5">BCFP curriculum review tool</div>
                     <h1>{this.props.dimensionName} summary for {this.props.curriculumTitle}</h1>
                     <p className="lead-paragraph u-mb30">
                         {this.props.dimensionSummary}

--- a/teachers_digital_platform/crtool/src/js/components/common/FinalCurriculumInformation.js
+++ b/teachers_digital_platform/crtool/src/js/components/common/FinalCurriculumInformation.js
@@ -26,7 +26,7 @@ export default class FinalCurriculumInformation extends React.Component {
                                 block__flush-top
                                 block__padded-bottom
                                 block__border-bottom">
-                    <div className="h5">CFPB curriculum review tool</div>
+                    <div className="h5">BCFP curriculum review tool</div>
                     <h1>Final summary for {this.props.curriculumTitle}</h1>
                     <p className="lead-paragraph u-mb30">
                         This summary shows the scores for all four dimensions.


### PR DESCRIPTION
Change CFPB to BCFP on summary pages

## Changes

- Change CFPB to BCFP on summary pages

## Review

- @atuggle 
- @rrstoll 

[Preview this PR without the whitespace changes](?w=0)
