### PR TITLE
Remove python 2

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,5 @@
 language: python
 python:
-- '2.7'
 - '3.6'
 install:
 - pip install tox-travis
@@ -11,7 +10,7 @@ script:
 - npm install
 - tox
 - npm test
-- python setup.py bdist_wheel --universal
+- python setup.py bdist_wheel
 deploy:
   provider: releases
   api_key:

--- a/setup.py
+++ b/setup.py
@@ -53,8 +53,6 @@ setup(
         'License :: CC0 1.0 Universal (CC0 1.0) Public Domain Dedication',
         'License :: Public Domain',
         'Programming Language :: Python',
-        'Programming Language :: Python :: 2',
-        'Programming Language :: Python :: 2.7',
         'Programming Language :: Python :: 3',
         'Programming Language :: Python :: 3.6',
     ],

--- a/tox.ini
+++ b/tox.ini
@@ -1,6 +1,6 @@
 [tox]
 skipsdist=True
-envlist=lint-py{27,36},py{27,36}-dj{111}
+envlist=lint-py{36},py{36}-dj{111}
 
 [testenv]
 install_command=pip install -e ".[testing]" -U {opts} {packages}
@@ -15,7 +15,6 @@ setenv=
     PYTHONPATH={toxinidir}/cfgov-refresh/cfgov:{env:PYTHONPATH:}
 
 basepython=
-    py27: python2.7
     py36: python3.6
 
 deps=


### PR DESCRIPTION
Remove references to python 2 from tox, travis, and setup.py.

## Checklist

* [x] Changes are limited to a single goal (no scope creep)
* [x] Code can be automatically merged (no conflicts)
* [x] Code follows the standards laid out in the [front end playbook](https://github.com/cfpb/front-end)
* [ ] Passes all existing automated tests
* [x] New functions include new tests
* [x] New functions are documented (with a description, list of inputs, and expected output)
* [x] Placeholder code is flagged
* [ ] Visually tested in supported browsers and devices
* [x] Project documentation has been updated (including the "Unreleased" section of the CHANGELOG)