### PR TITLE
Support Wagtail up to 2.5

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -2,7 +2,7 @@ from setuptools import find_packages, setup
 
 
 install_requires = [
-    "wagtail>=2.3,<2.4",
+    "wagtail>=2.3,<2.6",
     "Django>=1.11,<2.3",
     "django-haystack",
     "django-mptt==0.9.0",

--- a/tox.ini
+++ b/tox.ini
@@ -120,7 +120,7 @@ deps=
 basepython=python3.6
 deps=
     Django>=2.2,<2.3
-    wagtail>=2.3,<2.4
+    wagtail>=2.3,<2.6
 
 
 [testenv:unittest-future]


### PR DESCRIPTION
This PR bumps support for versions of Wagtail up to 2.5, and makes `unittest-future` test against Django 2.2 and Wagtail 2.5.

## Checklist

* [ ] Changes are limited to a single goal (no scope creep)
* [ ] Code can be automatically merged (no conflicts)
* [ ] Code follows the standards laid out in the [front end playbook](https://github.com/cfpb/front-end)
* [ ] Passes all existing automated tests
* [ ] New functions include new tests
* [ ] New functions are documented (with a description, list of inputs, and expected output)
* [ ] Placeholder code is flagged
* [ ] Visually tested in supported browsers and devices
* [ ] Project documentation has been updated (including the "Unreleased" section of the CHANGELOG)
