### PR TITLE
Analytics: Enhanced to not send Efficacy Criterion 1 if studies are s…

### DIFF
--- a/teachers_digital_platform/crtool/src/js/business.logic/summary/efficacyCalculationService.js
+++ b/teachers_digital_platform/crtool/src/js/business.logic/summary/efficacyCalculationService.js
@@ -106,9 +106,12 @@ const EfficacyCalculationService = {
      * We need to know if a study exists that was started but not finished
      */
     unfinishedEfficacyStudyExists() {
-        let criterionScores = Repository.getCriterionScores(); // component.state does not reflect current change
-        for (var score in criterionScores) {
-            if (score.indexOf("efficacy-crt-1") >= 0 && criterionScores[score].answered_all_complete === false) {
+        // Since studies can be added and removed we must use the index from StudyAnswers to know which ones still exist
+        let allCriterionScores = Repository.getCriterionScores(); // component.state does not reflect current change
+        for (var idx in Repository.getStudyAnswers()) {
+            let criterionScoreName = "efficacy-crt-1-" + idx;
+            if (allCriterionScores[criterionScoreName] !== undefined && 
+                allCriterionScores[criterionScoreName].answered_all_complete === false) {
                 return true;
             }
         }
@@ -116,12 +119,45 @@ const EfficacyCalculationService = {
         return false;
     },
 
+    /*
+     * We need to know if a study exists that was started but not finished, and how many
+     */
+    getCountOfUnfinishedEfficacyStudies() {
+        let allCriterionScores = Repository.getCriterionScores(); // component.state does not reflect current change
+        let count = 0;
+        for (var idx in Repository.getStudyAnswers()) {
+
+            let criterionScoreName = "efficacy-crt-1-" + idx;
+            if (allCriterionScores[criterionScoreName] === undefined ||
+                allCriterionScores[criterionScoreName].answered_all_complete === false) {
+
+                count += 1;
+            }
+        }
+
+        return count;
+    },
+
+    /*
+     * Is first study started.  You do not have to fill out any studies but once you start one you must finish it
+     */
+    firstStudyStarted() {
+        let criterionScores = Repository.getCriterionScores(); // component.state does not reflect current change
+    
+        //Once you start the first study the criterionScore is created. So if its undefined it has not been started
+        if (criterionScores["efficacy-crt-1-0"] === undefined) {
+            return false;
+        }
+
+        return true;
+    },    
+
     /* 
      * There is a need to know if I'm done reviewing studies button is clicked with out any studies
      * being answered. (Skipped).  Once a study is started it must be finished.
      */
-    EfficacyStudiesAreBeingSkipped() {
-        let efficacyStudiesAreBeingSkipped = Repository.getCriterionScores()["efficacy-crt-1"];
+    efficacyStudiesAreBeingSkipped() {
+        let efficacyStudiesAreBeingSkipped = Repository.getCriterionScores()["efficacy-crt-1-0"];
         return efficacyStudiesAreBeingSkipped === undefined;
     },
 


### PR DESCRIPTION
Now that Form and Field level error messages are in place knowing when Efficacy Criterion 1 is complete and what analytics to send is more complicated.

Expected behavior:
* If not Efficacy Studies were started and I'm done reviewing studies btn is clicked only send one analytics update states: Number of studies completed: 0
* Any time a study has been started it must be finished.  If it is not finished then the analytics update states: Number of studies completed: x; Number of studies not completed: x .  Where x represents the actual associated values.
* If at least 1 Efficacy Study is complete and I'm done reviewing studies btn is clicked then you send all 3 analytics.  Number of studies completed..., Efficacy Criterion 1 completed, Study scores


## Review

- @dcmouyard @rrstoll 

[Preview this PR without the whitespace changes](?w=0)
