### PR TITLE
Update TDP search tool's results count format

### DIFF
--- a/teachers_digital_platform/jinja2/teachers_digital_platform/activity_search_facets_and_results.html
+++ b/teachers_digital_platform/jinja2/teachers_digital_platform/activity_search_facets_and_results.html
@@ -435,9 +435,16 @@
 <section id="tdp-search-results" class="content_main content__flush-all-on-small content__flush-bottom results{% if not activities %} results__full{% endif %}" tabindex="-1">
     <a id="content_main"></a>
     <div class="results_header">
-        {% if activities %}
+        {% if page.results.total_results and page.results.total_results > 0 %}
             <div class="results_count">
-                <h3>Showing {{ activities | length }} of {{ page.results.total_results }}  results</h3>
+                <h3>
+                    {% if page.results.total_activities > page.results.total_results %}
+                        Showing {{ page.results.total_results }}
+                        match{% if page.results.total_results > 1 %}es{% endif %}
+                        out of
+                    {% endif %}
+                    {{ page.results.total_activities }} activities
+                </h3>
             </div>
         {% else %}
             <div class="results_count results_count__empty">

--- a/teachers_digital_platform/models/pages.py
+++ b/teachers_digital_platform/models/pages.py
@@ -90,6 +90,7 @@ class ActivityIndexPage(CFGOVPage):
         )
         search_query = request.GET.get('q', '')  # haystack cleans this string
         sqs = SearchQuerySet().models(ActivityPage).filter(live=True)
+        total_activities = sqs.count()
         # Load selected facets
         selected_facets = {}
         facet_queries = {}
@@ -104,6 +105,7 @@ class ActivityIndexPage(CFGOVPage):
             'search_query': search_query,
             'results': [],
             'total_results': 0,
+            'total_activities': total_activities,
             'selected_facets': selected_facets,
             'facet_queries': facet_queries,
             'all_facets': {},


### PR DESCRIPTION
Updating results count format to match:

> Desired syntax for results
> Default display: [x] activities (where x is the total number of activities currently in wagtail)
> Filtered display: Showing [y] matches of [x] activities (where y is the number of results based on the user filters / search)

## Checklist

* [x] Changes are limited to a single goal (no scope creep)
* [x] Code can be automatically merged (no conflicts)
* [ ] Code follows the standards laid out in the [front end playbook](https://github.com/cfpb/front-end)
* [ ] Passes all existing automated tests
* [x] New functions include new tests
* [ ] New functions are documented (with a description, list of inputs, and expected output)
* [x] Placeholder code is flagged
* [ ] Visually tested in supported browsers and devices
* [ ] Project documentation has been updated (including the "Unreleased" section of the CHANGELOG)
