### PR TITLE
Updates to support isort 5.0

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -62,7 +62,7 @@ setup(
         "Programming Language :: Python",
         "Programming Language :: Python :: 3",
     ],
-    python_requires=">=3",
+    python_requires=">=3.6",
     install_requires=install_requires,
     setup_requires=setup_requires,
     extras_require={"testing": testing_extras},

--- a/setup.py
+++ b/setup.py
@@ -2,7 +2,7 @@ from setuptools import find_packages, setup
 
 
 install_requires = [
-    "wagtail~=2.0",
+    "wagtail>=2.5,<2.6",
     "Django>=2.2,<2.3",
     "django-haystack",
     "django-mptt==0.9.0",

--- a/setup.py
+++ b/setup.py
@@ -2,7 +2,7 @@ from setuptools import find_packages, setup
 
 
 install_requires = [
-    "wagtail>=2.5,<2.6",
+    "wagtail~=2.0",
     "Django>=2.2,<2.3",
     "django-haystack",
     "django-mptt==0.9.0",
@@ -62,6 +62,7 @@ setup(
         "Programming Language :: Python",
         "Programming Language :: Python :: 3",
     ],
+    python_requires=">=3",
     install_requires=install_requires,
     setup_requires=setup_requires,
     extras_require={"testing": testing_extras},

--- a/tox.ini
+++ b/tox.ini
@@ -66,7 +66,7 @@ deps=
     isort
 commands=
     flake8 crtool
-    isort --check-only --diff --recursive crtool
+    isort --check-only --diff crtool
 
 
 [unittest-config]
@@ -179,7 +179,6 @@ lines_after_imports=2
 include_trailing_comma=1
 multi_line_output=3
 skip=.tox,migrations
-not_skip=__init__.py
 use_parentheses=1
 known_django=django,haystack
 known_first_party=cfgov,v1


### PR DESCRIPTION
Removed `not_skip` and `recursive` from `tox.ini` to fix
TypeError: __init__() got an unexpected keyword argument 'not_skip'

## recursive
Prior to version 5.0.0, isort wouldn't automatically traverse directories. The --recursive option was necessary to tell it to do so. In 5.0.0 directories are automatically traversed for all Python files, and as such this option is no longer necessary and should simply be removed.

## not_skip
In an earlier version isort had a default skip of __init__.py. To get around that many projects wanted a way to not skip __init__.py or any other files that were automatically skipped in the future by isort. isort no longer has any default skips, so if the value here is __init__.py you can simply remove the setting.

https://timothycrosley.github.io/isort/docs/upgrade_guides/5.0.0/

Short description explaining the high-level reason for the pull request

## Checklist

* [x] Changes are limited to a single goal (no scope creep)
* [x] Code can be automatically merged (no conflicts)
* [x] Code follows the standards laid out in the [front end playbook](https://github.com/cfpb/front-end)
* [x] Passes all existing automated tests