### PR TITLE
[TDP] Fix clear filter tags in IE11

### DIFF
--- a/teachers_digital_platform/js/search.js
+++ b/teachers_digital_platform/js/search.js
@@ -64,15 +64,28 @@ function clearFilter( event ) {
     return;
   }
   target = closest( event.target, '.a-tag' );
-  const checkbox = find( `${ target.dataset.value }` );
+  const checkbox = find( `${ target.getAttribute( 'data-value' ) }` );
   // Remove the filter tag
-  target.remove();
+  removeTag( target );
   // Uncheck the filter checkbox
   checkbox.checked = false;
   if ( event instanceof Event ) {
     handleFilter( event, checkbox );
   }
 }
+
+/**
+ * Remove a filter tag from the search results page.
+ * node.remove() isn't supported by IE so we have to removeChild();
+ *
+ * @param {Node} tag Filter tag HTML element
+ */
+function removeTag( tag ) {
+  if ( tag.parentNode !== null ) {
+    tag.parentNode.removeChild( tag );
+  }
+}
+
 
 /**
  * Remove all filters from the search results page.

--- a/teachers_digital_platform/js/util/dom-traverse.js
+++ b/teachers_digital_platform/js/util/dom-traverse.js
@@ -72,14 +72,18 @@ function closest( elem, selector ) {
   const matchesSelector = _getMatchesMethod( elem );
   let match;
 
-  while ( elem ) {
-    if ( matchesSelector.bind( elem )( selector ) ) {
-      match = elem;
-    } else {
-      elem = elem.parentElement;
-    }
+  try {
+    while ( elem ) {
+      if ( matchesSelector.bind( elem )( selector ) ) {
+        match = elem;
+      } else {
+        elem = elem.parentNode;
+      }
 
-    if ( match ) { return elem; }
+      if ( match ) { return elem; }
+    }
+  } catch ( err ) {
+    return null;
   }
 
   return null;


### PR DESCRIPTION
Updating clear filter functionality to match eRegs. This fixes bugs in IE11 where the Clear Filter tags and Clear all filters link would throw JS errors.

## Checklist

* [ ] Changes are limited to a single goal (no scope creep)
* [ ] Code can be automatically merged (no conflicts)
* [ ] Code follows the standards laid out in the [front end playbook](https://github.com/cfpb/front-end)
* [ ] Passes all existing automated tests
* [ ] New functions include new tests
* [ ] New functions are documented (with a description, list of inputs, and expected output)
* [ ] Placeholder code is flagged
* [ ] Visually tested in supported browsers and devices
* [ ] Project documentation has been updated (including the "Unreleased" section of the CHANGELOG)
