### PR TITLE
[CRTOOL] Update PDF links

### DIFF
--- a/teachers_digital_platform/crtool/src/__tests__/__snapshots__/ContentElementaryCriterionPage.test.js.snap
+++ b/teachers_digital_platform/crtool/src/__tests__/__snapshots__/ContentElementaryCriterionPage.test.js.snap
@@ -40,7 +40,7 @@ Array [
   >
     This dimension assesses whether the curriculum content helps students develop knowledge, skills, and behaviors that are important for financial capability. Evaluation criteria are based on research and major national and state education standards. 
     <a
-      href="https://files.consumerfinance.gov/f/documents/cfpb_youth-financialeducation-curriculum-review.pdf"
+      href="https://files.consumerfinance.gov/f/documents/cfpb_youth-financial-education-curriculum-report.pdf"
       onClick={[Function]}
       rel="noopener noreferrer"
       target="_blank"
@@ -397,7 +397,7 @@ Array [
   >
     This dimension assesses whether the curriculum content helps students develop knowledge, skills, and behaviors that are important for financial capability. Evaluation criteria are based on research and major national and state education standards. 
     <a
-      href="https://files.consumerfinance.gov/f/documents/cfpb_youth-financialeducation-curriculum-review.pdf"
+      href="https://files.consumerfinance.gov/f/documents/cfpb_youth-financial-education-curriculum-report.pdf"
       onClick={[Function]}
       rel="noopener noreferrer"
       target="_blank"
@@ -2004,7 +2004,7 @@ Array [
   >
     This dimension assesses whether the curriculum content helps students develop knowledge, skills, and behaviors that are important for financial capability. Evaluation criteria are based on research and major national and state education standards. 
     <a
-      href="https://files.consumerfinance.gov/f/documents/cfpb_youth-financialeducation-curriculum-review.pdf"
+      href="https://files.consumerfinance.gov/f/documents/cfpb_youth-financial-education-curriculum-report.pdf"
       onClick={[Function]}
       rel="noopener noreferrer"
       target="_blank"
@@ -2744,7 +2744,7 @@ Array [
   >
     This dimension assesses whether the curriculum content helps students develop knowledge, skills, and behaviors that are important for financial capability. Evaluation criteria are based on research and major national and state education standards. 
     <a
-      href="https://files.consumerfinance.gov/f/documents/cfpb_youth-financialeducation-curriculum-review.pdf"
+      href="https://files.consumerfinance.gov/f/documents/cfpb_youth-financial-education-curriculum-report.pdf"
       onClick={[Function]}
       rel="noopener noreferrer"
       target="_blank"
@@ -3101,7 +3101,7 @@ Array [
   >
     This dimension assesses whether the curriculum content helps students develop knowledge, skills, and behaviors that are important for financial capability. Evaluation criteria are based on research and major national and state education standards. 
     <a
-      href="https://files.consumerfinance.gov/f/documents/cfpb_youth-financialeducation-curriculum-review.pdf"
+      href="https://files.consumerfinance.gov/f/documents/cfpb_youth-financial-education-curriculum-report.pdf"
       onClick={[Function]}
       rel="noopener noreferrer"
       target="_blank"

--- a/teachers_digital_platform/crtool/src/__tests__/__snapshots__/ContentHighCriterionPage.test.js.snap
+++ b/teachers_digital_platform/crtool/src/__tests__/__snapshots__/ContentHighCriterionPage.test.js.snap
@@ -40,7 +40,7 @@ Array [
   >
     This dimension assesses whether the curriculum content helps students develop knowledge, skills, and behaviors that are important for financial capability. Evaluation criteria are based on research and major national and state education standards. 
     <a
-      href="https://files.consumerfinance.gov/f/documents/cfpb_youth-financialeducation-curriculum-review.pdf"
+      href="https://files.consumerfinance.gov/f/documents/cfpb_youth-financial-education-curriculum-report.pdf"
       onClick={[Function]}
       rel="noopener noreferrer"
       target="_blank"
@@ -641,7 +641,7 @@ Array [
   >
     This dimension assesses whether the curriculum content helps students develop knowledge, skills, and behaviors that are important for financial capability. Evaluation criteria are based on research and major national and state education standards. 
     <a
-      href="https://files.consumerfinance.gov/f/documents/cfpb_youth-financialeducation-curriculum-review.pdf"
+      href="https://files.consumerfinance.gov/f/documents/cfpb_youth-financial-education-curriculum-report.pdf"
       onClick={[Function]}
       rel="noopener noreferrer"
       target="_blank"
@@ -3628,7 +3628,7 @@ Array [
   >
     This dimension assesses whether the curriculum content helps students develop knowledge, skills, and behaviors that are important for financial capability. Evaluation criteria are based on research and major national and state education standards. 
     <a
-      href="https://files.consumerfinance.gov/f/documents/cfpb_youth-financialeducation-curriculum-review.pdf"
+      href="https://files.consumerfinance.gov/f/documents/cfpb_youth-financial-education-curriculum-report.pdf"
       onClick={[Function]}
       rel="noopener noreferrer"
       target="_blank"
@@ -4949,7 +4949,7 @@ Array [
   >
     This dimension assesses whether the curriculum content helps students develop knowledge, skills, and behaviors that are important for financial capability. Evaluation criteria are based on research and major national and state education standards. 
     <a
-      href="https://files.consumerfinance.gov/f/documents/cfpb_youth-financialeducation-curriculum-review.pdf"
+      href="https://files.consumerfinance.gov/f/documents/cfpb_youth-financial-education-curriculum-report.pdf"
       onClick={[Function]}
       rel="noopener noreferrer"
       target="_blank"
@@ -5550,7 +5550,7 @@ Array [
   >
     This dimension assesses whether the curriculum content helps students develop knowledge, skills, and behaviors that are important for financial capability. Evaluation criteria are based on research and major national and state education standards. 
     <a
-      href="https://files.consumerfinance.gov/f/documents/cfpb_youth-financialeducation-curriculum-review.pdf"
+      href="https://files.consumerfinance.gov/f/documents/cfpb_youth-financial-education-curriculum-report.pdf"
       onClick={[Function]}
       rel="noopener noreferrer"
       target="_blank"

--- a/teachers_digital_platform/crtool/src/__tests__/__snapshots__/ContentMiddleCriterionPage.test.js.snap
+++ b/teachers_digital_platform/crtool/src/__tests__/__snapshots__/ContentMiddleCriterionPage.test.js.snap
@@ -40,7 +40,7 @@ Array [
   >
     This dimension assesses whether the curriculum content helps students develop knowledge, skills, and behaviors that are important for financial capability. Evaluation criteria are based on research and major national and state education standards. 
     <a
-      href="https://files.consumerfinance.gov/f/documents/cfpb_youth-financialeducation-curriculum-review.pdf"
+      href="https://files.consumerfinance.gov/f/documents/cfpb_youth-financial-education-curriculum-report.pdf"
       onClick={[Function]}
       rel="noopener noreferrer"
       target="_blank"
@@ -458,7 +458,7 @@ Array [
   >
     This dimension assesses whether the curriculum content helps students develop knowledge, skills, and behaviors that are important for financial capability. Evaluation criteria are based on research and major national and state education standards. 
     <a
-      href="https://files.consumerfinance.gov/f/documents/cfpb_youth-financialeducation-curriculum-review.pdf"
+      href="https://files.consumerfinance.gov/f/documents/cfpb_youth-financial-education-curriculum-report.pdf"
       onClick={[Function]}
       rel="noopener noreferrer"
       target="_blank"
@@ -2896,7 +2896,7 @@ Array [
   >
     This dimension assesses whether the curriculum content helps students develop knowledge, skills, and behaviors that are important for financial capability. Evaluation criteria are based on research and major national and state education standards. 
     <a
-      href="https://files.consumerfinance.gov/f/documents/cfpb_youth-financialeducation-curriculum-review.pdf"
+      href="https://files.consumerfinance.gov/f/documents/cfpb_youth-financial-education-curriculum-report.pdf"
       onClick={[Function]}
       rel="noopener noreferrer"
       target="_blank"
@@ -3973,7 +3973,7 @@ Array [
   >
     This dimension assesses whether the curriculum content helps students develop knowledge, skills, and behaviors that are important for financial capability. Evaluation criteria are based on research and major national and state education standards. 
     <a
-      href="https://files.consumerfinance.gov/f/documents/cfpb_youth-financialeducation-curriculum-review.pdf"
+      href="https://files.consumerfinance.gov/f/documents/cfpb_youth-financial-education-curriculum-report.pdf"
       onClick={[Function]}
       rel="noopener noreferrer"
       target="_blank"
@@ -4391,7 +4391,7 @@ Array [
   >
     This dimension assesses whether the curriculum content helps students develop knowledge, skills, and behaviors that are important for financial capability. Evaluation criteria are based on research and major national and state education standards. 
     <a
-      href="https://files.consumerfinance.gov/f/documents/cfpb_youth-financialeducation-curriculum-review.pdf"
+      href="https://files.consumerfinance.gov/f/documents/cfpb_youth-financial-education-curriculum-report.pdf"
       onClick={[Function]}
       rel="noopener noreferrer"
       target="_blank"

--- a/teachers_digital_platform/crtool/src/__tests__/__snapshots__/EfficacyCriterionPage.test.js.snap
+++ b/teachers_digital_platform/crtool/src/__tests__/__snapshots__/EfficacyCriterionPage.test.js.snap
@@ -32,7 +32,7 @@ Array [
   >
     The efficacy dimension assesses the measurable impact the curriculum has had on students by looking at high-quality studies that have been done about its effectiveness. Evaluation criteria are based on research and major national and state education standards. 
     <a
-      href="https://files.consumerfinance.gov/f/documents/cfpb_youth-financialeducation-curriculum-review.pdf"
+      href="https://files.consumerfinance.gov/f/documents/cfpb_youth-financial-education-curriculum-report.pdf"
       onClick={[Function]}
       rel="noopener noreferrer"
       target="_blank"
@@ -1269,7 +1269,7 @@ Array [
   >
     The efficacy dimension assesses the measurable impact the curriculum has had on students by looking at high-quality studies that have been done about its effectiveness. Evaluation criteria are based on research and major national and state education standards. 
     <a
-      href="https://files.consumerfinance.gov/f/documents/cfpb_youth-financialeducation-curriculum-review.pdf"
+      href="https://files.consumerfinance.gov/f/documents/cfpb_youth-financial-education-curriculum-report.pdf"
       onClick={[Function]}
       rel="noopener noreferrer"
       target="_blank"
@@ -2792,7 +2792,7 @@ Array [
   >
     The efficacy dimension assesses the measurable impact the curriculum has had on students by looking at high-quality studies that have been done about its effectiveness. Evaluation criteria are based on research and major national and state education standards. 
     <a
-      href="https://files.consumerfinance.gov/f/documents/cfpb_youth-financialeducation-curriculum-review.pdf"
+      href="https://files.consumerfinance.gov/f/documents/cfpb_youth-financial-education-curriculum-report.pdf"
       onClick={[Function]}
       rel="noopener noreferrer"
       target="_blank"
@@ -4586,7 +4586,7 @@ Array [
   >
     The efficacy dimension assesses the measurable impact the curriculum has had on students by looking at high-quality studies that have been done about its effectiveness. Evaluation criteria are based on research and major national and state education standards. 
     <a
-      href="https://files.consumerfinance.gov/f/documents/cfpb_youth-financialeducation-curriculum-review.pdf"
+      href="https://files.consumerfinance.gov/f/documents/cfpb_youth-financial-education-curriculum-report.pdf"
       onClick={[Function]}
       rel="noopener noreferrer"
       target="_blank"

--- a/teachers_digital_platform/crtool/src/__tests__/__snapshots__/QualityCriterionPage.test.js.snap
+++ b/teachers_digital_platform/crtool/src/__tests__/__snapshots__/QualityCriterionPage.test.js.snap
@@ -29,7 +29,7 @@ Array [
   >
     The quality dimension assesses whether curriculum materials are clear, accurate, and objective and how easy the materials are for teachers and students to access. Evaluation criteria are based on research and major national and state education standards. 
     <a
-      href="https://files.consumerfinance.gov/f/documents/cfpb_youth-financialeducation-curriculum-review.pdf"
+      href="https://files.consumerfinance.gov/f/documents/cfpb_youth-financial-education-curriculum-report.pdf"
       onClick={[Function]}
       rel="noopener noreferrer"
       target="_blank"
@@ -1001,7 +1001,7 @@ Array [
   >
     The quality dimension assesses whether curriculum materials are clear, accurate, and objective and how easy the materials are for teachers and students to access. Evaluation criteria are based on research and major national and state education standards. 
     <a
-      href="https://files.consumerfinance.gov/f/documents/cfpb_youth-financialeducation-curriculum-review.pdf"
+      href="https://files.consumerfinance.gov/f/documents/cfpb_youth-financial-education-curriculum-report.pdf"
       onClick={[Function]}
       rel="noopener noreferrer"
       target="_blank"
@@ -3539,7 +3539,7 @@ Array [
   >
     The quality dimension assesses whether curriculum materials are clear, accurate, and objective and how easy the materials are for teachers and students to access. Evaluation criteria are based on research and major national and state education standards. 
     <a
-      href="https://files.consumerfinance.gov/f/documents/cfpb_youth-financialeducation-curriculum-review.pdf"
+      href="https://files.consumerfinance.gov/f/documents/cfpb_youth-financial-education-curriculum-report.pdf"
       onClick={[Function]}
       rel="noopener noreferrer"
       target="_blank"
@@ -4899,7 +4899,7 @@ Array [
   >
     The quality dimension assesses whether curriculum materials are clear, accurate, and objective and how easy the materials are for teachers and students to access. Evaluation criteria are based on research and major national and state education standards. 
     <a
-      href="https://files.consumerfinance.gov/f/documents/cfpb_youth-financialeducation-curriculum-review.pdf"
+      href="https://files.consumerfinance.gov/f/documents/cfpb_youth-financial-education-curriculum-report.pdf"
       onClick={[Function]}
       rel="noopener noreferrer"
       target="_blank"
@@ -5871,7 +5871,7 @@ Array [
   >
     The quality dimension assesses whether curriculum materials are clear, accurate, and objective and how easy the materials are for teachers and students to access. Evaluation criteria are based on research and major national and state education standards. 
     <a
-      href="https://files.consumerfinance.gov/f/documents/cfpb_youth-financialeducation-curriculum-review.pdf"
+      href="https://files.consumerfinance.gov/f/documents/cfpb_youth-financial-education-curriculum-report.pdf"
       onClick={[Function]}
       rel="noopener noreferrer"
       target="_blank"

--- a/teachers_digital_platform/crtool/src/__tests__/__snapshots__/UtilityCriterionPage.test.js.snap
+++ b/teachers_digital_platform/crtool/src/__tests__/__snapshots__/UtilityCriterionPage.test.js.snap
@@ -34,7 +34,7 @@ Array [
   >
     The utility dimension evaluates the supports for using the curriculum. Such supports include guidance for teachers, materials that facilitate strong and effective instruction, and assessments to measure student mastery of skills and knowledge. Evaluation criteria are based on research and major national and state education standards. 
     <a
-      href="https://files.consumerfinance.gov/f/documents/cfpb_youth-financialeducation-curriculum-review.pdf"
+      href="https://files.consumerfinance.gov/f/documents/cfpb_youth-financial-education-curriculum-report.pdf"
       onClick={[Function]}
       rel="noopener noreferrer"
       target="_blank"
@@ -974,7 +974,7 @@ Array [
   >
     The utility dimension evaluates the supports for using the curriculum. Such supports include guidance for teachers, materials that facilitate strong and effective instruction, and assessments to measure student mastery of skills and knowledge. Evaluation criteria are based on research and major national and state education standards. 
     <a
-      href="https://files.consumerfinance.gov/f/documents/cfpb_youth-financialeducation-curriculum-review.pdf"
+      href="https://files.consumerfinance.gov/f/documents/cfpb_youth-financial-education-curriculum-report.pdf"
       onClick={[Function]}
       rel="noopener noreferrer"
       target="_blank"
@@ -6175,7 +6175,7 @@ Array [
   >
     The utility dimension evaluates the supports for using the curriculum. Such supports include guidance for teachers, materials that facilitate strong and effective instruction, and assessments to measure student mastery of skills and knowledge. Evaluation criteria are based on research and major national and state education standards. 
     <a
-      href="https://files.consumerfinance.gov/f/documents/cfpb_youth-financialeducation-curriculum-review.pdf"
+      href="https://files.consumerfinance.gov/f/documents/cfpb_youth-financial-education-curriculum-report.pdf"
       onClick={[Function]}
       rel="noopener noreferrer"
       target="_blank"
@@ -8766,7 +8766,7 @@ Array [
   >
     The utility dimension evaluates the supports for using the curriculum. Such supports include guidance for teachers, materials that facilitate strong and effective instruction, and assessments to measure student mastery of skills and knowledge. Evaluation criteria are based on research and major national and state education standards. 
     <a
-      href="https://files.consumerfinance.gov/f/documents/cfpb_youth-financialeducation-curriculum-review.pdf"
+      href="https://files.consumerfinance.gov/f/documents/cfpb_youth-financial-education-curriculum-report.pdf"
       onClick={[Function]}
       rel="noopener noreferrer"
       target="_blank"
@@ -9706,7 +9706,7 @@ Array [
   >
     The utility dimension evaluates the supports for using the curriculum. Such supports include guidance for teachers, materials that facilitate strong and effective instruction, and assessments to measure student mastery of skills and knowledge. Evaluation criteria are based on research and major national and state education standards. 
     <a
-      href="https://files.consumerfinance.gov/f/documents/cfpb_youth-financialeducation-curriculum-review.pdf"
+      href="https://files.consumerfinance.gov/f/documents/cfpb_youth-financial-education-curriculum-report.pdf"
       onClick={[Function]}
       rel="noopener noreferrer"
       target="_blank"

--- a/teachers_digital_platform/crtool/src/js/business.logic/constants.js
+++ b/teachers_digital_platform/crtool/src/js/business.logic/constants.js
@@ -122,7 +122,7 @@ const C = {
     GRADE_MIDDLE: "Middle school",
     GRADE_HIGH: "High school",
 
-    LEARN_MORE_PDF_LINK: "https://files.consumerfinance.gov/f/documents/cfpb_youth-financialeducation-curriculum-review.pdf",
+    LEARN_MORE_PDF_LINK: "https://files.consumerfinance.gov/f/documents/cfpb_youth-financial-education-curriculum-report.pdf",
     LEARN_MORE_LINK_TEXT: "Learn more about how the review was developed",
 
     APP_TITLE: "CFPB curriculum review tool",

--- a/teachers_digital_platform/jinja2/teachers_digital_platform/crt-start.html
+++ b/teachers_digital_platform/jinja2/teachers_digital_platform/crt-start.html
@@ -90,7 +90,7 @@
             <a class="a-link a-link__icon-after-text"
                 target="_blank"
                 rel="noopener noreferrer"
-                href="https://files.consumerfinance.gov/f/documents/cfpb_youth-financial-education-curriculum-review-tool.pdf">
+                href="https://files.consumerfinance.gov/f/documents/cfpb_curriculum-review-tool_checklist-to-get-started_checklist.pdf">
                     <span class="a-link_text">Download our curriculum review checklist</span>
                     <span class="a-icon"><svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 651.7 1200" class="cf-icon-svg"><path d="M507.1 692.8c-15.6-15.6-40.9-15.6-56.6 0l-85.1 85.1V466.6c0-22.1-17.9-40-40-40s-40 17.9-40 40V778l-85.1-85.1c-15.6-15.6-40.9-15.6-56.6 0-15.6 15.6-15.6 40.9 0 56.6L297 902.9c7.5 7.5 17.7 11.7 28.3 11.7s20.8-4.2 28.3-11.7l153.3-153.4c15.8-15.7 15.8-41 .2-56.7z"></path><path d="M30 161c-16.5 0-30 13.5-30 30v827.8c0 16.5 13.5 30 30 30h591.7c16.5 0 30-13.5 30-30V343.7L469 161H30zm389.6 60v134.8c0 19.9 16.3 36.2 36.2 36.2h135.9V988.8H60V221h359.6z"></path></svg></span></a>.
         </p>
@@ -220,7 +220,7 @@
             <a class="a-link a-link__icon-after-text"
                 target="_blank"
                 rel="noopener noreferrer"
-                href="https://files.consumerfinance.gov/f/201509_cfpb_youth-financial-education-curriculum-review.pdf">
+                href="https://files.consumerfinance.gov/f/documents/cfpb_youth-financial-education-curriculum-review-tool.pdf">
                     <span class="a-link_text">Download the curriculum review</span>
                     <span class="a-icon">
                         <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 651.7 1200" class="cf-icon-svg">

--- a/teachers_digital_platform/jinja2/teachers_digital_platform/crt-start.html
+++ b/teachers_digital_platform/jinja2/teachers_digital_platform/crt-start.html
@@ -90,7 +90,7 @@
             <a class="a-link a-link__icon-after-text"
                 target="_blank"
                 rel="noopener noreferrer"
-                href="https://files.consumerfinance.gov/f/documents/cfpb_curriculum-review-tool_checklist-to-get-started_checklist.pdf">
+                href="https://files.consumerfinance.gov/f/documents/cfpb_youth-financial-education-curriculum-review-tool.pdf">
                     <span class="a-link_text">Download our curriculum review checklist</span>
                     <span class="a-icon"><svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 651.7 1200" class="cf-icon-svg"><path d="M507.1 692.8c-15.6-15.6-40.9-15.6-56.6 0l-85.1 85.1V466.6c0-22.1-17.9-40-40-40s-40 17.9-40 40V778l-85.1-85.1c-15.6-15.6-40.9-15.6-56.6 0-15.6 15.6-15.6 40.9 0 56.6L297 902.9c7.5 7.5 17.7 11.7 28.3 11.7s20.8-4.2 28.3-11.7l153.3-153.4c15.8-15.7 15.8-41 .2-56.7z"></path><path d="M30 161c-16.5 0-30 13.5-30 30v827.8c0 16.5 13.5 30 30 30h591.7c16.5 0 30-13.5 30-30V343.7L469 161H30zm389.6 60v134.8c0 19.9 16.3 36.2 36.2 36.2h135.9V988.8H60V221h359.6z"></path></svg></span></a>.
         </p>


### PR DESCRIPTION
- Change the "Download the curriculum review" link on the [CRTool Before you begin page](https://www.consumerfinance.gov/practitioner-resources/youth-financial-education/curriculum-review/before-you-begin/) to: https://files.consumerfinance.gov/f/documents/cfpb_youth-financial-education-curriculum-review-tool.pdf

- Change the "Learn more about how the review was developed" link in dimension intros  to: https://files.consumerfinance.gov/f/documents/cfpb_youth-financial-education-curriculum-report.pdf

## Changes

- Changed URL from "https://files.consumerfinance.gov/f/201509_cfpb_youth-financial-education-curriculum-review.pdf" to "https://files.consumerfinance.gov/f/documents/cfpb_youth-financial-education-curriculum-review-tool.pdf"

- Changed URL from "https://files.consumerfinance.gov/f/documents/cfpb_youth-financialeducation-curriculum-review.pdf" to "https://files.consumerfinance.gov/f/documents/cfpb_youth-financial-education-curriculum-report.pdf"

## Review

- @dcmouyard @Scotchester 