### PR TITLE
Fix printing in Firefox for main content

### DIFF
--- a/teachers_digital_platform/css/cf-enhancements/base.less
+++ b/teachers_digital_platform/css/cf-enhancements/base.less
@@ -10,3 +10,12 @@
     text-shadow: none;
     text-transform: none;
 }
+
+// Layout
+// Remove once display: inline-block is no longer used in cf-grid.
+
+.content_main {
+    @media print {
+        display: block !important;
+    }
+}


### PR DESCRIPTION
Firefox will only print the first page of content within an element with `display: inline-block`, which the capital-framework grid system uses for layout.

## Changes

- Change the display of the `main_content` to block when printing the page.

## Review

- @rrstoll 

[Preview this PR without the whitespace changes](?w=0)
