### PR TITLE
Fix form label for search input

### DIFF
--- a/teachers_digital_platform/jinja2/teachers_digital_platform/activity_index_page.html
+++ b/teachers_digital_platform/jinja2/teachers_digital_platform/activity_index_page.html
@@ -65,10 +65,12 @@
                 <div class="o-form__input-w-btn">
                     <div class="o-form__input-w-btn_input-container">
                         <div class="m-btn-inside-input input-contains-label">
-                            <label for="searchText" class="input-contains-label_before input-contains-label_before__search">{{ svg_icon('search') }}</label>
+                            <label for="searchText" class="input-contains-label_before input-contains-label_before__search">
+                                {{ svg_icon('search') }}
+                                <span class="u-visually-hidden">The term to search for</span>
+                            </label>
                             <input id="searchText" type="text" autocomplete="off" class="a-text-input" name="q"
                                     placeholder="Enter your search term(s)"
-                                    aria-label="The term to search for"
                                     value="{% if page.results.search_query: %}{{ page.results.search_query }}{% endif %}">
                         </div>
                     </div>


### PR DESCRIPTION
Form label cannot be empty to pass WAVE toolbar.

## Review

- @rrstoll 

[Preview this PR without the whitespace changes](?w=0)
