### PR TITLE
Print coverage report after running tests

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -8,6 +8,7 @@ commands=
     ./install_cfgov_refresh.sh
     coverage erase
     coverage run --source='teachers_digital_platform' {envbindir}/django-admin.py test {posargs}
+    coverage report -m
 setenv=
     DJANGO_SETTINGS_MODULE=teachers_digital_platform.tests.settings
     PYTHONPATH={toxinidir}/cfgov-refresh/cfgov:{env:PYTHONPATH:}


### PR DESCRIPTION
This change dumps the Python test coverage report to console after the tests run.

## Testing

- Run `tox`, you'll see the test coverage report gets printed out.

## Checklist

* [X] Changes are limited to a single goal (no scope creep)
* [X] Code can be automatically merged (no conflicts)
* [X] Code follows the standards laid out in the [front end playbook](https://github.com/cfpb/front-end)
* [X] Passes all existing automated tests