### PR TITLE
[TDP] replace blooms taxonomy level with activity duration on search results

### DIFF
--- a/teachers_digital_platform/jinja2/teachers_digital_platform/activity_search_result.html
+++ b/teachers_digital_platform/jinja2/teachers_digital_platform/activity_search_result.html
@@ -29,8 +29,8 @@
                 {{ result.age_range.all() | join(', ') }}
             </div>
             <div class="layout-row">
-                <h5 class="activity_meta-key">Bloom’s Taxonomy level:</h5>
-                {{ result.blooms_taxonomy_level.all() | join(', ') }}
+                <h5 class="activity_meta-key">Activity duration:</h5>
+                {{ result.activity_duration }}
             </div>
         </div>
         <div>


### PR DESCRIPTION
Update ActivityPage Search result template to replace "Bloom's Taxonomy level" with "Activity duration"


## Testing

- Go here "practitioner-resources/youth-financial-education/teach/activities/"
- "Activity duration" should appear below "Age range" in search results

## Review

- @dcmouyard 

## Checklist

* [x] Changes are limited to a single goal (no scope creep)
* [x] Code can be automatically merged (no conflicts)
* [x] Code follows the standards laid out in the [front end playbook](https://github.com/cfpb/front-end)
* [x] Passes all existing automated tests
* [ ] Visually tested in supported browsers and devices