### PR TITLE
TDP Fixing sequence id numbers for django model tables

### DIFF
--- a/teachers_digital_platform/migrations/0016_auto_20180829_2323.py
+++ b/teachers_digital_platform/migrations/0016_auto_20180829_2323.py
@@ -1,0 +1,28 @@
+# -*- coding: utf-8 -*-
+from __future__ import unicode_literals
+
+from django.db import migrations, models
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('teachers_digital_platform', '0015_auto_20180816_0954'),
+    ]
+
+    operations = [
+        migrations.RunSQL([
+            "SELECT setval('teachers_digital_platform_activitybuildingblock_id_seq', (SELECT MAX(id) FROM teachers_digital_platform_activitybuildingblock));",
+            "SELECT setval('teachers_digital_platform_activityschoolsubject_id_seq', (SELECT MAX(id) FROM teachers_digital_platform_activityschoolsubject));",
+            "SELECT setval('teachers_digital_platform_activitytopic_id_seq', (SELECT MAX(id) FROM teachers_digital_platform_activitytopic));",
+            "SELECT setval('teachers_digital_platform_activitygradelevel_id_seq', (SELECT MAX(id) FROM teachers_digital_platform_activitygradelevel));",
+            "SELECT setval('teachers_digital_platform_activityagerange_id_seq', (SELECT MAX(id) FROM teachers_digital_platform_activityagerange));",
+            "SELECT setval('teachers_digital_platform_activityspecialpopulation_id_seq', (SELECT MAX(id) FROM teachers_digital_platform_activityspecialpopulation));",
+            "SELECT setval('teachers_digital_platform_activitytype_id_seq', (SELECT MAX(id) FROM teachers_digital_platform_activitytype));",
+            "SELECT setval('teachers_digital_platform_activityteachingstrategy_id_seq', (SELECT MAX(id) FROM teachers_digital_platform_activityteachingstrategy));",
+            "SELECT setval('teachers_digital_platform_activitybloomstaxonomylevel_id_seq', (SELECT MAX(id) FROM teachers_digital_platform_activitybloomstaxonomylevel));",
+            "SELECT setval('teachers_digital_platform_activityduration_id_seq', (SELECT MAX(id) FROM teachers_digital_platform_activityduration));",
+            "SELECT setval('teachers_digital_platform_activityjumpstartcoalition_id_seq', (SELECT MAX(id) FROM teachers_digital_platform_activityjumpstartcoalition));",
+            "SELECT setval('teachers_digital_platform_activitycouncilforeconed_id_seq', (SELECT MAX(id) FROM teachers_digital_platform_activitycouncilforeconed));",
+        ])
+    ]


### PR DESCRIPTION
Set id_seq values to the max id value of the model table, so errors aren't thrown when trying to create a new records using django's admin UI.

* [x] Changes are limited to a single goal (no scope creep)
* [x] Code can be automatically merged (no conflicts)
* [x] Code follows the standards laid out in the [front end playbook](https://github.com/cfpb/front-end)
* [x] Passes all existing automated tests
* [x] New functions include new tests
* [x] New functions are documented (with a description, list of inputs, and expected output)
* [x] Placeholder code is flagged
* [x] Visually tested in supported browsers and devices
* [x] Project documentation has been updated (including the "Unreleased" section of the CHANGELOG)
