### PR TITLE
Removing link wrapper within o-well

### DIFF
--- a/teachers_digital_platform/jinja2/teachers_digital_platform/activity_page.html
+++ b/teachers_digital_platform/jinja2/teachers_digital_platform/activity_page.html
@@ -27,44 +27,42 @@
     {{ page.objectives|richtext }}
     <h2 class="u-mt45">What students will do</h2>
     {{ page.what_students_will_do|richtext }}
-    <div class="o-well u-mt45">
-        <h2>Download activity</h2>
-        <div class="u-mb30">
-            <h3 class="h5">Teacher guide</h3>
+    <h2>Download activity</h2>
+    <div class="u-mb30">
+        <h3 class="h5">Teacher guide</h3>
+        <p>
+            <a class="a-link a-link__icon" target="_blank" rel="noopener noreferrer" href="{{ page.activity_file.url }}">
+                <span class="a-link_text">{{ page.activity_file.title | striptags | safe }}</span>
+                <span class="a-icon">{{ svg_icon('download') }}</span>
+            </a>
+        </p>
+
+        {% if page.handout_file %}
+            <h3 class="h5">Student materials</h3>
             <p>
-                <a class="a-link a-link__icon" target="_blank" rel="noopener noreferrer" href="{{ page.activity_file.url }}">
-                    <span class="a-link_text">{{ page.activity_file.title | striptags | safe }}</span>
+                <a class="a-link a-link__icon" target="_blank" rel="noopener noreferrer" href="{{ page.handout_file.url }}">
+                    <span class="a-link_text">{{ page.handout_file.title | striptags | safe }}</span>
                     <span class="a-icon">{{ svg_icon('download') }}</span>
                 </a>
             </p>
+        {% endif %}
+        {% if page.handout_file_2 %}
+            <p>
+                <a class="a-link a-link__icon" target="_blank" rel="noopener noreferrer" href="{{ page.handout_file_2.url }}">
+                    <span class="a-link_text">{{ page.handout_file_2.title | striptags | safe }}</span>
+                    <span class="a-icon">{{ svg_icon('download') }}</span>
+                </a>
+            </p>
+        {% endif %}
+        {% if page.handout_file_3 %}
+            <p>
+                <a class="a-link a-link__icon" target="_blank" rel="noopener noreferrer" href="{{ page.handout_file_3.url }}">
+                    <span class="a-link_text">{{ page.handout_file_3.title | striptags | safe }}</span>
+                    <span class="a-icon">{{ svg_icon('download') }}</span>
+                </a>
+            </p>
+        {% endif %}
 
-            {% if page.handout_file %}
-                <h3 class="h5">Student materials</h3>
-                <p>
-                    <a class="a-link a-link__icon" target="_blank" rel="noopener noreferrer" href="{{ page.handout_file.url }}">
-                        <span class="a-link_text">{{ page.handout_file.title | striptags | safe }}</span>
-                        <span class="a-icon">{{ svg_icon('download') }}</span>
-                    </a>
-                </p>
-            {% endif %}
-            {% if page.handout_file_2 %}
-                <p>
-                    <a class="a-link a-link__icon" target="_blank" rel="noopener noreferrer" href="{{ page.handout_file_2.url }}">
-                        <span class="a-link_text">{{ page.handout_file_2.title | striptags | safe }}</span>
-                        <span class="a-icon">{{ svg_icon('download') }}</span>
-                    </a>
-                </p>
-            {% endif %}
-            {% if page.handout_file_3 %}
-                <p>
-                    <a class="a-link a-link__icon" target="_blank" rel="noopener noreferrer" href="{{ page.handout_file_3.url }}">
-                        <span class="a-link_text">{{ page.handout_file_3.title | striptags | safe }}</span>
-                        <span class="a-icon">{{ svg_icon('download') }}</span>
-                    </a>
-                </p>
-            {% endif %}
-
-        </div>
     </div>
 {% endblock content_main %}
 


### PR DESCRIPTION
Short description explaining the high-level reason for the pull request

## Additions

-

## Removals

- Removing wrapper div around download links within Downloads .o-well

## Changes

-

## Testing

-

## Review

- @dcmouyard

[Preview this PR without the whitespace changes](?w=0)

## Screenshots


## Notes

-

## Todos

-

## Checklist

* [ ] Changes are limited to a single goal (no scope creep)
* [ ] Code can be automatically merged (no conflicts)
* [ ] Code follows the standards laid out in the [front end playbook](https://github.com/cfpb/front-end)
* [ ] Passes all existing automated tests
* [ ] New functions include new tests
* [ ] New functions are documented (with a description, list of inputs, and expected output)
* [ ] Placeholder code is flagged
* [ ] Visually tested in supported browsers and devices
* [ ] Project documentation has been updated (including the "Unreleased" section of the CHANGELOG)
