### PR TITLE
[CRTOOL] Allow for the removal of the first study item.

### DIFF
--- a/teachers_digital_platform/crtool/src/js/components/pages/efficacy/EfficacyCriterion.js
+++ b/teachers_digital_platform/crtool/src/js/components/pages/efficacy/EfficacyCriterion.js
@@ -11,6 +11,10 @@ export default class EfficacyCriterion extends React.Component {
         this.props.criterionAnswerChanged(C.QUALITY_PAGE, key, checkedValue);
     }
 
+    componentDidMount() {
+        this.initializeAnswerValuesByRefs();
+    }
+
     initializeAnswerValuesByRefs() {
         var myObjects = this.refs;
         this.props.initializeAnswerObjects(myObjects);

--- a/teachers_digital_platform/crtool/src/js/components/pages/efficacy/EfficacyCriterion.js
+++ b/teachers_digital_platform/crtool/src/js/components/pages/efficacy/EfficacyCriterion.js
@@ -8,7 +8,7 @@ export default class EfficacyCriterion extends React.Component {
 
     criterionAnswerChanged(key, checkedValue) {
         this.initializeAnswerValuesByRefs();
-        this.props.criterionAnswerChanged(C.QUALITY_PAGE, key, checkedValue);
+        this.props.criterionAnswerChanged(C.EFFICACY_PAGE, key, checkedValue);
     }
 
     componentDidMount() {

--- a/teachers_digital_platform/crtool/src/js/components/pages/efficacy/EfficacyCriterionPage.js
+++ b/teachers_digital_platform/crtool/src/js/components/pages/efficacy/EfficacyCriterionPage.js
@@ -15,6 +15,10 @@ export default class EfficacyCriterionPage extends React.Component {
         this.props.criterionAnswerChanged(C.EFFICACY_PAGE, key, checkedValue);
     }
 
+    componentDidMount() {
+        this.initializeAnswerValuesByRefs();
+    }
+
     initializeAnswerValuesByRefs() {
         var myObjects = this.refs;
         this.props.initializeAnswerObjects(myObjects);
@@ -175,7 +179,7 @@ export default class EfficacyCriterionPage extends React.Component {
                         <EfficacyStudyComponent key={i}
                             {...this.props}
                             studyCount={i}
-                            showRemoveButton={i>0}
+                            showRemoveButton={this.getEfficacyStudyItems().length > 1}
                             criterionAnswerChanged={this.criterionAnswerChanged.bind(this)} />
                     )}
 

--- a/teachers_digital_platform/crtool/src/js/components/pages/efficacy/EfficacyCriterionRow.js
+++ b/teachers_digital_platform/crtool/src/js/components/pages/efficacy/EfficacyCriterionRow.js
@@ -11,6 +11,10 @@ export default class EfficacyCriterionRow extends React.Component {
         this.props.criterionAnswerChanged(C.EFFICACY_PAGE, key, checkedValue);
     }
 
+    componentDidMount() {
+        this.initializeAnswerValuesByRefs();
+    }
+
     initializeAnswerValuesByRefs() {
         var myObjects = this.refs;
         this.props.initializeAnswerObjects(myObjects);

--- a/teachers_digital_platform/crtool/src/js/components/pages/quality/QualityCriterion.js
+++ b/teachers_digital_platform/crtool/src/js/components/pages/quality/QualityCriterion.js
@@ -11,6 +11,10 @@ export default class QualityCriterion extends React.Component {
         this.props.criterionAnswerChanged(C.QUALITY_PAGE, key, checkedValue);
     }
 
+    componentDidMount() {
+        this.initializeAnswerValuesByRefs();
+    }
+
     initializeAnswerValuesByRefs() {
         var myObjects = this.refs;
         this.props.initializeAnswerObjects(myObjects);

--- a/teachers_digital_platform/crtool/src/js/components/pages/quality/QualityCriterionComponent.js
+++ b/teachers_digital_platform/crtool/src/js/components/pages/quality/QualityCriterionComponent.js
@@ -10,6 +10,10 @@ export default class QualityCriterionComponent extends React.Component {
         this.props.criterionAnswerChanged(C.QUALITY_PAGE, key, checkedValue);
     }
 
+    componentDidMount() {
+        this.initializeAnswerValuesByRefs();
+    }
+
     initializeAnswerValuesByRefs() {
         var myObjects = this.refs;
         this.props.initializeAnswerObjects(myObjects);

--- a/teachers_digital_platform/crtool/src/js/components/pages/utility/UtilityCriterion.js
+++ b/teachers_digital_platform/crtool/src/js/components/pages/utility/UtilityCriterion.js
@@ -11,6 +11,10 @@ export default class UtilityCriterion extends React.Component {
         this.props.criterionAnswerChanged(C.UTILITY_PAGE, key, checkedValue);
     }
 
+    componentDidMount() {
+        this.initializeAnswerValuesByRefs();
+    }
+
     initializeAnswerValuesByRefs() {
         var myObjects = this.refs;
         this.props.initializeAnswerObjects(myObjects);

--- a/teachers_digital_platform/crtool/src/js/components/pages/utility/UtilityCriterionComponent.js
+++ b/teachers_digital_platform/crtool/src/js/components/pages/utility/UtilityCriterionComponent.js
@@ -10,6 +10,10 @@ export default class UtilityCriterionComponent extends React.Component {
         this.props.criterionAnswerChanged(C.UTILITY_PAGE, key, checkedValue);
     }
 
+    componentDidMount() {
+        this.initializeAnswerValuesByRefs();
+    }
+
     initializeAnswerValuesByRefs() {
         var myObjects = this.refs;
         this.props.initializeAnswerObjects(myObjects);


### PR DESCRIPTION
This fix would allow someone to remove their first study in Criterion 1, while safeguarding against them getting rid of all their studies. Currently, the first study does not have a "remove a study" link next to it ever, even as they start adding other studies.

## Changes

- Allow for the removal of the first study item without allowing for the removal of all studies
- Fix complete statuses for efficacy, quality, and utility. Completion statuses for those three dimensions were prematurely marking criteria as complete after the first answer has been filled in. This makes it so the complete flag isn't displayed until all answers in a criteria are filled out.

## Testing

- Navigate to /practitioner-resources/youth-financial-education/curriculum-review/tool/
- Start a Curriculum Review
- Open the "Efficacy" dimension
- Scroll down and click "Review another study"
- A "Remove" button should appear to the right of the new study and the first study
- Remove either the first or the second study, the "Remove" button should disappear when only one study remains

## Review

- @Scotchester @willbarton 