### PR TITLE
Restore Wagtail 1.13 support to setup.py

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -8,7 +8,7 @@ except (IOError, ImportError):
 
 
 install_requires = [
-    'wagtail>=2.3,<2.4',
+    'wagtail>=1.13,<2.4',
     'Django>=1.11,<1.12',
     'django-haystack',
     'django-mptt==0.9.0',


### PR DESCRIPTION
#371 added support for Wagtail 2.3 but also modified setup.py to make 2.3 the minimal supported Wagtail version. We still want to support Wagtail 1.13.

If you're working on cfgov-refresh against 1.13, you should be able to `pip install` TDP without getting upgraded to 2.3.

## Checklist

* [x] Changes are limited to a single goal (no scope creep)
* [x] Code can be automatically merged (no conflicts)
* [x] Code follows the standards laid out in the [front end playbook](https://github.com/cfpb/front-end)
* [x] Passes all existing automated tests
* [ ] New functions include new tests
* [ ] New functions are documented (with a description, list of inputs, and expected output)
* [ ] Placeholder code is flagged
* [ ] Visually tested in supported browsers and devices
* [ ] Project documentation has been updated (including the "Unreleased" section of the CHANGELOG)