### PR TITLE
Fix link style on activity detail page

### DIFF
--- a/teachers_digital_platform/jinja2/teachers_digital_platform/activity_page.html
+++ b/teachers_digital_platform/jinja2/teachers_digital_platform/activity_page.html
@@ -43,7 +43,7 @@
         <div class="u-mb30">
             <p>This activity includes teacher materials and the student activity.</p>
             <p>
-                <a class="a-link a-link__icon-after-text" target="_blank" rel="noopener noreferrer" href="{{ page.activity_file.url }}">
+                <a class="a-link a-link__icon" target="_blank" rel="noopener noreferrer" href="{{ page.activity_file.url }}">
                     <span class="a-link_text">Download {{ page.activity_file.title | striptags | safe }}</span>
                     <span class="a-icon"><svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 651.7 1200" class="cf-icon-svg"><path d="M507.1 692.8c-15.6-15.6-40.9-15.6-56.6 0l-85.1 85.1V466.6c0-22.1-17.9-40-40-40s-40 17.9-40 40V778l-85.1-85.1c-15.6-15.6-40.9-15.6-56.6 0-15.6 15.6-15.6 40.9 0 56.6L297 902.9c7.5 7.5 17.7 11.7 28.3 11.7s20.8-4.2 28.3-11.7l153.3-153.4c15.8-15.7 15.8-41 .2-56.7z"></path><path d="M30 161c-16.5 0-30 13.5-30 30v827.8c0 16.5 13.5 30 30 30h591.7c16.5 0 30-13.5 30-30V343.7L469 161H30zm389.6 60v134.8c0 19.9 16.3 36.2 36.2 36.2h135.9V988.8H60V221h359.6z"></path></svg></span>
                 </a>
@@ -52,7 +52,7 @@
             {% if page.handout_file %}
                 <p>The handout is required reading material for students.</p>
                 <p>
-                    <a class="a-link a-link__icon-after-text" target="_blank" rel="noopener noreferrer" href="{{ page.handout_file.url }}">
+                    <a class="a-link a-link__icon" target="_blank" rel="noopener noreferrer" href="{{ page.handout_file.url }}">
                         <span class="a-link_text">Download {{ page.handout_file.title | striptags | safe }}</span>
                         <span class="a-icon"><svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 651.7 1200" class="cf-icon-svg"><path d="M507.1 692.8c-15.6-15.6-40.9-15.6-56.6 0l-85.1 85.1V466.6c0-22.1-17.9-40-40-40s-40 17.9-40 40V778l-85.1-85.1c-15.6-15.6-40.9-15.6-56.6 0-15.6 15.6-15.6 40.9 0 56.6L297 902.9c7.5 7.5 17.7 11.7 28.3 11.7s20.8-4.2 28.3-11.7l153.3-153.4c15.8-15.7 15.8-41 .2-56.7z"></path><path d="M30 161c-16.5 0-30 13.5-30 30v827.8c0 16.5 13.5 30 30 30h591.7c16.5 0 30-13.5 30-30V343.7L469 161H30zm389.6 60v134.8c0 19.9 16.3 36.2 36.2 36.2h135.9V988.8H60V221h359.6z"></path></svg></span>
                     </a>


### PR DESCRIPTION
Fix link style on activity detail page.

## Changes

- Class used for icon links.


## Review

- @rrstoll 

[Preview this PR without the whitespace changes](?w=0)
