### PR TITLE
Restore detailed tag version format

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,6 +8,7 @@ script:
 - nvm install 8 && nvm use 8
 - npm install -g gulp-cli
 - npm install
+- npm config set package-lock false
 - tox
 - npm test
 - python setup.py bdist_wheel

--- a/setup.py
+++ b/setup.py
@@ -28,7 +28,7 @@ setup(
     description='Teachers digital platform',
     long_description=long_description,
     license='CC0',
-    version_format='{tag}',
+    version_format='{tag}.dev{commitcount}+{gitsha}',
     include_package_data=True,
     packages=find_packages(),
     package_data={


### PR DESCRIPTION
This change reverts #186 and restores the use of detailed (dirty) release version formatting.

@contolini, @Scotchester and I debugged this on the [cfpb/retirement](https://github.com/cfpb/retirement) repo and determined that the unexpected version numbers are due to the frontend script changing the `package-lock.json` file.

See https://github.com/cfpb/retirement/pull/227 for the PR that fixed this on the retirement repo.

See https://travis-ci.org/chosak/teachers-digital-platform/jobs/407162397 for an example Travis build (on my fork) demonstrating that this works to properly name the built wheel. In this example, I've made a tag on my fork of [1.0.5](https://github.com/chosak/teachers-digital-platform/releases/tag/1.0.5). Travis then builds the wheel with the correct name `teachers_digital_platform-1.0.5` -- you can see this in the log, ignore the fact that the job fails as that only happens because the fork doesn't (and shouldn't) have push permissions to the repo.