### PR TITLE
Add unit testing against Django 1.11

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -1,6 +1,6 @@
 [tox]
 skipsdist=True
-envlist=lint,py{27,36}-dj{18}
+envlist=lint,py{27,36}-dj{18,111}
 
 [testenv]
 install_command=pip install -e ".[testing]" -U {opts} {packages}


### PR DESCRIPTION
This PR adds testing against Django 1.11 as part of the Tox matrix, as a new environment factor (`dj{18,111}`). Due to recent work on cfgov-refresh it is now possible to run and pass all unit tests there against Django 1.11.

## Testing

- `tox`

## Checklist

* [X] Changes are limited to a single goal (no scope creep)
* [X] Code can be automatically merged (no conflicts)
* [X] Code follows the standards laid out in the [front end playbook](https://github.com/cfpb/front-end)
* [X] Passes all existing automated tests
* [ ] Project documentation has been updated (including the "Unreleased" section of the CHANGELOG)
