### PR TITLE
[TDP-259] add element-qsa-scope polyfill for edge and ie11

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -6665,6 +6665,11 @@
       "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.3.28.tgz",
       "integrity": "sha1-jdTmRYCGZE6fnwoc8y4qH53/2e4="
     },
+    "element-qsa-scope": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/element-qsa-scope/-/element-qsa-scope-1.1.0.tgz",
+      "integrity": "sha512-oBBTdmleT5eJ0r5/3/tVg0NcWv95ut4Oxj5Oh/IkZ3kc0UACF8psJU8Rocd4aXDgtoE5WD5/rqYOXvjOE1DxIg=="
+    },
     "elliptic": {
       "version": "6.4.0",
       "resolved": "https://registry.npmjs.org/elliptic/-/elliptic-6.4.0.tgz",

--- a/package.json
+++ b/package.json
@@ -48,6 +48,7 @@
     "cf-tables": "4.2.1",
     "cf-typography": "4.6.0",
     "del": "3.0.0",
+    "element-qsa-scope": "1.1.0",
     "es5-shim": "4.5.9",
     "glob-all": "3.1.0",
     "gulp": "3.9.1",

--- a/teachers_digital_platform/js/search.js
+++ b/teachers_digital_platform/js/search.js
@@ -7,6 +7,7 @@ const find = require( './util/dom-traverse' ).queryOne;
 const expandableFacets = require( './expandable-facets' );
 const cfExpandables = require( 'cf-expandables/src/Expandable' );
 const tdpAnalytics = require( './tdp-analytics' );
+require( 'element-qsa-scope' );
 
 
 // Keep track of the most recent XHR request so that we can cancel it if need be

--- a/teachers_digital_platform/js/tdp-analytics.js
+++ b/teachers_digital_platform/js/tdp-analytics.js
@@ -4,6 +4,7 @@ const Analytics = require( './Analytics' );
 const closest = require( './util/dom-traverse' ).closest;
 const bindEvent = require( './util/dom-events' ).bindEvent;
 const find = require( './util/dom-traverse' ).queryOne;
+require( 'element-qsa-scope' );
 
 /* eslint-disable consistent-return */
 


### PR DESCRIPTION
Added Element QSA Scope (https://www.npmjs.com/package/element-qsa-scope) to support querySelectorAll(':scope') in Edge and IE11.

## Testing

- See testing steps in #259 

## Review

- @Scotchester @atuggle 


## Checklist

* [ ] Changes are limited to a single goal (no scope creep)
* [ ] Code can be automatically merged (no conflicts)
* [ ] Code follows the standards laid out in the [front end playbook](https://github.com/cfpb/front-end)
* [ ] Passes all existing automated tests
* [ ] New functions include new tests
* [ ] New functions are documented (with a description, list of inputs, and expected output)
* [ ] Placeholder code is flagged
* [ ] Visually tested in supported browsers and devices
* [ ] Project documentation has been updated (including the "Unreleased" section of the CHANGELOG)
