### PR TITLE
[CRTOOL] Add a confirmation modal for the Remove Efficacy Study button

### DIFF
--- a/teachers_digital_platform/crtool/src/js/components/dialogs/RemoveEfficacyStudyModal.js
+++ b/teachers_digital_platform/crtool/src/js/components/dialogs/RemoveEfficacyStudyModal.js
@@ -1,7 +1,6 @@
 import React from "react";
 import Modal from "react-modal";
 
-import C from "../../business.logic/constants";
 import Analytics from "../../business.logic/analytics";
 import SvgIcon from "../svgs/SvgIcon";
 
@@ -47,7 +46,7 @@ export default class RemoveEfficacyStudyModal extends React.Component {
         this.setState({modalIsOpen: true});
 
         //Analytics opened start over with a new review
-        Analytics.sendEvent(Analytics.getDataLayerOptions("link clicked: Remove efficacy study", "Remove study"));
+        Analytics.sendEvent(Analytics.getDataLayerOptions("link clicked: Remove efficacy study", "Remove"));
     }
 
     /* Modal specific close dialog */

--- a/teachers_digital_platform/crtool/src/js/components/dialogs/RemoveEfficacyStudyModal.js
+++ b/teachers_digital_platform/crtool/src/js/components/dialogs/RemoveEfficacyStudyModal.js
@@ -1,0 +1,123 @@
+import React from "react";
+import Modal from "react-modal";
+
+import C from "../../business.logic/constants";
+import Analytics from "../../business.logic/analytics";
+import SvgIcon from "../svgs/SvgIcon";
+
+export default class RemoveEfficacyStudyModal extends React.Component {
+    constructor(props) {
+        super(props);
+
+        this.state = {
+            modalIsOpen: false
+        };
+
+        this.setWrapperRef = this.setWrapperRef.bind(this);
+        this.handleRemoveEfficacyStudyClickOutside = this.handleRemoveEfficacyStudyClickOutside.bind(this);
+        this.openRemoveEfficacyStudyModalDialog = this.openRemoveEfficacyStudyModalDialog.bind(this);
+        this.closeRemoveEfficacyStudyModalDialog = this.closeRemoveEfficacyStudyModalDialog.bind(this);
+    }
+
+    /* Click Outside setup */
+    componentDidMount() {
+        document.addEventListener('mousedown', this.handleRemoveEfficacyStudyClickOutside);
+    }
+
+    /* Click Outside setup */
+    componentWillUnmount() {
+        document.removeEventListener('mousedown', this.handleRemoveEfficacyStudyClickOutside);
+    }
+
+    /* Click Outside setup */
+    setWrapperRef(node) {
+        this.wrapperRef = node;
+    }
+
+    /* Click Outside setup */
+    handleRemoveEfficacyStudyClickOutside(event) {
+        if (this.wrapperRef && !this.wrapperRef.contains(event.target)) {
+            this.setState({modalIsOpen: false});
+        }
+    }
+
+    /* Modal specific open dialog */
+    openRemoveEfficacyStudyModalDialog() {
+        //Show dialog
+        this.setState({modalIsOpen: true});
+
+        //Analytics opened start over with a new review
+        Analytics.sendEvent(Analytics.getDataLayerOptions("link clicked: Remove efficacy study", "Remove study"));
+    }
+
+    /* Modal specific close dialog */
+    closeRemoveEfficacyStudyModalDialog(linkText) {
+        //Hide dialog
+        this.setState({modalIsOpen: false});
+
+        //Analytics close start over with a new review
+        if (linkText !== undefined) {
+            Analytics.sendEvent(Analytics.getDataLayerOptions("Remove efficacy study modal", linkText));
+        }
+    }
+
+    render() {
+        return (
+        <React.Fragment>
+            <button className="a-btn a-btn__link a-btn__no-line"
+                data-gtm_ignore="true"
+                onClick={() => {this.openRemoveEfficacyStudyModalDialog();}} >
+                Remove
+                <SvgIcon
+                    icon="x-round"
+                    islarge="true"
+                    hasSpaceBefore="true" />
+            </button>
+            <Modal
+                isOpen={this.state.modalIsOpen}
+                className="o-modal_container"
+                contentLabel="CFPB Modal Dialog"
+                onRequestClose={this.closeRemoveEfficacyStudyModalDialog}
+                shouldCloseOnOverlayClick={true}
+                style={{
+                    overlay: {
+                        backgroundColor: 'transparent',
+                        zIndex: '10'
+                    }
+                }}>
+                <div className="o-modal o-modal__visible"
+                    id="modal-start-over"
+                    aria-hidden="false"
+                    role="alertdialog"
+                    aria-labelledby="modal-start-over_title"
+                    aria-describedby="modal-start-over_desc">
+                    <div className="o-modal_backdrop"></div>
+                    <div className="o-modal_container">
+                        <form className="o-modal_content" ref={this.setWrapperRef} action="#" >
+                            <div className="o-modal_body">
+                                <button className="o-modal_close a-btn a-btn__link" onClick={(e) => {this.closeRemoveEfficacyStudyModalDialog("Close"); e.preventDefault();}}>
+                                    Close
+                                    <SvgIcon
+                                        icon="x-round"
+                                        isLarge="true"
+                                        hasSpaceBefore="true" />
+                                </button>
+                                <h2 id="modal-start-over_title" className="h3">Remove this study</h2>
+                                <div id="modal-start-over_desc">
+                                    <p>Are you sure you want to remove this study?</p>
+                                </div>
+                            </div>
+                            <div className="o-modal_footer">
+                                <div className="m-btn-group m-btn-group__wide">
+                                    <button className="a-btn" onClick={(e) => {this.props.removeEfficacyStudy(this.props.studyCount);}}>Yes</button>
+                                    <button className="a-btn a-btn__link" onClick={(e) => {this.closeRemoveEfficacyStudyModalDialog("No, keep this study"); e.preventDefault();}}>No, keep this study</button>
+                                </div>
+                            </div>
+                        </form>
+                    </div>
+                </div>
+            </Modal>
+        </React.Fragment>
+        );
+    }
+}

--- a/teachers_digital_platform/crtool/src/js/components/dialogs/RemoveEfficacyStudyModal.js
+++ b/teachers_digital_platform/crtool/src/js/components/dialogs/RemoveEfficacyStudyModal.js
@@ -101,15 +101,15 @@ export default class RemoveEfficacyStudyModal extends React.Component {
                                         isLarge="true"
                                         hasSpaceBefore="true" />
                                 </button>
-                                <h2 id="modal-start-over_title" className="h3">Remove this study</h2>
+                                <h2 id="modal-start-over_title" className="h3">Remove this study?</h2>
                                 <div id="modal-start-over_desc">
-                                    <p>Are you sure you want to remove this study?</p>
+                                    <p>This will permanently erase all information related to this study.</p>
                                 </div>
                             </div>
                             <div className="o-modal_footer">
                                 <div className="m-btn-group m-btn-group__wide">
-                                    <button className="a-btn" onClick={(e) => {this.props.removeEfficacyStudy(this.props.studyCount);}}>Yes</button>
-                                    <button className="a-btn a-btn__link" onClick={(e) => {this.closeRemoveEfficacyStudyModalDialog("No, keep this study"); e.preventDefault();}}>No, keep this study</button>
+                                    <button className="a-btn" onClick={(e) => {this.props.removeEfficacyStudy(this.props.studyCount);}}>Yes, remove it</button>
+                                    <button className="a-btn a-btn__link" onClick={(e) => {this.closeRemoveEfficacyStudyModalDialog("No, keep it"); e.preventDefault();}}>No, keep it</button>
                                 </div>
                             </div>
                         </form>

--- a/teachers_digital_platform/crtool/src/js/components/dialogs/RemoveEfficacyStudyModal.js
+++ b/teachers_digital_platform/crtool/src/js/components/dialogs/RemoveEfficacyStudyModal.js
@@ -108,7 +108,7 @@ export default class RemoveEfficacyStudyModal extends React.Component {
                             </div>
                             <div className="o-modal_footer">
                                 <div className="m-btn-group m-btn-group__wide">
-                                    <button className="a-btn" onClick={(e) => {this.props.removeEfficacyStudy(this.props.studyCount);}}>Yes, remove it</button>
+                                    <button className="a-btn a-btn__warning" onClick={(e) => {this.props.removeEfficacyStudy(this.props.studyCount);}}>Yes, remove it</button>
                                     <button className="a-btn a-btn__link" onClick={(e) => {this.closeRemoveEfficacyStudyModalDialog("No, keep it"); e.preventDefault();}}>No, keep it</button>
                                 </div>
                             </div>

--- a/teachers_digital_platform/crtool/src/js/components/pages/partial.pages/EfficacyStudyComponent.js
+++ b/teachers_digital_platform/crtool/src/js/components/pages/partial.pages/EfficacyStudyComponent.js
@@ -5,6 +5,7 @@ import EditableSubComponentRow from "./EditableSubComponentRow";
 import EfficacyStudyNameComponent from "../../common/EfficacyStudyNameComponent";
 import SvgIcon from "../../svgs/SvgIcon";
 import { EfficacyStudyContent } from "../../../content_data/efficacyStudyContent";
+import RemoveEfficacyStudyModal from "../../dialogs/RemoveEfficacyStudyModal";
 
 export default class EfficacyStudyComponent extends React.Component {
 
@@ -12,15 +13,7 @@ export default class EfficacyStudyComponent extends React.Component {
         if (this.props.showRemoveButton) {
             return (
                 <div className="l-survey-top">
-                    <button className="a-btn a-btn__link a-btn__no-line"
-                        data-gtm_ignore="true"
-                        onClick={() => this.removeEfficacyStudy(this.props.studyCount)} >
-                        Remove
-                        <SvgIcon
-                            icon="x-round"
-                            islarge="true"
-                            hasSpaceBefore="true" />
-                    </button>
+                    <RemoveEfficacyStudyModal {...this.props} />
                 </div>
             );
         }

--- a/teachers_digital_platform/crtool/src/js/components/pages/partial.pages/EfficacyStudyComponent.js
+++ b/teachers_digital_platform/crtool/src/js/components/pages/partial.pages/EfficacyStudyComponent.js
@@ -3,7 +3,6 @@ import React from "react";
 import EfficacyStudyScoreComponent from "./EfficacyStudyScoreComponent";
 import EditableSubComponentRow from "./EditableSubComponentRow";
 import EfficacyStudyNameComponent from "../../common/EfficacyStudyNameComponent";
-import SvgIcon from "../../svgs/SvgIcon";
 import { EfficacyStudyContent } from "../../../content_data/efficacyStudyContent";
 import RemoveEfficacyStudyModal from "../../dialogs/RemoveEfficacyStudyModal";
 


### PR DESCRIPTION
Currently, we allow users to remove a second "study" they're working on under Efficacy with one click. I would expect there to be an interstitial modal before allowing them to (potentially inadvertently) delete the work they've just done on that new study.

## Additions

- There is a new confirmation modal that appears when you click the button to remove an efficacy study.
- There are new Analytics events for opening and closing the modal window. New events include:
    - Modal opened:
         - action: "link clicked: Remove efficacy study", label: "Remove"
    - Modal closed: 
        - action: "Remove efficacy study modal", label: "Close"
        - action: "Remove efficacy study modal", label: "No, keep it" 

## Testing

- Navigate to /practitioner-resources/youth-financial-education/curriculum-review/tool/
- Start a Curriculum Review
- Open the "Efficacy" dimension
- Scroll down and click "Review another study"
- A "Remove" button should appear to the right of the new study
- Clicking the "Remove" button should open a dialog modal that prompts you to confirm the removal of the study
    - Clicking "Yes, remove it" removes the study 
    - Clicking  "Close" or "No, keep it" closes the modal without removing the modal

## Review

- @Scotchester 

[Preview this PR without the whitespace changes](?w=0)

## Screenshots

<img width="537" alt="Screen Shot 2020-02-10 at 11 44 04 AM" src="https://user-images.githubusercontent.com/2914091/74171778-0de2d500-4bfd-11ea-89ef-e5c2753aa369.png">

## Checklist

* [x] Changes are limited to a single goal (no scope creep)
* [x] Code can be automatically merged (no conflicts)
* [x] Code follows the standards laid out in the [front end playbook](https://github.com/cfpb/front-end)
* [x] Passes all existing automated tests
* [ ] New functions include new tests
* [ ] New functions are documented (with a description, list of inputs, and expected output)
* [ ] Placeholder code is flagged
* [x] Visually tested in supported browsers and devices
* [ ] Project documentation has been updated (including the "Unreleased" section of the CHANGELOG)
