### PR TITLE
TDP: Got Unit Test working with RoutablePageMixin

### DIFF
--- a/teachers_digital_platform/fixtures/tdp_initial_data.json
+++ b/teachers_digital_platform/fixtures/tdp_initial_data.json
@@ -399,7 +399,7 @@
             "weight": 0,
             "title": "English language learner (ELL)"
         },
-        "model": "teachers_digital_platform.activityspecialpopulation",
+        "model": "teachers_digital_platform.activitystudentcharacteristics",
         "pk": 1
     },
     {
@@ -407,7 +407,7 @@
             "weight": 0,
             "title": "Free and reduced lunch (FRL)"
         },
-        "model": "teachers_digital_platform.activityspecialpopulation",
+        "model": "teachers_digital_platform.activitystudentcharacteristics",
         "pk": 2
     },
     {
@@ -415,7 +415,7 @@
             "weight": 0,
             "title": "Rural communities"
         },
-        "model": "teachers_digital_platform.activityspecialpopulation",
+        "model": "teachers_digital_platform.activitystudentcharacteristics",
         "pk": 3
     },
     {
@@ -423,7 +423,7 @@
             "weight": 0,
             "title": "Special education (SPED)"
         },
-        "model": "teachers_digital_platform.activityspecialpopulation",
+        "model": "teachers_digital_platform.activitystudentcharacteristics",
         "pk": 4
     },
     {
@@ -431,7 +431,7 @@
             "weight": 0,
             "title": "Urban communities"
         },
-        "model": "teachers_digital_platform.activityspecialpopulation",
+        "model": "teachers_digital_platform.activitystudentcharacteristics",
         "pk": 5
     },
     {

--- a/teachers_digital_platform/tests/models/test_pages_utilities.py
+++ b/teachers_digital_platform/tests/models/test_pages_utilities.py
@@ -1,0 +1,29 @@
+from wagtail.tests.utils import WagtailTestUtils
+from django.test.client import RequestFactory
+from django.core.paginator import Paginator
+from django.http import Http404, HttpRequest, HttpResponse
+from unittest import TestCase
+
+from teachers_digital_platform.models.pages import validate_results_per_page
+
+class PagingTestCases(TestCase, WagtailTestUtils):
+
+    def test_validate_results_per_page_default_id_five(self):
+        mock_request = HttpRequest()
+        default_per_page = 5
+        results_per_page = validate_results_per_page(mock_request)
+        self.assertEqual(results_per_page, default_per_page)
+
+    def test_validate_results_per_page_by_request_ten_is_correct(self):
+        factory = RequestFactory()
+        expectedVaue = 10
+        mock_request = factory.get('/search/?q=test&results=' + str(expectedVaue))
+        results_per_page = validate_results_per_page(mock_request)
+        self.assertEqual(results_per_page, expectedVaue)
+
+    def test_validate_results_per_page_by_request_fifty_is_correct(self):
+        factory = RequestFactory()
+        expectedVaue = 50
+        mock_request = factory.get('/search/?q=test&results=' + str(expectedVaue))
+        results_per_page = validate_results_per_page(mock_request)
+        self.assertEqual(results_per_page, expectedVaue)

--- a/teachers_digital_platform/tests/settings.py
+++ b/teachers_digital_platform/tests/settings.py
@@ -1,1 +1,4 @@
 from cfgov.settings.test_nomigrations import *
+
+# Put any test settings that might be needed here
+SECRET_KEY = 'testing'


### PR DESCRIPTION
Implemented initial Search page Unit Test using tox.  

### WARNING: To get this working I had to update the module ActivityIndexPage.search in pages.py.  Specifically I moved 100% of its business logic to the "get_context(...)" definition. (This was a rather small code change)
Reasons for this are listed below in Additions:

## Additions
1. When rendering the page from a unit test, using page.serve(...) or client.get(...) the search method was because they both use the serve(...) which then calls get_context(...) skipping the part where we add facets to the context so the template would fail to load because it depends on the facets

- See wagtail documentation on page.serve(...) here: https://github.com/wagtail/wagtail/blob/master/wagtail/core/models.py#L716
- Since serve invokes both get_template & get_context, this appears to be the recommended way to implement the business logic for a view

2. I implemented 2 unit test one that renders the search index page "ActivityIndexPage" with no URL query parameters. and one that renders it with multiple URL query parameters.
- I will be able to move forward much faster with all the test required for testing the search/facets functionality now that I have the initial render with and without query parameters.

3. Implemented test_pages_utilities for testing any definition not inside a page class (i.e. def validate_results_per_page(...) )

## Testing

- execute the following command at the root of teachers_digital_platform repository:
%> tox -e py27-dj18

## Review

- @nbucknor @Scotchester @willbarton

[Preview this PR without the whitespace changes](?w=0)
