### PR TITLE
Fix location of scrolling target

### DIFF
--- a/teachers_digital_platform/js/scroll.js
+++ b/teachers_digital_platform/js/scroll.js
@@ -16,7 +16,7 @@ const scroll = {
         event.preventDefault();
 
         // Scroll smoothly to the target.
-        target.scrollIntoView( { behavior: 'smooth' } );
+        target.scrollIntoView( { behavior: 'smooth', block: 'start' } );
 
         // Update url hash.
         if ( history.pushState ) {


### PR DESCRIPTION
Fix location of scrolling target so that the illustration is always at the top.

## Review

- @rrstoll 

[Preview this PR without the whitespace changes](?w=0)
