### PR TITLE
Deprecate support for Django < 1.11

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -8,7 +8,7 @@ except (IOError, ImportError):
 
 
 install_requires = [
-    'Django>=1.8,<1.12',
+    'Django>=1.11,<1.12',
     'django-haystack',
     'django-mptt==0.9.0',
     'django-js-asset==1.1.0',
@@ -52,10 +52,7 @@ setup(
     },
     classifiers=[
         'Framework :: Django',
-        'Framework :: Django :: 1.10',
         'Framework :: Django :: 1.11',
-        'Framework :: Django :: 1.8',
-        'Framework :: Django :: 1.9',
         'License :: CC0 1.0 Universal (CC0 1.0) Public Domain Dedication',
         'License :: Public Domain',
         'Programming Language :: Python',

--- a/tox.ini
+++ b/tox.ini
@@ -1,6 +1,6 @@
 [tox]
 skipsdist=True
-envlist=lint,py{27,36}-dj{18,111}
+envlist=lint,py{27,36}-dj{111}
 
 [testenv]
 install_command=pip install -e ".[testing]" -U {opts} {packages}
@@ -18,7 +18,6 @@ basepython=
     py36: python3.6
 
 deps=
-    dj18: Django>=1.8,<1.9
     dj111: Django>=1.11,<1.12
 
 [testenv:lint]


### PR DESCRIPTION
Stop testing against Django 1.8 as cfgov-refresh no longer supports it. Remove support for Django 1.8/9/10 from setup.py.

## Checklist

* [X] Changes are limited to a single goal (no scope creep)
* [X] Code can be automatically merged (no conflicts)
* [X] Passes all existing automated tests
* [X] Project documentation has been updated (including the "Unreleased" section of the CHANGELOG)
