### PR TITLE
Add rel="noopener noreferrer" to target blank links

### DIFF
--- a/teachers_digital_platform/jinja2/teachers_digital_platform/activity_page.html
+++ b/teachers_digital_platform/jinja2/teachers_digital_platform/activity_page.html
@@ -66,8 +66,8 @@
         <h2 class="u-mt45">Explore related resources</h2>
         <ul>
             <li><a href="{{ page.get_related_activities_url() }}">Search for related CFPB activities</a></li>
-            <li><a href="https://www.fdic.gov/consumers/consumer/moneysmart/young.html" target="_blank">Find financial education lessons from FDIC</a></li>
-            <li><a href="https://www.federalreserveeducation.org/" target="_blank">View financial education resources from the Federal Reserve</a></li>
+            <li><a href="https://www.fdic.gov/consumers/consumer/moneysmart/young.html" target="_blank" rel="noopener noreferrer">Find financial education lessons from FDIC</a></li>
+            <li><a href="https://www.federalreserveeducation.org/" target="_blank" rel="noopener noreferrer">View financial education resources from the Federal Reserve</a></li>
         </ul>
     </div>
 {% endblock content_main %}


### PR DESCRIPTION
@lfatty reported that these links were targeting `_blank` but didn't have `rel="noopener noreferrer"` added, which is potentially a security vulnerability. This PR adds those attributes.

## Changes

- Adds `rel="noopener noreferrer"` to external links that targeted `_blank`

## Testing

- The two affected links should function as before.
