### PR TITLE
Consolidate urls into one file, so we can delete individual url files…

### DIFF
--- a/teachers_digital_platform/tests/models/test_activity_index_page.py
+++ b/teachers_digital_platform/tests/models/test_activity_index_page.py
@@ -1,4 +1,4 @@
-from django.test import RequestFactory, TestCase, override_settings
+from django.test import RequestFactory, TestCase
 
 from wagtail.tests.utils import WagtailPageTests
 from wagtail.wagtailcore.blocks import StreamValue
@@ -20,9 +20,6 @@ from v1.models import HomePage
 from v1.tests.wagtail_pages.helpers import publish_page
 
 
-@override_settings(
-    FLAGS={'TDP_SEARCH_INTERFACE': {'boolean': True}}
-)
 class ActivityIndexPageTests(WagtailPageTests):
     @classmethod
     def setUpClass(self):

--- a/teachers_digital_platform/urls.py
+++ b/teachers_digital_platform/urls.py
@@ -1,0 +1,27 @@
+from django.conf.urls import url
+from django.views.generic import TemplateView
+
+from wagtailsharing.views import ServeView
+
+
+urlpatterns = [
+    url(
+        r'^curriculum-review/tool/$',
+        TemplateView.as_view(template_name='teachers_digital_platform/crt-survey.html')  # noqa: E501
+    ),
+
+    url(
+        r'^curriculum-review/before-you-begin/$',
+        TemplateView.as_view(template_name='teachers_digital_platform/crt-start.html')  # noqa: E501
+    ),
+
+    url(
+        r'^journey',
+        TemplateView.as_view(template_name='teachers_digital_platform/bb-tool.html')  # noqa: E501
+    ),
+
+    url(
+        r'^$',
+        lambda request: ServeView.as_view()(request, request.path)  # noqa: E501
+    )
+]


### PR DESCRIPTION

This is step one of a two stage effort to remove Feature flags for TDP and consolidate to a single urls.py file while removing the others.

Step 1. Add consolidated urls.py file then push an updated release of TDP to cfgov-refresh
Step 2. Remove bb_urls.py, begin_urls.py, and tool_urls.py then push an updated release

## Additions

- urls.py

## Removals

- removed references to TDP flags

