### PR TITLE
Update migrations so jenkins doesn't fail on 0011_update_initial_data

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -41,6 +41,7 @@ setup(
             'static/tdp/js/*',
             'static/tdp/fonts/*',
             'fixtures/tdp_initial_data.json',
+            'fixtures/tdp_updated_council_for_ed_data.json',
             'fixtures/tdp_updated_building_blocks.json'
         ],
     },

--- a/teachers_digital_platform/fixtures/tdp_updated_council_for_ed_data.json
+++ b/teachers_digital_platform/fixtures/tdp_updated_council_for_ed_data.json
@@ -1,0 +1,50 @@
+[
+   {
+        "fields": {
+            "weight": 0,
+            "title": "Standard I. Earning Income"
+        },
+        "model": "teachers_digital_platform.activitycouncilforeconed",
+        "pk": 1
+    },
+    {
+        "fields": {
+            "weight": 1,
+            "title": "Standard II. Buying goods and services"
+        },
+        "model": "teachers_digital_platform.activitycouncilforeconed",
+        "pk": 2
+    },
+    {
+        "fields": {
+            "weight": 2,
+            "title": "Standard III. Saving"
+        },
+        "model": "teachers_digital_platform.activitycouncilforeconed",
+        "pk": 3
+    },
+    {
+        "fields": {
+            "weight": 3,
+            "title": "Standard IV. Using credit"
+        },
+        "model": "teachers_digital_platform.activitycouncilforeconed",
+        "pk": 4
+    },
+    {
+        "fields": {
+            "weight": 4,
+            "title": "Standard V. Financial investing"
+        },
+        "model": "teachers_digital_platform.activitycouncilforeconed",
+        "pk": 5
+    },
+    {
+        "fields": {
+            "weight": 5,
+            "title": "Standard VI. Protecting and insuring"
+        },
+        "model": "teachers_digital_platform.activitycouncilforeconed",
+        "pk": 6
+    }
+]

--- a/teachers_digital_platform/migrations/0011_update_initial_data.py
+++ b/teachers_digital_platform/migrations/0011_update_initial_data.py
@@ -5,7 +5,7 @@ from django.db import migrations, models
 from django.core import serializers
 
 fixture_dir = os.path.abspath(os.path.join(os.path.dirname(__file__), '../fixtures'))
-fixture_filename = 'tdp_initial_data.json'
+fixture_filename = 'tdp_updated_council_for_ed_data.json'
 
 
 def load_fixture(apps, schema_editor):
@@ -20,17 +20,6 @@ def load_fixture(apps, schema_editor):
 def unload_fixture(apps, schema_editor):
     """Brutally deleting all entries for these models..."""
     model_names = [
-        "ActivityBuildingBlock",
-        "ActivitySchoolSubject",
-        "ActivityTopic",
-        "ActivityGradeLevel",
-        "ActivityAgeRange",
-        "ActivitySpecialPopulation",
-        "ActivityType",
-        "ActivityTeachingStrategy",
-        "ActivityBloomsTaxonomyLevel",
-        "ActivityDuration",
-        "ActivityJumpStartCoalition",
         "ActivityCouncilForEconEd",
     ]
     for model_name in model_names:

--- a/teachers_digital_platform/migrations/0014_update_building_blocks.py
+++ b/teachers_digital_platform/migrations/0014_update_building_blocks.py
@@ -21,17 +21,6 @@ def unload_fixture(apps, schema_editor):
     """Brutally deleting all entries for these models..."""
     model_names = [
         "ActivityBuildingBlock",
-        "ActivitySchoolSubject",
-        "ActivityTopic",
-        "ActivityGradeLevel",
-        "ActivityAgeRange",
-        "ActivitySpecialPopulation",
-        "ActivityType",
-        "ActivityTeachingStrategy",
-        "ActivityBloomsTaxonomyLevel",
-        "ActivityDuration",
-        "ActivityJumpStartCoalition",
-        "ActivityCouncilForEconEd",
     ]
     for model_name in model_names:
         MyModel = apps.get_model("teachers_digital_platform", model_name)


### PR DESCRIPTION
Updated migration 0011 to use it's own fixture file instead of reusing the tdp_initial_data.json fixture
