### PR TITLE
[TDP] Add all fields to keyword search

### DIFF
--- a/teachers_digital_platform/templates/search/indexes/teachers_digital_platform/activitypage_text.txt
+++ b/teachers_digital_platform/templates/search/indexes/teachers_digital_platform/activitypage_text.txt
@@ -12,3 +12,37 @@
 {% for building_block in object.building_block.all %}
 {{ building_block.title|striptags|safe }}
 {% endfor %}
+
+{% for grade_level in object.grade_level.all %}
+{{ grade_level.title|striptags|safe }}
+{% endfor %}
+
+{% for age_range in object.age_range.all %}
+{{ age_range.title|striptags|safe }}
+{% endfor %}
+
+{% for student_characteristics in object.student_characteristics.all %}
+{{ student_characteristics.title|striptags|safe }}
+{% endfor %}
+
+{% for activity_type in object.activity_type.all %}
+{{ activity_type.title|striptags|safe }}
+{% endfor %}
+
+{% for teaching_strategy in object.teaching_strategy.all %}
+{{ teaching_strategy.title|striptags|safe }}
+{% endfor %}
+
+{% for blooms_taxonomy_level in object.blooms_taxonomy_level.all %}
+{{ blooms_taxonomy_level.title|striptags|safe }}
+{% endfor %}
+
+{{ object.activity_duration.title|striptags|safe }}
+
+{% for jump_start_coalition in object.jump_start_coalition.all %}
+{{ jump_start_coalition.title|striptags|safe }}
+{% endfor %}
+
+{% for council_for_economic_education in object.council_for_economic_education.all %}
+{{ council_for_economic_education.title|striptags|safe }}
+{% endfor %}


### PR DESCRIPTION
Adding all Activity page fields to elasticsearch for keyword search

## Changes

- updated activitypage_text.txt to include all activity page fields

## Testing

- After updating the search index, `./cfgov/manage.py update_index -r teachers_digital_platform`, try to search for text that exists in any of those fields.

## Review

- @atuggle 

## Checklist

* [ ] Changes are limited to a single goal (no scope creep)
* [ ] Code can be automatically merged (no conflicts)
* [ ] Code follows the standards laid out in the [front end playbook](https://github.com/cfpb/front-end)
* [ ] Passes all existing automated tests
* [ ] New functions include new tests
* [ ] New functions are documented (with a description, list of inputs, and expected output)
* [ ] Placeholder code is flagged
* [ ] Visually tested in supported browsers and devices
* [ ] Project documentation has been updated (including the "Unreleased" section of the CHANGELOG)
