### PR TITLE
Add an action to attach the wheel to releases

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,58 @@
+name: Publish 
+
+on: 
+  release:
+    types: [published]
+
+jobs:
+  release:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v1
+
+      - name: Set up Node
+        uses: actions/setup-node@v1
+        with:
+          node-version: 10.x
+
+      - name: Install Node dependencies
+        run: |
+          npm install -g gulp-cli
+          npm config set package-lock false
+
+      - name: Set up Python
+        uses: actions/setup-python@v1
+        with:
+          python-version: 3.6
+
+      - name: Install Python dependencies
+        run: python -m pip install --upgrade pip wheel
+
+      - name: Build the packages
+        id: build
+        run: |
+            python setup.py sdist bdist_wheel
+            # Get the name of the .whl and .tar.gz files and set them as 
+            # "outputs" of this step so we can upload them
+            echo "::set-output name=bdist_wheel::$(cd dist && ls *.whl)"
+            echo "::set-output name=sdist::$(cd dist && ls *.tar.gz)"
+
+      - name: Upload the wheel
+        uses: actions/upload-release-asset@v1
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          upload_url: ${{ github.event.release.upload_url }}
+          asset_path: dist/${{ steps.build.outputs.bdist_wheel }}
+          asset_name: ${{ steps.build.outputs.bdist_wheel }}
+          asset_content_type: application/zip
+
+      - name: Upload the source distribution
+        uses: actions/upload-release-asset@v1
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          upload_url: ${{ github.event.release.upload_url }}
+          asset_path: dist/${{ steps.build.outputs.sdist }}
+          asset_name: ${{ steps.build.outputs.sdist }}
+          asset_content_type: application/gzip


### PR DESCRIPTION
This change adds a GitHub Actions workflow that will trigger on a new release being published. The workflow will build this package's wheel and source distribution files and then upload them to GitHub attached to that new release.

You can see an example of this action in, erm, action here: https://github.com/willbarton/teachers-digital-platform/runs/605991641?check_suite_focus=true

## Checklist

* [x] Changes are limited to a single goal (no scope creep)
* [x] Code can be automatically merged (no conflicts)
* [ ] Code follows the standards laid out in the [front end playbook](https://github.com/cfpb/front-end)
* [ ] Passes all existing automated tests
* [ ] New functions include new tests
* [ ] New functions are documented (with a description, list of inputs, and expected output)
* [ ] Placeholder code is flagged
* [ ] Visually tested in supported browsers and devices
* [x] Project documentation has been updated (including the "Unreleased" section of the CHANGELOG)
