### PR TITLE
Fix dirty Travis wheel names

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,8 +7,8 @@ install:
 script:
 - nvm install 8 && nvm use 8
 - npm install -g gulp-cli
-- npm install
 - npm config set package-lock false
+- npm install
 - tox
 - npm test
 - python setup.py bdist_wheel


### PR DESCRIPTION
As a follow-up to #213, this fixes dirty wheel names as built by Travis. Moving the disabling of `package-lock.json` up better prevents creation of that file. Without changes to that file, the local git workspace looks cleaner, allowing for proper build wheel names.

See https://travis-ci.org/chosak/teachers-digital-platform/jobs/428793415 for a Travis release wheel build on my fork that successfully build a wheel named `teachers_digital_platform-1.0.5` -- ignore the error at the end due to an expected GH upload failure.