### PR TITLE
Wrapping legal info in .block div with no top margin

### DIFF
--- a/teachers_digital_platform/jinja2/teachers_digital_platform/activity_page.html
+++ b/teachers_digital_platform/jinja2/teachers_digital_platform/activity_page.html
@@ -121,7 +121,7 @@
         {% if page.jump_start_coalition.all() %}<p><strong><span aria-hidden="true">Jump$tart</span><span class="u-visually-hidden">JumpStart</span> National Standards:</strong> {{ page.jump_start_coalition.all() | join(', ') }}</p>{% endif %}
         <div class="content_line u-mt30 u-mb30"></div>
     {% endif %}
-    
+
     <div class="block block__flush-top">
         <h5>Legal Disclaimer</h5>
         <p>This resource includes links and references to third-party resources or content that consumers may find helpful. The Bureau does not control or guarantee the accuracy of this third-party information. By listing these links and references, the Bureau in not endorsing and has not vetted these third-parties, the views they express, or the products or services they offer. Other entities and resources also may meet your needs.</p>

--- a/teachers_digital_platform/jinja2/teachers_digital_platform/activity_page.html
+++ b/teachers_digital_platform/jinja2/teachers_digital_platform/activity_page.html
@@ -121,7 +121,9 @@
         {% if page.jump_start_coalition.all() %}<p><strong><span aria-hidden="true">Jump$tart</span><span class="u-visually-hidden">JumpStart</span> National Standards:</strong> {{ page.jump_start_coalition.all() | join(', ') }}</p>{% endif %}
         <div class="content_line u-mt30 u-mb30"></div>
     {% endif %}
-
-    <h5>Legal Disclaimer</h5>
-    <p>This resource includes links and references to third-party resources or content that consumers may find helpful. The Bureau does not control or guarantee the accuracy of this third-party information. By listing these links and references, the Bureau in not endorsing and has not vetted these third-parties, the views they express, or the products or services they offer. Other entities and resources also may meet your needs.</p>
+    
+    <div class="block block__flush-top">
+        <h5>Legal Disclaimer</h5>
+        <p>This resource includes links and references to third-party resources or content that consumers may find helpful. The Bureau does not control or guarantee the accuracy of this third-party information. By listing these links and references, the Bureau in not endorsing and has not vetted these third-parties, the views they express, or the products or services they offer. Other entities and resources also may meet your needs.</p>
+    </div>
 {% endblock content_sidebar %}


### PR DESCRIPTION
Wrapped the legal information divs in a .block div with the top margin set to zero.  Saw this on localhost:8000/practitioner-resources/youth-financial-education/.