### PR TITLE
[TDP] send keywords that have no results to analytics

### DIFF
--- a/teachers_digital_platform/js/search.js
+++ b/teachers_digital_platform/js/search.js
@@ -151,7 +151,7 @@ function fetchSearchResults( filters = [] ) {
     // Reattach event handlers after tags are reloaded
     attachHandlers();
     // Send search query to Analytics.
-    tdpAnalytics.handleFetchSearchResults(searchField.value);
+    tdpAnalytics.handleFetchSearchResults( searchField.value );
     return data;
   } );
   return searchUrl;

--- a/teachers_digital_platform/js/tdp-analytics.js
+++ b/teachers_digital_platform/js/tdp-analytics.js
@@ -255,23 +255,27 @@ const handleFetchSearchResults = ( searchTerm, sendEventMethod ) => {
     return;
   }
 
-  // Send the result count to Analytics
+  // Send the keywords that return 0 results to Analytics.
   const resultsCountBlock = find( '#tdp-search-facets-and-results .results_count' );
   if ( resultsCountBlock ) {
     const resultsCount = resultsCountBlock.getAttribute( 'data-results-count' );
 
-    const action = 'searchResultCount';
-    const label = resultsCount;
-    if ( sendEventMethod ) {
-      sendEventMethod( action, label );
-    } else {
-      sendEvent( action, label );
+    // Check if result count is 0
+    if ( resultsCount === '0' ) {
+      const action = 'noSearchResults';
+      const label = searchTerm.toLowerCase() + ':0';
+
+      if ( sendEventMethod ) {
+        sendEventMethod( action, label );
+      } else {
+        sendEvent( action, label );
+      }
     }
   }
 
-  // Send the keyword to Analytics
+  // Send the keyword to Analytics.
   const action = 'search';
-  const label = searchTerm;
+  const label = searchTerm.toLowerCase();
   if ( sendEventMethod ) {
     return sendEventMethod( action, label );
   }


### PR DESCRIPTION
Short description explaining the high-level reason for the pull request

## Changes

- Convert keywords to lowercase before sending to Analytics
- Send "keyword:0" as label for "noSearchResults"

## Testing

- @kelleyholden will likely have to test this once it is deployed.

## Review

- @dcmouyard 