### PR TITLE
Don't try to install TDP into itself

### DIFF
--- a/install_cfgov_refresh.sh
+++ b/install_cfgov_refresh.sh
@@ -3,5 +3,12 @@
 git clone --depth 1 https://github.com/cfpb/cfgov-refresh
 cd cfgov-refresh
 pip install -r requirements/wagtail.txt
-pip install -r requirements/libraries.txt
+
+# If cfgov-refresh includes this project in its list of requirements, we should
+# skip it when installing dependencies.
+pip install $(
+    cat requirements/libraries.txt | \
+    awk '!/teachers_digital_platform/ && !/^#/'
+)
+
 pip install -r requirements/test.txt


### PR DESCRIPTION
[cfgov-refresh#5083](https://github.com/cfpb/cfgov-refresh/pull/5083) aims to make the cf.gov satellite apps (including this one) non-optional, meaning that they are treated the same as any other Python dependency. This is a bit problematic for TDP, because TDP both depends on and is depended on by cfgov-refresh.

This change modifies the install_cfgov_refresh.sh script so that it filters out teachers_digital_platform when installing cfgov-refresh dependencies. This avoids us installing a built wheel of this project which would hide the local directories that we really want to test.

## Checklist

* [X] Changes are limited to a single goal (no scope creep)
* [X] Code can be automatically merged (no conflicts)
* [X] Code follows the standards laid out in the [front end playbook](https://github.com/cfpb/front-end)
* [X] Passes all existing automated tests
* [ ] New functions include new tests
* [ ] New functions are documented (with a description, list of inputs, and expected output)
* [ ] Placeholder code is flagged
* [ ] Visually tested in supported browsers and devices
* [X] Project documentation has been updated (including the "Unreleased" section of the CHANGELOG)