### PR TITLE
[TDP] similar activities block

### DIFF
--- a/README.md
+++ b/README.md
@@ -241,9 +241,11 @@ npm run test
 
 Unit tests can be found in "teachers_digital_platform/tests/"
 
-**The two main files are**:
+**The three main files are**:
 
 - teachers_digital_platform/tests/models/test_activity_index_page.py
+
+- teachers_digital_platform/tests/models/test_activity_page.py
 
 - teachers_digital_platform/tests/models/test_pages_utility_definitions.py
 

--- a/teachers_digital_platform/jinja2/teachers_digital_platform/activity_page.html
+++ b/teachers_digital_platform/jinja2/teachers_digital_platform/activity_page.html
@@ -65,8 +65,7 @@
     <div>
         <h2 class="u-mt45">Explore related resources</h2>
         <ul>
-            {% set parent_page = pageurl(page.get_parent()) %}
-            <li><a class="a-link a-lnk__icon" href="{{ parent_page }}?q=&topic={{page.get_subtopic_ids() | join('&topic=')}}&grade_level={{ page.get_grade_level_ids() | join('&grade_level=') }}">Search for related CFPB activities</a></li>
+            <li><a href="{{ page.get_related_activities_url() }}">Search for related CFPB activities</a></li>
             <li><a href="https://www.fdic.gov/consumers/consumer/moneysmart/young.html" target="_blank">Find financial education lessons from FDIC</a></li>
             <li><a href="https://www.federalreserveeducation.org/" target="_blank">View financial education resources from the Federal Reserve</a></li>
         </ul>

--- a/teachers_digital_platform/jinja2/teachers_digital_platform/activity_page.html
+++ b/teachers_digital_platform/jinja2/teachers_digital_platform/activity_page.html
@@ -65,7 +65,7 @@
     <div>
         <h2 class="u-mt45">Explore related resources</h2>
         <ul>
-            {% set parent_page = page.get_parent().url %}
+            {% set parent_page = pageurl(page.get_parent()) %}
             <li><a class="a-link a-lnk__icon" href="{{ parent_page }}?q=&topic={{page.get_subtopic_ids() | join('&topic=')}}&grade_level={{ page.get_grade_level_ids() | join('&grade_level=') }}">Search for related CFPB activities</a></li>
             <li><a href="https://www.fdic.gov/consumers/consumer/moneysmart/young.html" target="_blank">Find financial education lessons from FDIC</a></li>
             <li><a href="https://www.federalreserveeducation.org/" target="_blank">View financial education resources from the Federal Reserve</a></li>

--- a/teachers_digital_platform/jinja2/teachers_digital_platform/activity_page.html
+++ b/teachers_digital_platform/jinja2/teachers_digital_platform/activity_page.html
@@ -63,7 +63,7 @@
             {% endif %}
     </div>
     <div>
-        <h2 class="u-mt45">Explore similar activities</h2>
+        <h2 class="u-mt45">Explore related resources</h2>
         <ul>
             {% set parent_page = page.get_parent().url %}
             <li><a class="a-link a-lnk__icon" href="{{ parent_page }}?q=&topic={{page.get_subtopic_ids() | join('&topic=')}}&grade_level={{ page.get_grade_level_ids() | join('&grade_level=') }}">Search for related CFPB activities</a></li>

--- a/teachers_digital_platform/jinja2/teachers_digital_platform/activity_page.html
+++ b/teachers_digital_platform/jinja2/teachers_digital_platform/activity_page.html
@@ -62,6 +62,15 @@
                 </p>
             {% endif %}
     </div>
+    <div>
+        <h2 class="u-mt45">Explore similar activities</h2>
+        <ul>
+            {% set parent_page = page.get_parent().url %}
+            <li><a class="a-link a-lnk__icon" href="{{ parent_page }}?q=&topic={{page.get_subtopic_ids() | join('&topic=')}}&grade_level={{ page.get_grade_level_ids() | join('&grade_level=') }}">Search for related CFPB activities</a></li>
+            <li><a href="https://www.fdic.gov/consumers/consumer/moneysmart/young.html" target="_blank">Find financial education lessons from FDIC</a></li>
+            <li><a href="https://www.federalreserveeducation.org/" target="_blank">View financial education resources from the Federal Reserve</a></li>
+        </ul>
+    </div>
 {% endblock content_main %}
 
 {% block content_sidebar scoped %}

--- a/teachers_digital_platform/models/pages.py
+++ b/teachers_digital_platform/models/pages.py
@@ -401,6 +401,21 @@ class ActivityPage(CFGOVPage):
         index.FilterField('council_for_economic_education'),
     ]
 
+    def get_subtopic_ids(self):
+        """
+        Get a list of this activity's subtopic ids
+        """
+        topic_ids = [topic.id for topic in self.topic.all()]
+        root_ids = ActivityTopic.objects.filter(id__in=topic_ids).filter(parent=None).values_list('id', flat=True)
+        return set(topic_ids) - set(root_ids)
+
+    def get_grade_level_ids(self):
+        """
+        Get a list of this activity's grade_level ids
+        """
+        grade_level_ids = [grade_level.id for grade_level in self.grade_level.all()]
+        return grade_level_ids
+
     def get_topics_list(self, parent=None):
         """
         Get a hierarchical list of this activity's topics.

--- a/teachers_digital_platform/models/pages.py
+++ b/teachers_digital_platform/models/pages.py
@@ -420,6 +420,26 @@ class ActivityPage(CFGOVPage):
         ]
         return grade_level_ids
 
+    def get_related_activities_url(self):
+        """
+        Generate a search url for related Activities by
+        subtopic and grade-level
+        """
+        parent_page = self.get_parent()
+        subtopic_ids = [str(x) for x in self.get_subtopic_ids()]
+        grade_level_ids = [str(y) for y in self.get_grade_level_ids()]
+
+        url = parent_page.get_url() + '?q='
+        if subtopic_ids:
+            subtopics = '&topic=' + \
+                        '&topic='.join(subtopic_ids)
+            url += subtopics
+        if grade_level_ids:
+            grade_levels = '&grade_level=' + \
+                           '&grade_level='.join(grade_level_ids)
+            url += grade_levels
+        return url
+
     def get_topics_list(self, parent=None):
         """
         Get a hierarchical list of this activity's topics.

--- a/teachers_digital_platform/models/pages.py
+++ b/teachers_digital_platform/models/pages.py
@@ -406,9 +406,8 @@ class ActivityPage(CFGOVPage):
         Get a list of this activity's subtopic ids
         """
         topic_ids = [topic.id for topic in self.topic.all()]
-        root_ids = ActivityTopic.objects\
-            .filter(id__in=topic_ids)\
-            .filter(parent=None)\
+        root_ids = ActivityTopic.objects \
+            .filter(id__in=topic_ids, parent=None) \
             .values_list('id', flat=True)
         return set(topic_ids) - set(root_ids)
 

--- a/teachers_digital_platform/models/pages.py
+++ b/teachers_digital_platform/models/pages.py
@@ -406,14 +406,19 @@ class ActivityPage(CFGOVPage):
         Get a list of this activity's subtopic ids
         """
         topic_ids = [topic.id for topic in self.topic.all()]
-        root_ids = ActivityTopic.objects.filter(id__in=topic_ids).filter(parent=None).values_list('id', flat=True)
+        root_ids = ActivityTopic.objects\
+            .filter(id__in=topic_ids)\
+            .filter(parent=None)\
+            .values_list('id', flat=True)
         return set(topic_ids) - set(root_ids)
 
     def get_grade_level_ids(self):
         """
         Get a list of this activity's grade_level ids
         """
-        grade_level_ids = [grade_level.id for grade_level in self.grade_level.all()]
+        grade_level_ids = [
+            grade_level.id for grade_level in self.grade_level.all()
+        ]
         return grade_level_ids
 
     def get_topics_list(self, parent=None):

--- a/teachers_digital_platform/tests/models/test_activity_page.py
+++ b/teachers_digital_platform/tests/models/test_activity_page.py
@@ -1,0 +1,91 @@
+from django.test import TestCase
+
+from wagtail.wagtaildocs.models import Document
+
+from model_mommy import mommy
+from teachers_digital_platform.models import (
+    ActivityAgeRange, ActivityBloomsTaxonomyLevel, ActivityBuildingBlock,
+    ActivityCouncilForEconEd, ActivityDuration, ActivityGradeLevel,
+    ActivityJumpStartCoalition, ActivityPage, ActivitySchoolSubject,
+    ActivityTeachingStrategy, ActivityTopic, ActivityType
+)
+
+
+class TestActivityPage(TestCase):
+    fixtures = ['tdp_initial_data']
+
+    def setUp(self):
+        super(TestActivityPage, self).setUp()
+
+    def test_get_subtopic_ids_returns_correct_subtopics(self):
+        # Arrange
+        activity_page = self.create_activity_detail_page('Test', 'test')
+        # Act
+        actual_subtopic_ids = activity_page.get_subtopic_ids()
+        # Assert
+        self.assertTrue(6 not in actual_subtopic_ids)
+        self.assertTrue(7 in actual_subtopic_ids)
+
+    def test_get_subtopic_ids_works_with_no_topics(self):
+        # Arrange
+        activity_page = self.create_activity_detail_page('Test', 'test', topic_list=[])  # noqa: E501
+        # Act
+        actual_subtopic_ids = activity_page.get_subtopic_ids()
+        # Assert
+        self.assertTrue(isinstance(actual_subtopic_ids, (list, set)))
+        self.assertFalse(actual_subtopic_ids)
+
+    def test_get_subtopic_ids_works_with_no_subtopics(self):
+        # Arrange
+        activity_page = self.create_activity_detail_page('Test', 'test', topic_list=[6])  # noqa: E501
+        # Act
+        actual_subtopic_ids = activity_page.get_subtopic_ids()
+        # Assert
+        self.assertTrue(isinstance(actual_subtopic_ids, (list, set)))
+        self.assertFalse(actual_subtopic_ids)
+
+    def test_get_grade_level_ids_returns_correct_grade_levels(self):
+        # Arrange
+        activity_page = self.create_activity_detail_page('Test', 'test')
+        # Act
+        actual_grade_level_ids = activity_page.get_grade_level_ids()
+        # Assert
+        self.assertTrue(2 in actual_grade_level_ids)
+        self.assertTrue(1 == len(actual_grade_level_ids))
+
+    def test_get_grade_level_ids_works_with_no_grade_levels(self):
+        # Arrange
+        activity_page = self.create_activity_detail_page('Test', 'test', grade_level_list=[])  # noqa: E501
+        # Act
+        actual_grade_level_ids = activity_page.get_grade_level_ids()
+        # Assert
+        self.assertTrue(isinstance(actual_grade_level_ids, (list, set)))
+        self.assertFalse(actual_grade_level_ids)
+
+    def create_activity_detail_page(self, title='title', slug='slug', topic_list=[6, 7], grade_level_list=[2]):  # noqa: E501
+        activity_page = ActivityPage(
+            live=True,
+            title=title,
+            slug=slug,
+            path=slug,
+            activity_file=mommy.make(Document),
+            date="2018-07-31",
+            summary="Students will discuss short-term and long-term goals and what\r\nmakes a goal SMART. They\u2019ll then create a short-term savings goal\r\nand make a plan to meet that goal.",  # noqa: E501
+            big_idea="<p>Saving money is essential to a positive\u00a0financial future.</p>",  # noqa: E501
+            objectives="<ul><li>Understand the importance of setting SMARTsavings goals<br/></li><li>Create a short-term SMART savings goal</li><li>Make an action plan to save money</li></ul>",  # noqa: E501
+            essential_questions="<p></p><ul><li>How can I reach my savings goals?<br/></li></ul><p></p>",  # noqa: E501
+            what_students_will_do="<ul><li>Use the \u201cCreating a savings plan\u201d worksheet to\u00a0brainstorm a financial goal<br/></li><li>Create a SMART goal and a savings plan to\u00a0achieve this goal</li></ul>",  # noqa: E501
+            building_block=ActivityBuildingBlock.objects.filter(pk__in=[2]).all(),  # noqa: E501
+            school_subject=ActivitySchoolSubject.objects.filter(pk__in=[1, 4]).all(),  # noqa: E501
+            topic=ActivityTopic.objects.filter(pk__in=topic_list).all(),
+            grade_level=ActivityGradeLevel.objects.filter(pk__in=grade_level_list).all(),  # noqa: E501
+            age_range=ActivityAgeRange.objects.filter(pk__in=[2]).all(),
+            student_characteristics=[],
+            activity_type=ActivityType.objects.filter(pk__in=[1, 2, 3]).all(),
+            teaching_strategy=ActivityTeachingStrategy.objects.filter(pk__in=[6, 7]).all(),  # noqa: E501
+            blooms_taxonomy_level=ActivityBloomsTaxonomyLevel.objects.filter(pk__in=[6]).all(),  # noqa: E501
+            activity_duration=ActivityDuration.objects.get(pk=2),
+            council_for_economic_education=ActivityCouncilForEconEd.objects.filter(pk__in=[4]).all(),  # noqa: E501
+            jump_start_coalition=ActivityJumpStartCoalition.objects.filter(pk__in=[1]).all()  # noqa: E501
+        )
+        return activity_page

--- a/teachers_digital_platform/tests/models/test_activity_page.py
+++ b/teachers_digital_platform/tests/models/test_activity_page.py
@@ -14,17 +14,14 @@ from teachers_digital_platform.models import (
 class TestActivityPage(TestCase):
     fixtures = ['tdp_initial_data']
 
-    def setUp(self):
-        super(TestActivityPage, self).setUp()
-
     def test_get_subtopic_ids_returns_correct_subtopics(self):
         # Arrange
         activity_page = self.create_activity_detail_page('Test', 'test')
         # Act
         actual_subtopic_ids = activity_page.get_subtopic_ids()
         # Assert
-        self.assertTrue(6 not in actual_subtopic_ids)
-        self.assertTrue(7 in actual_subtopic_ids)
+        self.assertNotIn(6, actual_subtopic_ids)
+        self.assertIn(7, actual_subtopic_ids)
 
     def test_get_subtopic_ids_works_with_no_topics(self):
         # Arrange
@@ -41,11 +38,15 @@ class TestActivityPage(TestCase):
 
     def test_get_subtopic_ids_works_with_no_subtopics(self):
         # Arrange
-        activity_page = self.create_activity_detail_page('Test', 'test', topic_list=[6])  # noqa: E501
+        activity_page = self.create_activity_detail_page(
+            'Test',
+            'test',
+            topic_list=[6]
+        )
         # Act
         actual_subtopic_ids = activity_page.get_subtopic_ids()
         # Assert
-        self.assertTrue(isinstance(actual_subtopic_ids, (list, set)))
+        self.assertIsInstance(actual_subtopic_ids, set)
         self.assertFalse(actual_subtopic_ids)
 
     def test_get_grade_level_ids_returns_correct_grade_levels(self):
@@ -54,16 +55,20 @@ class TestActivityPage(TestCase):
         # Act
         actual_grade_level_ids = activity_page.get_grade_level_ids()
         # Assert
-        self.assertTrue(2 in actual_grade_level_ids)
+        self.assertIn(2, actual_grade_level_ids)
         self.assertEqual(len(actual_grade_level_ids), 1)
 
     def test_get_grade_level_ids_works_with_no_grade_levels(self):
         # Arrange
-        activity_page = self.create_activity_detail_page('Test', 'test', grade_level_list=[])  # noqa: E501
+        activity_page = self.create_activity_detail_page(
+            'Test',
+            'test',
+            grade_level_list=[]
+        )
         # Act
         actual_grade_level_ids = activity_page.get_grade_level_ids()
         # Assert
-        self.assertTrue(isinstance(actual_grade_level_ids, (list, set)))
+        self.assertIsInstance(actual_grade_level_ids, list)
         self.assertFalse(actual_grade_level_ids)
 
     def create_activity_detail_page(self, title='title', slug='slug', topic_list=[6, 7], grade_level_list=[2]):  # noqa: E501

--- a/teachers_digital_platform/tests/models/test_activity_page.py
+++ b/teachers_digital_platform/tests/models/test_activity_page.py
@@ -28,11 +28,15 @@ class TestActivityPage(TestCase):
 
     def test_get_subtopic_ids_works_with_no_topics(self):
         # Arrange
-        activity_page = self.create_activity_detail_page('Test', 'test', topic_list=[])  # noqa: E501
+        activity_page = self.create_activity_detail_page(
+            'Test',
+            'test',
+            topic_list=[]
+        )
         # Act
         actual_subtopic_ids = activity_page.get_subtopic_ids()
         # Assert
-        self.assertTrue(isinstance(actual_subtopic_ids, (list, set)))
+        self.assertIsInstance(actual_subtopic_ids, set)
         self.assertFalse(actual_subtopic_ids)
 
     def test_get_subtopic_ids_works_with_no_subtopics(self):
@@ -51,7 +55,7 @@ class TestActivityPage(TestCase):
         actual_grade_level_ids = activity_page.get_grade_level_ids()
         # Assert
         self.assertTrue(2 in actual_grade_level_ids)
-        self.assertTrue(1 == len(actual_grade_level_ids))
+        self.assertEqual(len(actual_grade_level_ids), 1)
 
     def test_get_grade_level_ids_works_with_no_grade_levels(self):
         # Arrange


### PR DESCRIPTION
Added an "Explore related resources" section to the bottom ActivityPage detail pages. This section has links for similar Activities, FDIC financial lessons, and Federal Reserve financial education resources.
## Additions
- ActivityPage.get_subtopic_ids(): returns a set of all subtopic ids associated with a given ActivityPage. Used to generate a link for related Activities in the detail page template file.
- ActivityPage.get_grade_level_ids(): returns a list of all grade level ids associated with a given ActivityPage. Used to generate a link for related Activities in the detail page template file.
- ActivityPage.get_related_activities_url(): returns a relative url string with search parameters that
match the subtopics and grade level of a given ActivityPage.
# ScreenShot
![Screen Shot 2019-11-25 at 2 38 30 PM](https://user-images.githubusercontent.com/2914091/69572028-45909800-0f91-11ea-9988-f45305c7827a.png)


## Review

- @dcmouyard  @cfpb/cfgov-backends 

[Preview this PR without the whitespace changes](?w=0)

