### PR TITLE
Activity detail sidebar tweaks

### DIFF
--- a/teachers_digital_platform/css/cf-enhancements/molecules/form-fields.less
+++ b/teachers_digital_platform/css/cf-enhancements/molecules/form-fields.less
@@ -66,14 +66,3 @@
         color: @black;
     }
 }
-
-.m-form-field__checkbox {
-    .a-checkbox + .a-label.indeterminate {
-        &::before {
-            background-image: url(/static/tdp/img/square-gray.png);
-            background-size: auto 0.875em;
-            background-position: center;
-            background-repeat: no-repeat;
-        }
-    }
-}

--- a/teachers_digital_platform/css/molecules/form-fields.less
+++ b/teachers_digital_platform/css/molecules/form-fields.less
@@ -1,0 +1,14 @@
+//
+// Custom Form fields styling
+//
+
+.m-form-field__checkbox {
+    .a-checkbox + .a-label.indeterminate {
+        &::before {
+            background-image: url(/static/tdp/img/square-gray.png);
+            background-size: auto 0.875em auto unit( 15px / @base-font-size-px, em );
+            background-position: center;
+            background-repeat: no-repeat;
+        }
+    }
+}

--- a/teachers_digital_platform/css/tdp.less
+++ b/teachers_digital_platform/css/tdp.less
@@ -31,6 +31,7 @@
 @import 'molecules/char-icon.less';
 @import 'molecules/component-list.less';
 @import 'molecules/curriculum-status.less';
+@import 'molecules/form-fields.less';
 @import 'organisms/dimension-selection-bar.less';
 @import 'organisms/inner-footer.less';
 @import 'organisms/expandable-facets.less';

--- a/teachers_digital_platform/jinja2/teachers_digital_platform/activity_page.html
+++ b/teachers_digital_platform/jinja2/teachers_digital_platform/activity_page.html
@@ -27,42 +27,40 @@
     {{ page.objectives|richtext }}
     <h2 class="u-mt45">What students will do</h2>
     {{ page.what_students_will_do|richtext }}
-    <h2>Download activity</h2>
-    <div class="u-mb30">
-        <h3 class="h5">Teacher guide</h3>
-        <p>
-            <a class="a-link a-link__icon" target="_blank" rel="noopener noreferrer" href="{{ page.activity_file.url }}">
-                <span class="a-link_text">{{ page.activity_file.title | striptags | safe }}</span>
-                <span class="a-icon">{{ svg_icon('download') }}</span>
-            </a>
-        </p>
-
-        {% if page.handout_file %}
-            <h3 class="h5">Student materials</h3>
+    <div class="o-well u-mt45">
+        <h2>Download activity</h2>
+            <h3 class="h5">Teacher guide</h3>
             <p>
-                <a class="a-link a-link__icon" target="_blank" rel="noopener noreferrer" href="{{ page.handout_file.url }}">
-                    <span class="a-link_text">{{ page.handout_file.title | striptags | safe }}</span>
+                <a class="a-link a-link__icon" target="_blank" rel="noopener noreferrer" href="{{ page.activity_file.url }}">
+                    <span class="a-link_text">{{ page.activity_file.title | striptags | safe }}</span>
                     <span class="a-icon">{{ svg_icon('download') }}</span>
                 </a>
             </p>
-        {% endif %}
-        {% if page.handout_file_2 %}
-            <p>
-                <a class="a-link a-link__icon" target="_blank" rel="noopener noreferrer" href="{{ page.handout_file_2.url }}">
-                    <span class="a-link_text">{{ page.handout_file_2.title | striptags | safe }}</span>
-                    <span class="a-icon">{{ svg_icon('download') }}</span>
-                </a>
-            </p>
-        {% endif %}
-        {% if page.handout_file_3 %}
-            <p>
-                <a class="a-link a-link__icon" target="_blank" rel="noopener noreferrer" href="{{ page.handout_file_3.url }}">
-                    <span class="a-link_text">{{ page.handout_file_3.title | striptags | safe }}</span>
-                    <span class="a-icon">{{ svg_icon('download') }}</span>
-                </a>
-            </p>
-        {% endif %}
-
+            {% if page.handout_file %}
+                <h3 class="h5">Student materials</h3>
+                <p>
+                    <a class="a-link a-link__icon" target="_blank" rel="noopener noreferrer" href="{{ page.handout_file.url }}">
+                        <span class="a-link_text">{{ page.handout_file.title | striptags | safe }}</span>
+                        <span class="a-icon">{{ svg_icon('download') }}</span>
+                    </a>
+                </p>
+            {% endif %}
+            {% if page.handout_file_2 %}
+                <p>
+                    <a class="a-link a-link__icon" target="_blank" rel="noopener noreferrer" href="{{ page.handout_file_2.url }}">
+                        <span class="a-link_text">{{ page.handout_file_2.title | striptags | safe }}</span>
+                        <span class="a-icon">{{ svg_icon('download') }}</span>
+                    </a>
+                </p>
+            {% endif %}
+            {% if page.handout_file_3 %}
+                <p>
+                    <a class="a-link a-link__icon" target="_blank" rel="noopener noreferrer" href="{{ page.handout_file_3.url }}">
+                        <span class="a-link_text">{{ page.handout_file_3.title | striptags | safe }}</span>
+                        <span class="a-icon">{{ svg_icon('download') }}</span>
+                    </a>
+                </p>
+            {% endif %}
     </div>
 {% endblock content_main %}
 


### PR DESCRIPTION
Edits to Activity detail page Download activity block (H3 tags given h6 styling at mobile widths; adjustments to the Download block's bottom padding values at mobile and desktop widths.

Note:  the wrapper div around the download links with class .u-mb30 was removed in PR #247.