### PR TITLE
Adding legal information to bottom of activity detail page sidebar

### DIFF
--- a/teachers_digital_platform/jinja2/teachers_digital_platform/activity_page.html
+++ b/teachers_digital_platform/jinja2/teachers_digital_platform/activity_page.html
@@ -120,4 +120,9 @@
         {% if page.council_for_economic_education.all() %}<p><strong>Council for Economic Education:</strong> {{ page.council_for_economic_education.all() | join(', ') }}</p>{% endif %}
         {% if page.jump_start_coalition.all() %}<p><strong><span aria-hidden="true">Jump$tart</span><span class="u-visually-hidden">JumpStart</span> National Standards:</strong> {{ page.jump_start_coalition.all() | join(', ') }}</p>{% endif %}
     {% endif %}
+
+    <div class="content_line u-mt30 u-mb30"></div>
+
+    <h5>Legal Disclaimer</h5>
+    <p>This resource includes links and references to third-party resources or content that consumers may find helpful. The Bureau does not control or guarantee the accuracy of this third-party information. By listing these links and references, the Bureau in not endorsing and has not vetted these third-parties, the views they express, or the products or services they offer. Other entities and resources also may meet your needs.</p>
 {% endblock content_sidebar %}


### PR DESCRIPTION
Adding dividing line and legal text (with h5 heading) to activity detail sidebar.  