### PR TITLE
[TDP] Allow ActivityPages to go into the Trash and other HomePages

### DIFF
--- a/teachers_digital_platform/models/pages.py
+++ b/teachers_digital_platform/models/pages.py
@@ -26,7 +26,7 @@ from teachers_digital_platform.models import (
 )
 
 from v1.atomic_elements import molecules
-from v1.models import CFGOVPage, CFGOVPageManager
+from v1.models import CFGOVPage, CFGOVPageManager, HomePage
 
 
 class ActivityIndexPage(CFGOVPage):
@@ -253,7 +253,8 @@ class ActivityPage(CFGOVPage):
     """
     A model for the Activity Detail page.
     """
-    parent_page_types = [ActivityIndexPage]
+    # Allow Activity pages to exist under the ActivityIndexPage or the Trash
+    parent_page_types = [ActivityIndexPage, HomePage]
     subpage_types = []
     objects = CFGOVPageManager()
 

--- a/teachers_digital_platform/search_indexes.py
+++ b/teachers_digital_platform/search_indexes.py
@@ -110,5 +110,6 @@ class ActivityPageIndex(indexes.SearchIndex, indexes.Indexable):
 
     def index_queryset(self, using=None):
         """Only index descendants of the Activity Search page"""
+        # This is safe because ActivityIndexPage is a singleton
         search_page = ActivityIndexPage.objects.get()
         return self.get_model().objects.live().descendant_of(search_page)

--- a/teachers_digital_platform/search_indexes.py
+++ b/teachers_digital_platform/search_indexes.py
@@ -1,6 +1,6 @@
 from haystack import indexes
 
-from teachers_digital_platform.models import ActivityPage
+from teachers_digital_platform.models import ActivityIndexPage, ActivityPage
 
 
 class ActivityPageIndex(indexes.SearchIndex, indexes.Indexable):
@@ -107,3 +107,8 @@ class ActivityPageIndex(indexes.SearchIndex, indexes.Indexable):
 
     def get_model(self):
         return ActivityPage
+
+    def index_queryset(self, using=None):
+        """Only index descendants of the Activity Search page"""
+        search_page = ActivityIndexPage.objects.get()
+        return self.get_model().objects.live().descendant_of(search_page)

--- a/teachers_digital_platform/tests/models/test_activity_index_page.py
+++ b/teachers_digital_platform/tests/models/test_activity_index_page.py
@@ -40,7 +40,7 @@ class ActivityIndexPageTests(WagtailPageTests):
     def test_activity_page_parent_pages(self):
         self.assertAllowedParentPageTypes(
             ActivityPage,
-            {ActivityIndexPage}
+            {ActivityIndexPage, HomePage}
         )
 
     def test_can_create_activity_index_page(self):


### PR DESCRIPTION
Allow admins to move ActivityPages to the Trash folder.

## Review

- @willbarton @chosak @Scotchester 

## Test

1. In Wagtail admin, navigate to the Activity Search page (/admin/pages/11875/)
2. Hover over an activity in the list and click "More"
3. From the dropdown, choose "Move"
4. The Search page and HomePage pages should be the only selectable options
5. Click "Trash"
6. Click "Yes, move this page" button

## Notes

- Because Activity pages can be moved to the Trash folder, we'll need to rely on a periodic  or manual process for updating the search index after pages are moved to the trash.