### PR TITLE
TDP: Implemented UnitTest and removed RoutablePageMixin

### DIFF
--- a/teachers_digital_platform/fixtures/tdp_initial_data.json
+++ b/teachers_digital_platform/fixtures/tdp_initial_data.json
@@ -399,7 +399,7 @@
             "weight": 0,
             "title": "English language learner (ELL)"
         },
-        "model": "teachers_digital_platform.activityspecialpopulation",
+        "model": "teachers_digital_platform.activitystudentcharacteristics",
         "pk": 1
     },
     {
@@ -407,7 +407,7 @@
             "weight": 0,
             "title": "Free and reduced lunch (FRL)"
         },
-        "model": "teachers_digital_platform.activityspecialpopulation",
+        "model": "teachers_digital_platform.activitystudentcharacteristics",
         "pk": 2
     },
     {
@@ -415,7 +415,7 @@
             "weight": 0,
             "title": "Rural communities"
         },
-        "model": "teachers_digital_platform.activityspecialpopulation",
+        "model": "teachers_digital_platform.activitystudentcharacteristics",
         "pk": 3
     },
     {
@@ -423,7 +423,7 @@
             "weight": 0,
             "title": "Special education (SPED)"
         },
-        "model": "teachers_digital_platform.activityspecialpopulation",
+        "model": "teachers_digital_platform.activitystudentcharacteristics",
         "pk": 4
     },
     {
@@ -431,7 +431,7 @@
             "weight": 0,
             "title": "Urban communities"
         },
-        "model": "teachers_digital_platform.activityspecialpopulation",
+        "model": "teachers_digital_platform.activitystudentcharacteristics",
         "pk": 5
     },
     {

--- a/teachers_digital_platform/models/pages.py
+++ b/teachers_digital_platform/models/pages.py
@@ -39,7 +39,8 @@ from teachers_digital_platform.models import (
     ActivityDuration, ActivityJumpStartCoalition, ActivityCouncilForEconEd
 )
 
-class ActivityIndexPage(RoutablePageMixin, CFGOVPage):
+
+class ActivityIndexPage(CFGOVPage):
     """
     A model for the Activity Search page.
     """
@@ -72,11 +73,7 @@ class ActivityIndexPage(RoutablePageMixin, CFGOVPage):
             template = 'teachers_digital_platform/activity_search_facets_and_results.html'
         return template
 
-
-    @route(r'^$')
-    @flag_check('TDP_SEARCH_INTERFACE', True)
-    def search(self, request, *args, **kwargs):
-
+    def get_context(self, request, *args, **kwargs):
         facet_map = (
             ('building_block', (ActivityBuildingBlock, False, 10)),
             ('school_subject', (ActivitySchoolSubject, False, 25)),
@@ -161,12 +158,12 @@ class ActivityIndexPage(RoutablePageMixin, CFGOVPage):
             'total_results': total_results,
         })
         self.results = payload
-        context = self.get_context(request)
         results_per_page = validate_results_per_page(request)
         paginator = Paginator(payload['results'], results_per_page)
         current_page = validate_page_number(request, paginator)
         paginated_page = paginator.page(current_page)
 
+        context = super(ActivityIndexPage, self).get_context(request)
         context.update({
             'facet_counts': facet_counts,
             'facets': all_facets,
@@ -177,10 +174,7 @@ class ActivityIndexPage(RoutablePageMixin, CFGOVPage):
             'paginator': paginator,
             'show_filters': bool(facet_queries),
         })
-        return TemplateResponse(
-            request,
-            self.get_template(request),
-            context)
+        return context
 
     def get_flat_facets(self, class_object, narrowed_facets, selected_facets):
         final_facets = [
@@ -424,7 +418,7 @@ def validate_results_per_page(request):
     A utility for parsing the requested number of results per page.
 
     This should catch an invalid number of results and always return
-    a valid number of results, defaulting to 10.
+    a valid number of results, defaulting to 5.
     """
     raw_results = request.GET.get('results')
     if raw_results in ['10', '25', '50']:

--- a/teachers_digital_platform/tests/models/test_pages_utilities.py
+++ b/teachers_digital_platform/tests/models/test_pages_utilities.py
@@ -1,0 +1,31 @@
+from wagtail.wagtailcore.models import Page
+from wagtail.tests.utils import WagtailPageTests
+from wagtail.tests.utils import WagtailTestUtils
+from django.test.client import RequestFactory
+from django.core.paginator import Paginator
+from django.http import Http404, HttpRequest, HttpResponse
+from unittest import TestCase
+
+from teachers_digital_platform.models.pages import validate_results_per_page
+
+class PagingTestCases(TestCase, WagtailTestUtils):
+
+    def test_validate_results_per_page_default_id_five(self):
+        mock_request = HttpRequest()
+        default_per_page = 5
+        results_per_page = validate_results_per_page(mock_request)
+        self.assertEqual(results_per_page, default_per_page)
+
+    def test_validate_results_per_page_by_request_ten_is_correct(self):
+        factory = RequestFactory()
+        expectedVaue = 10
+        mock_request = factory.get('/search/?q=test&results=' + str(expectedVaue))
+        results_per_page = validate_results_per_page(mock_request)
+        self.assertEqual(results_per_page, expectedVaue)
+
+    def test_validate_results_per_page_by_request_fifty_is_correct(self):
+        factory = RequestFactory()
+        expectedVaue = 50
+        mock_request = factory.get('/search/?q=test&results=' + str(expectedVaue))
+        results_per_page = validate_results_per_page(mock_request)
+        self.assertEqual(results_per_page, expectedVaue)


### PR DESCRIPTION
Removed RoutablePageMixin and Implemented initial Search page Unit Test using tox.  

### NOTE: I removed the implementation of the RoutablePageMixin, and renamed the "search(...)" method to get_context(...).  This is because wagtail will call the serve method on the page that will invoke get_context & get_template, so we need all our search functionality in the get_context(...) method. (See wagtail implementation of the Serve(...) method here: https://github.com/wagtail/wagtail/blob/master/wagtail/core/models.py#L716)

Reasons for this are listed below in Additions:

## Additions
1. When rendering the page from a unit test, using page.serve(...) or client.get(...) the search method was because they both use the serve(...) which then calls get_context(...) skipping the part where we add facets to the context so the template would fail to load because it depends on the facets

- See wagtail documentation on page.serve(...) here (as mentioned above): https://github.com/wagtail/wagtail/blob/master/wagtail/core/models.py#L716
- Since serve invokes both get_template & get_context, this appears to be the recommended way to implement the business logic for a view

2. I implemented 2 unit test one that renders the search index page "ActivityIndexPage" with no URL query parameters. and one that renders it with multiple URL query parameters.
- I will be able to move forward much faster with all the test required for testing the search/facets functionality now that I have the initial render with and without query parameters.

3. Implemented test_pages_utilities for testing any definition not inside a page class (i.e. def validate_results_per_page(...) )

## Testing

- execute the following command at the root of teachers_digital_platform repository:
%> tox -e py27-dj18

## Review

- @nbucknor @Scotchester @willbarton

[Preview this PR without the whitespace changes](?w=0)
