### PR TITLE
[TDP] Only display div.results_footer when there are results.

### DIFF
--- a/teachers_digital_platform/jinja2/teachers_digital_platform/activity_search_facets_and_results.html
+++ b/teachers_digital_platform/jinja2/teachers_digital_platform/activity_search_facets_and_results.html
@@ -484,22 +484,21 @@
             </div>
         {% endif %}
     </div>
-    <div class="results_list">
-        {% if activities %}
-        <ul class="m-list__unstyled">
-            {% for result in activities %}
-                {% if result %}
-                <li class="u-mb30">{% include "activity_search_result.html" %}</li>
-                {% endif %}
-            {% endfor %}
-
-        </ul>
-        {% endif %}
-    </div>
-    <div class="results_footer">
-        {{ pagination.render( paginator.num_pages, current_page, 'tdp-search-facets-and-results', '', 'Previous', 'Next' ) }}
-        <div class="o-well">
-            Activities align with the My Money Five principles introduced by the statutorily created federal Financial Literacy and Education Commission.
+    {% if activities %}
+        <div class="results_list">
+            <ul class="m-list__unstyled">
+                {% for result in activities %}
+                    {% if result %}
+                    <li class="u-mb30">{% include "activity_search_result.html" %}</li>
+                    {% endif %}
+                {% endfor %}
+            </ul>
         </div>
-    </div>
+        <div class="results_footer">
+            {{ pagination.render( paginator.num_pages, current_page, 'tdp-search-facets-and-results', '', 'Previous', 'Next' ) }}
+            <div class="o-well">
+                Activities align with the My Money Five principles introduced by the statutorily created federal Financial Literacy and Education Commission.
+            </div>
+        </div>
+    {% endif %}
 </section>


### PR DESCRIPTION
When a user gets the "No results match your search." message is the footer message needed since no actitivites are listed

## Changes

- Hide the div.results_footer block when no results are found for a search.

## Review

- @Scotchester 

## Screenshots

### Before:
<img width="1235" alt="Screen Shot 2020-05-06 at 3 58 21 PM" src="https://user-images.githubusercontent.com/2914091/81223268-bd88d280-8fb3-11ea-9d13-dc938f7fbfc0.png">

### After:
<img width="1228" alt="Screen Shot 2020-05-06 at 3 58 48 PM" src="https://user-images.githubusercontent.com/2914091/81223338-d98c7400-8fb3-11ea-8576-baf73a12cdf5.png">


