### PR TITLE
Remove duplicate CRTool frontend build

### DIFF
--- a/setup.sh
+++ b/setup.sh
@@ -54,11 +54,6 @@ clean() {
 
 # Install project dependencies.
 install() {
-  cd teachers_digital_platform/crtool
-  echo 'Installing CRTOOL React dependencies'
-  npm install -d --loglevel warn
-
-  cd ../..
   echo 'Installing front-end dependencies…'
   npm install -d --loglevel warn
 }


### PR DESCRIPTION
The `setup.sh` script install step currently initiates two frontend builds: first, one under the `teachers_digital_platform/crtool` subdirectory (for the CRTool) and then a second one in the root
directory.

This first step is unnecessary, though, as the `package.json` "postinstall" script [already invokes the CRTool build](https://github.com/cfpb/teachers-digital-platform/blob/3e86033698ff827570e03e753861a03386343c89/package.json#L16).

To confirm, manually delete `node_modules` both in the root and under `teachers_digital_platform/crtool`, and then run `setup.sh`. You'll see that both builds complete successfully.

You can also confirm the [local functionality of the tool](http://localhost:8000/practitioner-resources/youth-financial-education/curriculum-review/tool/).

## Checklist

* [X] Changes are limited to a single goal (no scope creep)
* [X] Code can be automatically merged (no conflicts)
* [X] Code follows the standards laid out in the [front end playbook](https://github.com/cfpb/front-end)
* [X] Passes all existing automated tests
* [ ] New functions include new tests
* [ ] New functions are documented (with a description, list of inputs, and expected output)
* [ ] Placeholder code is flagged
* [X] Visually tested in supported browsers and devices
* [X] Project documentation has been updated (including the "Unreleased" section of the CHANGELOG)